### PR TITLE
feat: 实现 GameLoop 游戏主循环 (#50)

### DIFF
--- a/src/core/game-loop.ts
+++ b/src/core/game-loop.ts
@@ -1,8 +1,8 @@
 /**
- * STUB — GameLoop (not yet implemented).
- * @see test/unit/core/game-loop.test.ts
+ * GameLoop — 游戏主循环。
+ * 支持固定时间步长的 fixedUpdate + 可变帧率的 update + render 回调。
  */
-export const __STUB__ = true;
+import { Clock } from './clock';
 
 export interface GameLoopOptions {
   /** Fixed timestep in seconds (default: 1/60). */
@@ -21,27 +21,73 @@ export class GameLoop {
   /** Called after all updates, before next frame. */
   onRender: (() => void) | null;
 
-  constructor(_options?: GameLoopOptions) {
+  private fixedTimeStep: number;
+  private maxSubSteps: number;
+  private accumulator: number;
+  private clock: Clock;
+  private rafId: number | null;
+
+  constructor(options?: GameLoopOptions) {
     this.running = false;
     this.onUpdate = null;
     this.onFixedUpdate = null;
     this.onRender = null;
-    throw new Error('Not implemented');
+    this.fixedTimeStep = options?.fixedTimeStep ?? 1 / 60;
+    this.maxSubSteps = options?.maxSubSteps ?? 3;
+    this.accumulator = 0;
+    this.clock = new Clock(false);
+    this.rafId = null;
   }
 
   start(): void {
-    throw new Error('Not implemented');
+    if (this.running) return;
+    this.running = true;
+    this.clock.start();
+    const tick = () => {
+      if (!this.running) return;
+      const dt = this.clock.getDelta();
+      this.step(dt);
+      this.rafId = this._requestFrame(tick);
+    };
+    this.rafId = this._requestFrame(tick);
   }
 
   stop(): void {
-    throw new Error('Not implemented');
+    this.running = false;
+    if (this.rafId !== null) {
+      this._cancelFrame(this.rafId);
+      this.rafId = null;
+    }
   }
 
   /**
    * Manually advance one frame by dt seconds.
    * Useful for deterministic testing without rAF.
    */
-  step(_dt: number): void {
-    throw new Error('Not implemented');
+  step(dt: number): void {
+    this.accumulator += dt;
+    let steps = 0;
+    while (this.accumulator >= this.fixedTimeStep && steps < this.maxSubSteps) {
+      this.onFixedUpdate?.(this.fixedTimeStep);
+      this.accumulator -= this.fixedTimeStep;
+      steps++;
+    }
+    this.onUpdate?.(dt);
+    this.onRender?.();
+  }
+
+  private _requestFrame(cb: () => void): number {
+    if (typeof requestAnimationFrame !== 'undefined') {
+      return requestAnimationFrame(cb);
+    }
+    return setTimeout(cb, 0) as unknown as number;
+  }
+
+  private _cancelFrame(id: number): void {
+    if (typeof cancelAnimationFrame !== 'undefined') {
+      cancelAnimationFrame(id);
+    } else {
+      clearTimeout(id);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- 实现 `src/core/game-loop.ts`，移除 `__STUB__` 标记
- 支持固定时间步长 `fixedUpdate`（默认 1/60s，最多 `maxSubSteps` 次）
- 支持可变帧率 `onUpdate` 和 `onRender` 回调
- `accumulator` 余量跨帧保留，防止精度损失
- `start()`/`stop()` 重复调用安全，兼容无 `requestAnimationFrame` 的 Node 测试环境

## Test plan

- [x] `pnpm run test -- test/unit/core/game-loop.test.ts` — 17/17 通过
- [x] `pnpm run test:all` — 451 单元测试通过，8 视觉回归测试 0 diff

close #50