### PR TITLE
feat: 实现 LOD 层级细节距离自适应切换

### DIFF
--- a/src/core/lod.ts
+++ b/src/core/lod.ts
@@ -2,10 +2,7 @@
  * LOD — 基于距离的层级细节切换。
  * 根据到相机的距离自动显示/隐藏不同细节级别的子节点。
  * @see test/unit/core/lod.test.ts
- * @internal Stub — implementation pending.
  */
-
-export const __STUB__ = true;
 
 import { Node3D } from './node3d';
 import type { Vec3 } from '../math/vec3';
@@ -13,38 +10,80 @@ import type { Vec3 } from '../math/vec3';
 export interface LODLevel {
   /** 此层级对应的场景节点 */
   object: Node3D;
-  /** 切换距离阈值：当到相机距离 < distance 时显示此层级 */
+  /** 切换距离阈值：当到相机距离 >= distance 时显示此层级 */
   distance: number;
 }
 
 export class LOD extends Node3D {
-  /** 所有层级（按 distance 升序排列） */
-  readonly levels: ReadonlyArray<LODLevel> = [];
+  private _levels: LODLevel[] = [];
+  private _currentLevel = -1;
+
+  /** 所有层级（按 distance 升序排列，只读视图） */
+  get levels(): ReadonlyArray<LODLevel> {
+    return this._levels;
+  }
 
   constructor(name = 'lod') {
     super(name);
   }
 
   /**
-   * 添加一个细节层级。
-   * @param object   此层级的场景节点（自动成为 LOD 的子节点）
-   * @param distance 切换距离（0 = 最高细节）
+   * 添加一个细节层级，按 distance 升序插入，并将节点加为子节点。
+   * @param object   此层级的场景节点
+   * @param distance 切换距离阈值（0 = 最高细节）
    */
-  addLevel(_object: Node3D, _distance: number): this {
+  addLevel(object: Node3D, distance: number): this {
+    this.addChild(object);
+    // 按 distance 升序插入（稳定）
+    let idx = this._levels.length;
+    for (let i = 0; i < this._levels.length; i++) {
+      if (distance < this._levels[i].distance) {
+        idx = i;
+        break;
+      }
+    }
+    this._levels.splice(idx, 0, { object, distance });
     return this;
   }
 
   /**
    * 根据相机位置更新可见层级。
-   * 只有距离最匹配的层级可见，其余隐藏。
-   * @param cameraPosition 相机的世界坐标
+   * 选择最后一个 distance <= 实际距离的层级，其余隐藏。
+   * @param cameraPosition 相机世界坐标
    */
-  update(_cameraPosition: Vec3): void {
-    // stub
+  update(cameraPosition: Vec3): void {
+    if (this._levels.length === 0) {
+      this._currentLevel = -1;
+      return;
+    }
+
+    // 使用世界矩阵的平移分量计算 LOD 世界位置
+    const wm = this.worldMatrix;
+    const dx = wm[12] - cameraPosition[0];
+    const dy = wm[13] - cameraPosition[1];
+    const dz = wm[14] - cameraPosition[2];
+    const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+    // 找到最后一个 distance <= dist 的层级
+    let selected = 0;
+    for (let i = 0; i < this._levels.length; i++) {
+      if (this._levels[i].distance <= dist) {
+        selected = i;
+      } else {
+        break;
+      }
+    }
+
+    this._currentLevel = selected;
+
+    // 只有选中的层级可见
+    for (let i = 0; i < this._levels.length; i++) {
+      this._levels[i].object.visible = i === selected;
+    }
   }
 
-  /** 返回当前激活的层级索引，-1 表示无层级 */
+  /** 当前激活的层级索引，-1 表示无层级 */
   get currentLevel(): number {
-    return -1;
+    return this._currentLevel;
   }
 }

--- a/src/core/node3d.ts
+++ b/src/core/node3d.ts
@@ -23,6 +23,8 @@ export class Node3D {
 
   parent: Node3D | null;
   children: Node3D[];
+  /** 是否可见，默认 true */
+  visible: boolean;
 
   constructor(name = '') {
     this.name = name;
@@ -31,6 +33,7 @@ export class Node3D {
     this.scale = vec3(1, 1, 1);
     this.parent = null;
     this.children = [];
+    this.visible = true;
   }
 
   /** Add a child node, removing it from its previous parent first. */


### PR DESCRIPTION
## 概述

实现 Issue #81 要求的 LOD（Level of Detail）层级细节切换。

## 变更

### Node3D 扩展
- 新增 `visible: boolean`（默认 true）——LOD 切换可见性的基础

### LOD 类实现
- `addLevel(object, distance)`: 按 distance 升序插入，将 object 添加为子节点，支持链式调用
- `update(cameraPosition)`: 从 worldMatrix 提取世界坐标，计算欧氏距离，选择最后一个 `distance <= 实际距离` 的层级
- `get currentLevel()`: 当前层级索引，-1 表示无层级
- `get levels()`: ReadonlyArray 只读视图

## 测试结果

```
✓ test/unit/core/lod.test.ts (14 tests)
Tests: 668 passed | 32 skipped
```

close #81