### PR TITLE
feat: 实现 Fog 雾效渲染模块 (#78)

### DIFF
--- a/src/renderer/fog.ts
+++ b/src/renderer/fog.ts
@@ -2,10 +2,7 @@
  * Fog — 雾效数学计算与 GLSL 代码片段。
  * 支持 linear / exp / exp2 三种模式。
  * @see test/unit/renderer/fog.test.ts
- * @internal Stub — implementation pending.
  */
-
-export const __STUB__ = true;
 
 export type FogMode = 'linear' | 'exp' | 'exp2';
 
@@ -26,18 +23,37 @@ export interface FogConfig {
  * @param distance 片元到相机的距离
  * @param config   雾效配置
  */
-export function computeFogFactor(_distance: number, _config: FogConfig): number {
-  return 0;
+export function computeFogFactor(distance: number, config: FogConfig): number {
+  if (config.mode === 'linear') {
+    const near = config.near ?? 0;
+    const far = config.far ?? 1;
+    return Math.min(1, Math.max(0, (distance - near) / (far - near)));
+  }
+  if (config.mode === 'exp') {
+    const density = config.density ?? 1;
+    return Math.min(1, Math.max(0, 1 - Math.exp(-density * distance)));
+  }
+  // exp2
+  const density = config.density ?? 1;
+  return Math.min(1, Math.max(0, 1 - Math.exp(-Math.pow(density * distance, 2))));
 }
 
 /** 顶点着色器 — varying 声明 */
-export const FOG_VERTEX_PARS = '';
+export const FOG_VERTEX_PARS = 'varying float v_fogDist;';
 
 /** 顶点着色器 — 计算 v_fogDist */
-export const FOG_VERTEX_CODE = '';
+export const FOG_VERTEX_CODE = 'v_fogDist = -( u_modelMatrix * vec4(a_position, 1.0) ).z;';
 
 /** 片元着色器 — uniform + varying 声明 */
-export const FOG_FRAGMENT_PARS = '';
+export const FOG_FRAGMENT_PARS = [
+  'uniform vec3 u_fogColor;',
+  'uniform float u_fogNear;',
+  'uniform float u_fogFar;',
+  'varying float v_fogDist;',
+].join('\n');
 
 /** 片元着色器 — 混合雾色 */
-export const FOG_FRAGMENT_CODE = '';
+export const FOG_FRAGMENT_CODE = [
+  'float fogFactor = clamp((v_fogDist - u_fogNear) / (u_fogFar - u_fogNear), 0.0, 1.0);',
+  'gl_FragColor = mix(gl_FragColor, vec4(u_fogColor, gl_FragColor.a), fogFactor);',
+].join('\n');


### PR DESCRIPTION
## 概述

实现 Issue #78 要求的雾效渲染模块。

## 改动

- **src/renderer/fog.ts** — 去掉 `__STUB__` 标志，实现：
  - `computeFogFactor(distance, config)` — 支持 `linear` / `exp` / `exp2` 三种雾效模式
  - `FOG_VERTEX_PARS` — `varying float v_fogDist;` 声明
  - `FOG_VERTEX_CODE` — 计算 v_fogDist
  - `FOG_FRAGMENT_PARS` — uniform 声明（u_fogColor / u_fogNear / u_fogFar）+ varying
  - `FOG_FRAGMENT_CODE` — 计算 fogFactor 并混合雾色

## 测试

- `test/unit/renderer/fog.test.ts` — 13 个断言全部通过
- 全量测试：667 单元测试 + 12 视觉回归，0 失败

close #78