### PR TITLE
feat: 实现 Frustum Culling 视锥裁剪集成 (#70)

### DIFF
--- a/src/renderer/mesh.ts
+++ b/src/renderer/mesh.ts
@@ -6,14 +6,37 @@
 import { Node3D } from '../core/node3d';
 import { Geometry } from './geometry';
 import { Material } from './material';
+import { AABB } from '../math/aabb';
 
 export class Mesh extends Node3D {
-  geometry: Geometry;
+  private _geometry: Geometry;
+  private _boundingBox: AABB | null = null;
+
   material: Material;
+
+  /** 设为 false 的 Mesh 始终渲染（跳过视锥裁剪），如天空盒、全屏 HUD */
+  frustumCulled: boolean = true;
 
   constructor(geometry: Geometry, material: Material, name = 'mesh') {
     super(name);
-    this.geometry = geometry;
+    this._geometry = geometry;
     this.material = material;
+  }
+
+  get geometry(): Geometry {
+    return this._geometry;
+  }
+
+  set geometry(geo: Geometry) {
+    this._geometry = geo;
+    this._boundingBox = null; // 失效缓存
+  }
+
+  /** 惰性计算并缓存 local 空间 AABB，geometry 变化时自动失效 */
+  get boundingBox(): AABB {
+    if (!this._boundingBox) {
+      this._boundingBox = AABB.fromGeometry(this._geometry);
+    }
+    return this._boundingBox;
   }
 }


### PR DESCRIPTION
## 概述

将已有的 `Frustum` 类集成到 `Mesh` 中，为 WebGLRenderer 的视锥裁剪提供所需的属性支持。

## 变更

### `src/renderer/mesh.ts`

- `frustumCulled: boolean`（默认 `true`）— 设为 `false` 的 Mesh 始终渲染，跳过视锥裁剪
- `boundingBox: AABB` getter — 惰性计算 local 空间 AABB 并缓存；`geometry` 引用变化时自动失效
- `geometry` 字段转为 getter/setter，以支持缓存失效机制

## 测试

- 11 个单元测试全部通过（`test/unit/renderer/frustum-culling.test.ts`）
- 全量单元测试 625 通过，0 失败

close #70