### PR TITLE
feat: 实现 RenderInfo 渲染统计 (#73)

### DIFF
--- a/src/renderer/render-info.ts
+++ b/src/renderer/render-info.ts
@@ -4,8 +4,6 @@
  *
  * @see test/unit/renderer/render-info.test.ts
  */
-export const __STUB__ = true;
-
 export interface RenderInfo {
   /** 本帧 draw call 次数 */
   drawCalls: number;


### PR DESCRIPTION
## 概述

激活 `RenderInfo` 渲染统计模块（移除 `__STUB__` 标记）。
stub 中已包含完整的接口定义和函数实现。

## 变更

**`src/renderer/render-info.ts`**：移除 `export const __STUB__ = true`，激活：
- `RenderInfo` 接口（drawCalls / triangles / instances / culled / frameTime）
- `createRenderInfo()` — 返回归零对象
- `resetRenderInfo(info)` — 原地重置所有字段为 0

## 测试

- `test/unit/renderer/render-info.test.ts`：4/4 通过
- 全量单元测试：626 通过，无新增失败

close #73