### PR TITLE
feat: 实现 OrthographicCamera 和 Mat4.ortho

### DIFF
--- a/src/core/camera.ts
+++ b/src/core/camera.ts
@@ -8,6 +8,7 @@ import { type Vec3, vec3 } from '../math/vec3';
 import {
   type Mat4,
   perspective,
+  ortho,
   lookAt as mat4LookAt,
   multiply,
 } from '../math/mat4';
@@ -55,6 +56,48 @@ export class PerspectiveCamera extends Node3D {
    * Orient the camera to face the given target point.
    * Stores the target so that subsequent viewMatrix reads reflect it.
    */
+  lookAt(target: Vec3): void {
+    this._target = target;
+  }
+}
+
+export class OrthographicCamera extends Node3D {
+  left: number;
+  right: number;
+  bottom: number;
+  top: number;
+  near: number;
+  far: number;
+
+  private _target: Vec3;
+
+  constructor(
+    left: number, right: number,
+    bottom: number, top: number,
+    near = 0.1, far = 100,
+  ) {
+    super('orthographic-camera');
+    this.left   = left;
+    this.right  = right;
+    this.bottom = bottom;
+    this.top    = top;
+    this.near   = near;
+    this.far    = far;
+    this._target = vec3(0, 0, -1);
+  }
+
+  get projectionMatrix(): Mat4 {
+    return ortho(this.left, this.right, this.bottom, this.top, this.near, this.far);
+  }
+
+  get viewMatrix(): Mat4 {
+    return mat4LookAt(this.position, this._target, vec3(0, 1, 0));
+  }
+
+  get viewProjectionMatrix(): Mat4 {
+    return multiply(this.projectionMatrix, this.viewMatrix);
+  }
+
   lookAt(target: Vec3): void {
     this._target = target;
   }

--- a/src/math/mat4.ts
+++ b/src/math/mat4.ts
@@ -268,6 +268,27 @@ export function normalMatrix(modelMatrix: Mat4): Mat4 | null {
 }
 
 /**
+ * Create an orthographic projection matrix.
+ * Maps the box [left,right] × [bottom,top] × [-near,-far] to NDC [-1,+1]³.
+ * Standard OpenGL convention, column-major output.
+ */
+export function ortho(
+  left: number, right: number,
+  bottom: number, top: number,
+  near: number, far: number,
+): Mat4 {
+  const m = mat4();
+  m[0]  = 2 / (right - left);
+  m[5]  = 2 / (top - bottom);
+  m[10] = -2 / (far - near);
+  m[12] = -(right + left) / (right - left);
+  m[13] = -(top + bottom) / (top - bottom);
+  m[14] = -(far + near) / (far - near);
+  m[15] = 1;
+  return m;
+}
+
+/**
  * Transform a 3D point by a 4x4 matrix, performing perspective divide (w-divide).
  * Treats the point as a homogeneous coordinate (x, y, z, 1).
  */


### PR DESCRIPTION
## 变更内容

- `src/math/mat4.ts`：添加 `ortho()` 正交投影矩阵函数
- `src/core/camera.ts`：添加 `OrthographicCamera` 类

## 实现细节

### Mat4.ortho
将视锥体 `[left,right]×[bottom,top]×[-near,-far]` 映射到 NDC `[-1,+1]³`，标准 OpenGL 约定，列主序输出。

### OrthographicCamera
- 继承 `Node3D`
- 属性：`left`、`right`、`bottom`、`top`、`near`（默认 0.1）、`far`（默认 100）
- 只读属性：`projectionMatrix`、`viewMatrix`、`viewProjectionMatrix`
- 方法：`lookAt(target: Vec3)` — 与 `PerspectiveCamera` 实现一致

## 测试结果

```
✓ test/unit/core/orthographic-camera.test.ts (14 tests) — 全部通过
```

close #23