### PR TITLE
feat: 实现 AABB 空间包围盒

### DIFF
--- a/src/math/aabb.ts
+++ b/src/math/aabb.ts
@@ -1,50 +1,84 @@
-/**
- * AABB (Axis-Aligned Bounding Box) — stub implementation.
- * AI must implement the actual logic.
- */
-
-export const __STUB__ = true;
-
-import { type Vec3 } from './vec3';
+import { type Vec3, vec3 } from './vec3';
 import { type Geometry } from '../renderer/geometry';
 
 export class AABB {
-  min: Vec3 = null as any;
-  max: Vec3 = null as any;
+  min: Vec3;
+  max: Vec3;
 
   constructor(min?: Vec3, max?: Vec3) {
-    // stub: no-op constructor to allow describe.skip collection phase
+    this.min = min ? vec3(min[0], min[1], min[2]) : vec3(Infinity, Infinity, Infinity);
+    this.max = max ? vec3(max[0], max[1], max[2]) : vec3(-Infinity, -Infinity, -Infinity);
   }
 
   static fromGeometry(geometry: Geometry): AABB {
-    throw new Error('Not implemented');
+    const box = new AABB();
+    const pos = geometry.positions;
+    for (let i = 0; i < pos.length; i += 3) {
+      box.expandByPoint(vec3(pos[i], pos[i + 1], pos[i + 2]));
+    }
+    return box;
   }
 
   center(): Vec3 {
-    throw new Error('Not implemented');
+    return vec3(
+      (this.min[0] + this.max[0]) / 2,
+      (this.min[1] + this.max[1]) / 2,
+      (this.min[2] + this.max[2]) / 2,
+    );
   }
 
   size(): Vec3 {
-    throw new Error('Not implemented');
+    return vec3(
+      this.max[0] - this.min[0],
+      this.max[1] - this.min[1],
+      this.max[2] - this.min[2],
+    );
   }
 
   containsPoint(point: Vec3): boolean {
-    throw new Error('Not implemented');
+    return (
+      point[0] >= this.min[0] && point[0] <= this.max[0] &&
+      point[1] >= this.min[1] && point[1] <= this.max[1] &&
+      point[2] >= this.min[2] && point[2] <= this.max[2]
+    );
   }
 
   intersectsAABB(other: AABB): boolean {
-    throw new Error('Not implemented');
+    return (
+      this.min[0] <= other.max[0] && this.max[0] >= other.min[0] &&
+      this.min[1] <= other.max[1] && this.max[1] >= other.min[1] &&
+      this.min[2] <= other.max[2] && this.max[2] >= other.min[2]
+    );
   }
 
   expandByPoint(point: Vec3): void {
-    throw new Error('Not implemented');
+    if (point[0] < this.min[0]) this.min[0] = point[0];
+    if (point[1] < this.min[1]) this.min[1] = point[1];
+    if (point[2] < this.min[2]) this.min[2] = point[2];
+    if (point[0] > this.max[0]) this.max[0] = point[0];
+    if (point[1] > this.max[1]) this.max[1] = point[1];
+    if (point[2] > this.max[2]) this.max[2] = point[2];
   }
 
   union(other: AABB): AABB {
-    throw new Error('Not implemented');
+    return new AABB(
+      vec3(
+        Math.min(this.min[0], other.min[0]),
+        Math.min(this.min[1], other.min[1]),
+        Math.min(this.min[2], other.min[2]),
+      ),
+      vec3(
+        Math.max(this.max[0], other.max[0]),
+        Math.max(this.max[1], other.max[1]),
+        Math.max(this.max[2], other.max[2]),
+      ),
+    );
   }
 
   clone(): AABB {
-    throw new Error('Not implemented');
+    return new AABB(
+      vec3(this.min[0], this.min[1], this.min[2]),
+      vec3(this.max[0], this.max[1], this.max[2]),
+    );
   }
 }


### PR DESCRIPTION
## 概述

实现 `src/math/aabb.ts`，提供轴对齐包围盒（AABB）支持。

## 变更内容

- 新增 `AABB` 类，包含：
  - 构造器（空盒默认 min=+Inf, max=-Inf）
  - `fromGeometry` 静态方法从 Geometry 计算包围盒
  - `center()` / `size()` 计算中心与尺寸
  - `containsPoint()` / `intersectsAABB()` 空间查询（含边界）
  - `expandByPoint()` 原地扩展
  - `union()` 返回新合并盒（纯函数）
  - `clone()` 深拷贝

## 测试结果

- `pnpm run test -- test/unit/math/aabb.test.ts`：21/21 通过
- `pnpm run test`：无回归（其余失败为 Phase 3 预写测试基线）

close #22