### PR TITLE
feat: 实现 InputManager 键盘/指针输入管理器

### DIFF
--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -1,9 +1,3 @@
-/**
- * STUB — InputManager (not yet implemented).
- * @see test/unit/core/input.test.ts
- */
-export const __STUB__ = true;
-
 export interface InputEventData {
   type: 'keydown' | 'keyup' | 'pointerdown' | 'pointerup' | 'pointermove';
   key?: string;
@@ -24,43 +18,135 @@ export interface InputTarget {
 }
 
 export class InputManager {
-  constructor(_element: InputTarget) {
-    throw new Error('Not implemented');
+  private element: InputTarget;
+  private keysDown = new Set<string>();
+  private keysPressed = new Set<string>();
+  private buttonsDown = new Set<number>();
+  private pointerX = 0;
+  private pointerY = 0;
+  private listeners = new Map<string, Set<InputListener>>();
+
+  private onKeyDown = (e: { key: string }) => {
+    if (!this.keysDown.has(e.key)) {
+      this.keysPressed.add(e.key);
+    }
+    this.keysDown.add(e.key);
+    this.emit({ type: 'keydown', key: e.key });
+  };
+
+  private onKeyUp = (e: { key: string }) => {
+    this.keysDown.delete(e.key);
+    this.emit({ type: 'keyup', key: e.key });
+  };
+
+  private onPointerDown = (e: { button: number; offsetX: number; offsetY: number }) => {
+    this.buttonsDown.add(e.button);
+    this.pointerX = e.offsetX;
+    this.pointerY = e.offsetY;
+    this.emit({
+      type: 'pointerdown',
+      button: e.button,
+      x: e.offsetX,
+      y: e.offsetY,
+      ndcX: this.toNdcX(e.offsetX),
+      ndcY: this.toNdcY(e.offsetY),
+    });
+  };
+
+  private onPointerUp = (e: { button: number; offsetX: number; offsetY: number }) => {
+    this.buttonsDown.delete(e.button);
+    this.pointerX = e.offsetX;
+    this.pointerY = e.offsetY;
+    this.emit({
+      type: 'pointerup',
+      button: e.button,
+      x: e.offsetX,
+      y: e.offsetY,
+      ndcX: this.toNdcX(e.offsetX),
+      ndcY: this.toNdcY(e.offsetY),
+    });
+  };
+
+  private onPointerMove = (e: { offsetX: number; offsetY: number }) => {
+    this.pointerX = e.offsetX;
+    this.pointerY = e.offsetY;
+    this.emit({
+      type: 'pointermove',
+      x: e.offsetX,
+      y: e.offsetY,
+      ndcX: this.toNdcX(e.offsetX),
+      ndcY: this.toNdcY(e.offsetY),
+    });
+  };
+
+  constructor(element: InputTarget) {
+    this.element = element;
+    element.addEventListener('keydown', this.onKeyDown);
+    element.addEventListener('keyup', this.onKeyUp);
+    element.addEventListener('pointerdown', this.onPointerDown);
+    element.addEventListener('pointerup', this.onPointerUp);
+    element.addEventListener('pointermove', this.onPointerMove);
   }
 
-  isKeyDown(_key: string): boolean {
-    throw new Error('Not implemented');
+  private toNdcX(x: number): number {
+    return (x / this.element.width) * 2 - 1;
   }
 
-  wasKeyPressed(_key: string): boolean {
-    throw new Error('Not implemented');
+  private toNdcY(y: number): number {
+    return 1 - (y / this.element.height) * 2;
   }
 
-  isPointerDown(_button?: number): boolean {
-    throw new Error('Not implemented');
+  private emit(event: InputEventData): void {
+    const set = this.listeners.get(event.type);
+    if (set) {
+      for (const fn of set) fn(event);
+    }
+  }
+
+  isKeyDown(key: string): boolean {
+    return this.keysDown.has(key);
+  }
+
+  wasKeyPressed(key: string): boolean {
+    return this.keysPressed.has(key);
+  }
+
+  isPointerDown(button = 0): boolean {
+    return this.buttonsDown.has(button);
   }
 
   getPointerPosition(): { x: number; y: number } {
-    throw new Error('Not implemented');
+    return { x: this.pointerX, y: this.pointerY };
   }
 
   getPointerNDC(): { x: number; y: number } {
-    throw new Error('Not implemented');
+    return { x: this.toNdcX(this.pointerX), y: this.toNdcY(this.pointerY) };
   }
 
-  on(_type: string, _listener: InputListener): void {
-    throw new Error('Not implemented');
+  on(type: string, listener: InputListener): void {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set());
+    }
+    this.listeners.get(type)!.add(listener);
   }
 
-  off(_type: string, _listener: InputListener): void {
-    throw new Error('Not implemented');
+  off(type: string, listener: InputListener): void {
+    this.listeners.get(type)?.delete(listener);
   }
 
   update(): void {
-    throw new Error('Not implemented');
+    this.keysPressed.clear();
   }
 
   dispose(): void {
-    throw new Error('Not implemented');
+    this.element.removeEventListener('keydown', this.onKeyDown);
+    this.element.removeEventListener('keyup', this.onKeyUp);
+    this.element.removeEventListener('pointerdown', this.onPointerDown);
+    this.element.removeEventListener('pointerup', this.onPointerUp);
+    this.element.removeEventListener('pointermove', this.onPointerMove);
+    this.keysDown.clear();
+    this.keysPressed.clear();
+    this.buttonsDown.clear();
+    this.listeners.clear();
   }
 }


### PR DESCRIPTION
## Summary

- 实现 `src/core/input.ts` 中的 `InputManager` 类，移除 `__STUB__` 标记
- 支持键盘状态查询（`isKeyDown` / `wasKeyPressed`）和指针状态查询（`isPointerDown` / `getPointerPosition` / `getPointerNDC`）
- NDC 坐标规范：(0,0) = 中心，(-1,-1) = 左下，(1,1) = 右上
- `wasKeyPressed` 仅在 keydown 首次触发时为 true，`update()` 后清除，重复 keydown 不重新标记
- `dispose()` 移除全部 5 种 DOM 事件监听器

## Test plan

- [x] `pnpm run test -- test/unit/core/input.test.ts` — 20 个断言全部通过
- [x] `pnpm run test:all` — 454 单元测试通过，10 项视觉回归测试全部通过（0 失败）

close #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)