### PR TITLE
feat: 实现 AudioManager Web Audio API 封装 (#45)

### DIFF
--- a/src/audio/audio-manager.ts
+++ b/src/audio/audio-manager.ts
@@ -1,8 +1,7 @@
 /**
- * STUB — AudioManager (not yet implemented).
- * @see test/unit/audio/audio-manager.test.ts
+ * AudioManager — 基于 Web Audio API 的音频管理器
+ * 支持 BGM 循环播放和 SFX 一次性播放，带主音量控制
  */
-export const __STUB__ = true;
 
 export interface AudioClip {
   name: string;
@@ -23,41 +22,99 @@ export class AudioManager {
   readonly context: AudioContext;
   masterVolume: number;
 
+  private masterGain: GainNode;
+  private bgmSource: AudioBufferSourceNode | null = null;
+  private bgmPlaying: boolean = false;
+
   constructor() {
-    this.context = null as unknown as AudioContext;
+    // 支持 WeChat 小游戏的 webkitAudioContext 回退
+    const AudioCtx =
+      (globalThis as any).AudioContext || (globalThis as any).webkitAudioContext;
+    this.context = new AudioCtx();
     this.masterVolume = 1;
-    throw new Error('Not implemented');
+    this.masterGain = this.context.createGain();
+    this.masterGain.gain.value = this.masterVolume;
+    this.masterGain.connect(this.context.destination);
   }
 
-  loadClip(_name: string, _data: ArrayBuffer): Promise<AudioClip> {
-    throw new Error('Not implemented');
+  async loadClip(name: string, data: ArrayBuffer): Promise<AudioClip> {
+    const buffer = await this.context.decodeAudioData(data);
+    return { name, buffer, duration: buffer.duration };
   }
 
-  playSFX(_clip: AudioClip, _options?: PlaySFXOptions): AudioBufferSourceNode {
-    throw new Error('Not implemented');
+  playSFX(clip: AudioClip, options?: PlaySFXOptions): AudioBufferSourceNode {
+    const source = this.context.createBufferSource();
+    source.buffer = clip.buffer;
+
+    if (options?.loop) {
+      source.loop = true;
+    }
+
+    const gain = this.context.createGain();
+    if (options?.volume !== undefined) {
+      gain.gain.value = options.volume;
+    }
+
+    // 连接链：source → gain → masterGain → destination
+    source.connect(gain);
+    gain.connect(this.masterGain);
+    source.start();
+
+    return source;
   }
 
-  playBGM(_clip: AudioClip, _options?: PlayBGMOptions): void {
-    throw new Error('Not implemented');
+  playBGM(clip: AudioClip, options?: PlayBGMOptions): void {
+    // 先停止当前 BGM
+    this.stopBGM();
+
+    const source = this.context.createBufferSource();
+    source.buffer = clip.buffer;
+    source.loop = true;
+
+    const gain = this.context.createGain();
+    if (options?.volume !== undefined) {
+      gain.gain.value = options.volume;
+    }
+
+    // 连接链：source → gain → masterGain → destination
+    source.connect(gain);
+    gain.connect(this.masterGain);
+    source.start();
+
+    this.bgmSource = source;
+    this.bgmPlaying = true;
   }
 
   stopBGM(): void {
-    throw new Error('Not implemented');
+    if (this.bgmSource) {
+      try {
+        this.bgmSource.stop();
+      } catch {
+        // 节点已停止，忽略错误
+      }
+      this.bgmSource = null;
+    }
+    this.bgmPlaying = false;
   }
 
   pauseBGM(): void {
-    throw new Error('Not implemented');
+    this.context.suspend();
+    this.bgmPlaying = false;
   }
 
   resumeBGM(): void {
-    throw new Error('Not implemented');
+    this.context.resume();
+    if (this.bgmSource) {
+      this.bgmPlaying = true;
+    }
   }
 
   isBGMPlaying(): boolean {
-    throw new Error('Not implemented');
+    return this.bgmPlaying;
   }
 
   dispose(): void {
-    throw new Error('Not implemented');
+    this.stopBGM();
+    this.context.close();
   }
 }


### PR DESCRIPTION
## Summary

- 实现 `AudioManager` 类，基于 Web Audio API 提供 BGM 和 SFX 音频管理
- 支持 BGM 循环播放、暂停/恢复，以及 SFX 一次性播放
- 增益链：source → channel gain → masterGain → destination
- 支持 WeChat 小游戏的 `webkitAudioContext` 回退

## Test plan

- [x] `pnpm run test -- test/unit/audio/audio-manager.test.ts` — 15 tests passed
- [x] `pnpm run test:all` — 384 单元测试 + 9 视觉回归测试，0 失败

close #45