### PR TITLE
feat: 实现 InstancedMesh 实例化渲染 (#71)

### DIFF
--- a/src/renderer/instanced-mesh.ts
+++ b/src/renderer/instanced-mesh.ts
@@ -5,8 +5,6 @@
  * API 参考 Three.js InstancedMesh，但简化为仅支持 per-instance 变换和颜色。
  * @see test/unit/renderer/instanced-mesh.test.ts
  */
-export const __STUB__ = true;
-
 import { Mesh } from './mesh';
 import { Geometry } from './geometry';
 import { Material } from './material';
@@ -48,7 +46,7 @@ export class InstancedMesh extends Mesh {
     if (index < 0 || index >= this.count) {
       throw new RangeError(`Instance index ${index} out of range [0, ${this.count})`);
     }
-    return Array.from(this.instanceMatrix.slice(index * 16, index * 16 + 16)) as unknown as Mat4;
+    return this.instanceMatrix.slice(index * 16, index * 16 + 16);
   }
 
   /** 设置第 index 个实例的颜色。首次调用会自动分配 instanceColor 数组。 */


### PR DESCRIPTION
## 概述

实现 `InstancedMesh` 类，支持单 Geometry + Material 绘制多个实例（ANGLE_instanced_arrays 扩展数据管理层）。

## 变更

- `src/renderer/instanced-mesh.ts`：移除 `__STUB__` 标记，激活完整实现
  - `constructor`：分配 `instanceMatrix`（count × 16 floats），初始化为单位矩阵
  - `setMatrixAt` / `getMatrixAt`：越界抛 `RangeError`，`getMatrixAt` 返回 `Float32Array` slice
  - `setColorAt`：惰性分配 `instanceColor`（首次调用初始化为全白）
  - `getColorAt`：无颜色数据时返回默认白色

## 测试结果

- instanced-mesh.test.ts：14/14 通过
- 全量单元测试：636 通过（3 个预存在 stub 失败为 Phase 8 frustum-culling，与本 Issue 无关）

close #71