### PR TITLE
feat: Camera 抽象基类统一 (#52)

### DIFF
--- a/src/core/camera.ts
+++ b/src/core/camera.ts
@@ -1,6 +1,6 @@
 /**
- * PerspectiveCamera — a Node3D that maintains projection and view matrices.
- * Extends Node3D to participate in scene graph hierarchy.
+ * Camera 抽象基类 + PerspectiveCamera + OrthographicCamera。
+ * Camera extends Node3D，保留场景图参与能力。
  */
 
 import { Node3D } from './node3d';
@@ -13,7 +13,15 @@ import {
   multiply,
 } from '../math/mat4';
 
-export class PerspectiveCamera extends Node3D {
+/** Camera 抽象基类 — 所有相机共享的接口 */
+export abstract class Camera extends Node3D {
+  abstract get projectionMatrix(): Mat4;
+  abstract get viewMatrix(): Mat4;
+  abstract get viewProjectionMatrix(): Mat4;
+  abstract lookAt(target: Vec3): void;
+}
+
+export class PerspectiveCamera extends Camera {
   fov: number;
   aspect: number;
   near: number;
@@ -61,7 +69,7 @@ export class PerspectiveCamera extends Node3D {
   }
 }
 
-export class OrthographicCamera extends Node3D {
+export class OrthographicCamera extends Camera {
   left: number;
   right: number;
   bottom: number;

--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -6,7 +6,7 @@
 import { type Mat4, multiply, normalMatrix as computeNormalMatrix } from '../math/mat4';
 import { type Vec3, vec3 } from '../math/vec3';
 import { Node3D } from '../core/node3d';
-import { PerspectiveCamera } from '../core/camera';
+import { Camera } from '../core/camera';
 import { AmbientLight, DirectionalLight } from '../core/light';
 import { Mesh } from './mesh';
 import { Geometry } from './geometry';
@@ -120,7 +120,7 @@ export class WebGLRenderer {
    * @param scene  - root node of the scene (may be any Node3D)
    * @param camera - perspective camera providing view-projection matrix
    */
-  render(scene: Node3D, camera: PerspectiveCamera): void {
+  render(scene: Node3D, camera: Camera): void {
     const gl = this.gl;
 
     gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);


### PR DESCRIPTION
## 概要

- 新增 `Camera` 抽象基类（`extends Node3D`），声明 `projectionMatrix`、`viewMatrix`、`viewProjectionMatrix`、`lookAt` 四个抽象成员
- `PerspectiveCamera` 和 `OrthographicCamera` 改为继承 `Camera`
- `WebGLRenderer.render()` 的 `camera` 参数类型从 `PerspectiveCamera` 改为 `Camera`，支持多态渲染

## 测试计划

- [x] `pnpm run test -- test/unit/core/camera-base.test.ts` — 13 个测试全部通过
- [x] `pnpm run test -- test/unit/core/camera.test.ts` — 无回归
- [x] `pnpm run test -- test/unit/core/orthographic-camera.test.ts` — 无回归
- [x] `pnpm run test:all` — 全量 0 失败（单元 447 通过 + 视觉 10 通过）

close #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)