### PR TITLE
test: Phase 10 预写测试 — ShadowMap + PostProcess (41 tests)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1,0 +1,133 @@
+/**
+ * PostProcessor — 后处理管线。
+ * 管理 EffectPass 链，通过 ping-pong FBO 逐 pass 处理屏幕图像。
+ * 内置 GrayscalePass、BlurPass、BloomPass。
+ * @see test/unit/renderer/post-process.test.ts
+ * @internal Stub — implementation pending.
+ */
+
+export const __STUB__ = true;
+
+/* ── EffectPass 接口 ── */
+
+export interface EffectPass {
+  /** pass 唯一名称 */
+  readonly name: string;
+  /** 是否启用 */
+  enabled: boolean;
+  /** 返回此 pass 的片元着色器 GLSL 源码 */
+  getFragmentShader(): string;
+  /** 设置 pass 特有的 uniform（在 render 前由 PostProcessor 调用） */
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void;
+}
+
+/* ── PostProcessor ── */
+
+export class PostProcessor {
+  /** 当前注册的 pass 列表（按添加顺序执行） */
+  readonly passes: EffectPass[] = [];
+
+  private _width = 0;
+  private _height = 0;
+
+  get width(): number {
+    return this._width;
+  }
+  get height(): number {
+    return this._height;
+  }
+
+  /** 添加一个 pass（可链式调用） */
+  addPass(_pass: EffectPass): this {
+    return this;
+  }
+
+  /** 按名称移除 pass */
+  removePass(_name: string): this {
+    return this;
+  }
+
+  /**
+   * 初始化内部 FBO 和全屏四边形 VAO。
+   * 必须在首次 render 前调用。
+   */
+  initialize(_gl: WebGLRenderingContext, _width: number, _height: number): void {
+    // stub
+  }
+
+  /**
+   * 依次执行所有 enabled 的 pass，从 inputTexture 读取，最终输出到默认 framebuffer。
+   */
+  render(_gl: WebGLRenderingContext, _inputTexture: WebGLTexture): void {
+    // stub
+  }
+
+  /** 调整内部 FBO 尺寸 */
+  resize(_gl: WebGLRenderingContext, _width: number, _height: number): void {
+    // stub
+  }
+
+  /** 释放所有 GPU 资源 */
+  dispose(_gl: WebGLRenderingContext): void {
+    // stub
+  }
+}
+
+/* ── 内置 EffectPass 实现 ── */
+
+/** 灰度化效果 */
+export class GrayscalePass implements EffectPass {
+  readonly name = 'grayscale';
+  enabled = true;
+
+  getFragmentShader(): string {
+    return '';
+  }
+
+  setUniforms(_gl: WebGLRenderingContext, _program: WebGLProgram): void {
+    // stub
+  }
+}
+
+/** 高斯模糊效果 */
+export class BlurPass implements EffectPass {
+  readonly name = 'blur';
+  enabled = true;
+  /** 模糊半径（像素），默认 2.0 */
+  radius: number;
+
+  constructor(radius = 2.0) {
+    this.radius = radius;
+  }
+
+  getFragmentShader(): string {
+    return '';
+  }
+
+  setUniforms(_gl: WebGLRenderingContext, _program: WebGLProgram): void {
+    // stub
+  }
+}
+
+/** 泛光效果（亮度阈值 + 模糊 + 叠加） */
+export class BloomPass implements EffectPass {
+  readonly name = 'bloom';
+  enabled = true;
+  /** 亮度提取阈值，默认 0.8 */
+  threshold: number;
+  /** 泛光强度，默认 1.0 */
+  intensity: number;
+
+  constructor(threshold = 0.8, intensity = 1.0) {
+    this.threshold = threshold;
+    this.intensity = intensity;
+  }
+
+  getFragmentShader(): string {
+    return '';
+  }
+
+  setUniforms(_gl: WebGLRenderingContext, _program: WebGLProgram): void {
+    // stub
+  }
+}

--- a/src/renderer/shadow-map.ts
+++ b/src/renderer/shadow-map.ts
@@ -1,0 +1,90 @@
+/**
+ * ShadowMap — 方向光阴影映射。
+ * 使用 RenderTarget 渲染深度纹理，在主渲染 pass 中采样实现阴影。
+ * 支持可配置分辨率、bias、PCF 软阴影。
+ * @see test/unit/renderer/shadow-map.test.ts
+ * @internal Stub — implementation pending.
+ */
+
+export const __STUB__ = true;
+
+import { type Vec3 } from '../math/vec3';
+import { type Mat4 } from '../math/mat4';
+import { RenderTarget } from './render-target';
+
+export interface ShadowMapOptions {
+  /** 阴影贴图分辨率（正方形边长），默认 1024 */
+  resolution?: number;
+  /** 深度偏移量，减少 shadow acne，默认 0.005 */
+  bias?: number;
+  /** 阴影相机近平面，默认 0.1 */
+  near?: number;
+  /** 阴影相机远平面，默认 100 */
+  far?: number;
+}
+
+export class ShadowMap {
+  readonly resolution: number;
+  readonly bias: number;
+  readonly near: number;
+  readonly far: number;
+  readonly renderTarget: RenderTarget;
+
+  /** 光源视图矩阵 */
+  lightViewMatrix: Mat4 | null = null;
+  /** 光源投影矩阵（正交） */
+  lightProjMatrix: Mat4 | null = null;
+  /** 光源 VP 矩阵（lightProjMatrix * lightViewMatrix） */
+  lightVPMatrix: Mat4 | null = null;
+
+  constructor(_options?: ShadowMapOptions) {
+    this.resolution = 1024;
+    this.bias = 0.005;
+    this.near = 0.1;
+    this.far = 100;
+    this.renderTarget = new RenderTarget({ width: 1024, height: 1024 });
+  }
+
+  /**
+   * 根据方向光和场景包围信息配置光源矩阵。
+   * @param lightDirection 光线方向（归一化向量，指向光照方向）
+   * @param sceneCenter    场景中心点
+   * @param sceneRadius    场景包围球半径
+   */
+  configure(
+    _lightDirection: Vec3,
+    _sceneCenter: Vec3,
+    _sceneRadius: number,
+  ): void {
+    // stub — 应计算 lightViewMatrix、lightProjMatrix、lightVPMatrix
+  }
+
+  /** 深度渲染 pass 的顶点着色器 */
+  getDepthVertexShader(): string {
+    return '';
+  }
+
+  /** 深度渲染 pass 的片元着色器 */
+  getDepthFragmentShader(): string {
+    return '';
+  }
+
+  /** 释放 GPU 资源 */
+  dispose(_gl: WebGLRenderingContext): void {
+    // stub
+  }
+}
+
+/* ── 主渲染 pass 中注入的阴影 GLSL 片段 ── */
+
+/** 顶点着色器 — uniform + varying 声明 */
+export const SHADOW_VERTEX_PARS = '';
+
+/** 顶点着色器 — 计算 v_shadowCoord */
+export const SHADOW_VERTEX_CODE = '';
+
+/** 片元着色器 — uniform + varying + sampler 声明 */
+export const SHADOW_FRAGMENT_PARS = '';
+
+/** 片元着色器 — 采样阴影贴图并计算阴影因子 */
+export const SHADOW_FRAGMENT_CODE = '';

--- a/test/unit/renderer/post-process.test.ts
+++ b/test/unit/renderer/post-process.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import * as mod from '../../../src/renderer/post-process';
+
+const {
+  PostProcessor,
+  GrayscalePass,
+  BlurPass,
+  BloomPass,
+} = mod;
+
+const isStub = '__STUB__' in mod && (mod as any).__STUB__ === true;
+const describeImpl = isStub ? describe.skip : describe;
+
+/* ── PostProcessor 管理 ── */
+
+describeImpl('PostProcessor — pass 管理', () => {
+  it('初始 passes 为空数组', () => {
+    const pp = new PostProcessor();
+    expect(pp.passes).toEqual([]);
+  });
+
+  it('addPass 添加到 passes 列表', () => {
+    const pp = new PostProcessor();
+    const pass = new GrayscalePass();
+    pp.addPass(pass);
+    expect(pp.passes).toHaveLength(1);
+    expect(pp.passes[0]).toBe(pass);
+  });
+
+  it('addPass 可链式调用', () => {
+    const pp = new PostProcessor();
+    const result = pp.addPass(new GrayscalePass());
+    expect(result).toBe(pp);
+  });
+
+  it('多次 addPass 保持插入顺序', () => {
+    const pp = new PostProcessor();
+    const g = new GrayscalePass();
+    const b = new BlurPass();
+    const bl = new BloomPass();
+    pp.addPass(g).addPass(b).addPass(bl);
+    expect(pp.passes.map((p) => p.name)).toEqual(['grayscale', 'blur', 'bloom']);
+  });
+
+  it('removePass 按名称移除', () => {
+    const pp = new PostProcessor();
+    pp.addPass(new GrayscalePass()).addPass(new BlurPass());
+    pp.removePass('grayscale');
+    expect(pp.passes).toHaveLength(1);
+    expect(pp.passes[0].name).toBe('blur');
+  });
+
+  it('removePass 不存在的名称不报错', () => {
+    const pp = new PostProcessor();
+    pp.addPass(new GrayscalePass());
+    expect(() => pp.removePass('nonexistent')).not.toThrow();
+    expect(pp.passes).toHaveLength(1);
+  });
+
+  it('removePass 可链式调用', () => {
+    const pp = new PostProcessor();
+    pp.addPass(new GrayscalePass());
+    const result = pp.removePass('grayscale');
+    expect(result).toBe(pp);
+  });
+});
+
+/* ── PostProcessor 尺寸 ── */
+
+describeImpl('PostProcessor — 尺寸管理', () => {
+  // 使用一个最小的 mock GL context
+  const mockGL = {} as WebGLRenderingContext;
+
+  it('initialize 设置内部尺寸', () => {
+    const pp = new PostProcessor();
+    pp.initialize(mockGL, 800, 600);
+    expect(pp.width).toBe(800);
+    expect(pp.height).toBe(600);
+  });
+
+  it('resize 更新内部尺寸', () => {
+    const pp = new PostProcessor();
+    pp.initialize(mockGL, 800, 600);
+    pp.resize(mockGL, 1024, 768);
+    expect(pp.width).toBe(1024);
+    expect(pp.height).toBe(768);
+  });
+});
+
+/* ── GrayscalePass ── */
+
+describeImpl('GrayscalePass', () => {
+  it('name = "grayscale"', () => {
+    expect(new GrayscalePass().name).toBe('grayscale');
+  });
+
+  it('默认 enabled = true', () => {
+    expect(new GrayscalePass().enabled).toBe(true);
+  });
+
+  it('片元着色器包含亮度计算', () => {
+    const src = new GrayscalePass().getFragmentShader();
+    expect(src.length).toBeGreaterThan(10);
+    // 灰度通常用 dot(color, vec3(0.299, 0.587, 0.114)) 或类似
+    expect(src).toMatch(/0\.299|luminance|gray/i);
+  });
+});
+
+/* ── BlurPass ── */
+
+describeImpl('BlurPass', () => {
+  it('name = "blur"', () => {
+    expect(new BlurPass().name).toBe('blur');
+  });
+
+  it('默认 radius = 2.0', () => {
+    expect(new BlurPass().radius).toBeCloseTo(2.0);
+  });
+
+  it('自定义 radius', () => {
+    expect(new BlurPass(5.0).radius).toBeCloseTo(5.0);
+  });
+
+  it('片元着色器包含纹理采样', () => {
+    const src = new BlurPass().getFragmentShader();
+    expect(src.length).toBeGreaterThan(10);
+    expect(src).toContain('texture2D');
+  });
+
+  it('片元着色器使用多次采样（模糊核）', () => {
+    const src = new BlurPass().getFragmentShader();
+    // 高斯模糊至少采样 3 次（中心 + 两侧）
+    const sampleCount = (src.match(/texture2D/g) || []).length;
+    expect(sampleCount).toBeGreaterThanOrEqual(3);
+  });
+});
+
+/* ── BloomPass ── */
+
+describeImpl('BloomPass', () => {
+  it('name = "bloom"', () => {
+    expect(new BloomPass().name).toBe('bloom');
+  });
+
+  it('默认 threshold = 0.8', () => {
+    expect(new BloomPass().threshold).toBeCloseTo(0.8);
+  });
+
+  it('默认 intensity = 1.0', () => {
+    expect(new BloomPass().intensity).toBeCloseTo(1.0);
+  });
+
+  it('自定义 threshold 和 intensity', () => {
+    const bloom = new BloomPass(0.5, 2.0);
+    expect(bloom.threshold).toBeCloseTo(0.5);
+    expect(bloom.intensity).toBeCloseTo(2.0);
+  });
+
+  it('片元着色器包含亮度阈值提取', () => {
+    const src = new BloomPass().getFragmentShader();
+    expect(src.length).toBeGreaterThan(10);
+    // bloom 着色器应有亮度比较
+    expect(src).toMatch(/threshold|step|smoothstep/i);
+  });
+});

--- a/test/unit/renderer/shadow-map.test.ts
+++ b/test/unit/renderer/shadow-map.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import * as mod from '../../../src/renderer/shadow-map';
+
+const {
+  ShadowMap,
+  SHADOW_VERTEX_PARS,
+  SHADOW_VERTEX_CODE,
+  SHADOW_FRAGMENT_PARS,
+  SHADOW_FRAGMENT_CODE,
+} = mod;
+
+const isStub = '__STUB__' in mod && (mod as any).__STUB__ === true;
+const describeImpl = isStub ? describe.skip : describe;
+
+/* ── 辅助 ── */
+const vec3 = (x: number, y: number, z: number) => new Float32Array([x, y, z]);
+
+describeImpl('ShadowMap — 构造与默认值', () => {
+  it('默认 resolution = 1024', () => {
+    const sm = new ShadowMap();
+    expect(sm.resolution).toBe(1024);
+  });
+
+  it('默认 bias = 0.005', () => {
+    const sm = new ShadowMap();
+    expect(sm.bias).toBeCloseTo(0.005);
+  });
+
+  it('默认 near = 0.1, far = 100', () => {
+    const sm = new ShadowMap();
+    expect(sm.near).toBeCloseTo(0.1);
+    expect(sm.far).toBe(100);
+  });
+
+  it('自定义选项覆盖默认值', () => {
+    const sm = new ShadowMap({ resolution: 2048, bias: 0.01, near: 1, far: 200 });
+    expect(sm.resolution).toBe(2048);
+    expect(sm.bias).toBeCloseTo(0.01);
+    expect(sm.near).toBe(1);
+    expect(sm.far).toBe(200);
+  });
+
+  it('内部创建与 resolution 匹配的 RenderTarget', () => {
+    const sm = new ShadowMap({ resolution: 512 });
+    expect(sm.renderTarget).toBeDefined();
+    expect(sm.renderTarget.width).toBe(512);
+    expect(sm.renderTarget.height).toBe(512);
+  });
+
+  it('RenderTarget 启用深度缓冲', () => {
+    const sm = new ShadowMap();
+    expect(sm.renderTarget.depthBuffer).toBe(true);
+  });
+});
+
+describeImpl('ShadowMap — configure()', () => {
+  it('configure 后 lightViewMatrix 非 null', () => {
+    const sm = new ShadowMap();
+    sm.configure(vec3(0, -1, 0), vec3(0, 0, 0), 10);
+    expect(sm.lightViewMatrix).not.toBeNull();
+    expect(sm.lightViewMatrix).toBeInstanceOf(Float32Array);
+    expect(sm.lightViewMatrix!.length).toBe(16);
+  });
+
+  it('configure 后 lightProjMatrix 非 null（正交投影）', () => {
+    const sm = new ShadowMap();
+    sm.configure(vec3(0, -1, 0), vec3(0, 0, 0), 10);
+    expect(sm.lightProjMatrix).not.toBeNull();
+    expect(sm.lightProjMatrix).toBeInstanceOf(Float32Array);
+    expect(sm.lightProjMatrix!.length).toBe(16);
+  });
+
+  it('configure 后 lightVPMatrix 非 null（view * proj 乘积）', () => {
+    const sm = new ShadowMap();
+    sm.configure(vec3(0, -1, 0), vec3(0, 0, 0), 10);
+    expect(sm.lightVPMatrix).not.toBeNull();
+    expect(sm.lightVPMatrix!.length).toBe(16);
+  });
+
+  it('lightProjMatrix 是正交投影（m[15] = 1）', () => {
+    const sm = new ShadowMap();
+    sm.configure(vec3(0, -1, 0), vec3(0, 0, 0), 10);
+    // 正交投影矩阵的 m[15] = 1（透视投影为 0）
+    expect(sm.lightProjMatrix![15]).toBeCloseTo(1, 3);
+  });
+
+  it('sceneRadius 改变影响投影范围', () => {
+    const sm1 = new ShadowMap();
+    sm1.configure(vec3(0, -1, 0), vec3(0, 0, 0), 5);
+    const sm2 = new ShadowMap();
+    sm2.configure(vec3(0, -1, 0), vec3(0, 0, 0), 20);
+    // 不同 radius 应产生不同的投影矩阵
+    expect(sm1.lightProjMatrix![0]).not.toBeCloseTo(sm2.lightProjMatrix![0], 3);
+  });
+
+  it('不同光线方向产生不同的 view 矩阵', () => {
+    const sm1 = new ShadowMap();
+    sm1.configure(vec3(0, -1, 0), vec3(0, 0, 0), 10);
+    const sm2 = new ShadowMap();
+    sm2.configure(vec3(-1, -1, 0), vec3(0, 0, 0), 10);
+    // 至少有一个元素不同
+    let differ = false;
+    for (let i = 0; i < 16; i++) {
+      if (Math.abs(sm1.lightViewMatrix![i] - sm2.lightViewMatrix![i]) > 1e-6) {
+        differ = true;
+        break;
+      }
+    }
+    expect(differ).toBe(true);
+  });
+});
+
+describeImpl('ShadowMap — 深度渲染着色器', () => {
+  it('getDepthVertexShader() 返回非空 GLSL', () => {
+    const sm = new ShadowMap();
+    const src = sm.getDepthVertexShader();
+    expect(src.length).toBeGreaterThan(10);
+    expect(src).toContain('gl_Position');
+  });
+
+  it('getDepthFragmentShader() 返回非空 GLSL', () => {
+    const sm = new ShadowMap();
+    const src = sm.getDepthFragmentShader();
+    expect(src.length).toBeGreaterThan(10);
+    expect(src).toContain('gl_FragColor');
+  });
+
+  it('深度片元着色器写入深度值到颜色通道', () => {
+    const sm = new ShadowMap();
+    const src = sm.getDepthFragmentShader();
+    // 深度编码通常使用 gl_FragCoord.z 或自定义 varying
+    expect(src).toMatch(/gl_FragCoord|v_depth|depth/i);
+  });
+});
+
+describeImpl('ShadowMap — 主 pass GLSL 注入片段', () => {
+  it('SHADOW_VERTEX_PARS 声明 v_shadowCoord varying', () => {
+    expect(SHADOW_VERTEX_PARS).toContain('v_shadowCoord');
+  });
+
+  it('SHADOW_VERTEX_CODE 计算 v_shadowCoord', () => {
+    expect(SHADOW_VERTEX_CODE).toContain('v_shadowCoord');
+    expect(SHADOW_VERTEX_CODE).toContain('u_lightVP');
+  });
+
+  it('SHADOW_FRAGMENT_PARS 声明 u_shadowMap sampler', () => {
+    expect(SHADOW_FRAGMENT_PARS).toContain('u_shadowMap');
+    expect(SHADOW_FRAGMENT_PARS).toContain('sampler2D');
+  });
+
+  it('SHADOW_FRAGMENT_CODE 包含阴影因子计算', () => {
+    expect(SHADOW_FRAGMENT_CODE).toContain('shadow');
+    // 应引用 bias
+    expect(SHADOW_FRAGMENT_CODE).toContain('bias');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 10 渲染进阶的预写测试和 stub 文件：

- **ShadowMap** (19 tests): 方向光阴影映射 — 构造/配置/深度着色器/GLSL注入
- **PostProcessor** (22 tests): 后处理管线 — pass管理/GrayscalePass/BlurPass/BloomPass

所有测试在 stub 模式下正确 skip，全量测试 654 passed / 87 skipped。

## Test plan

- [x] 新增 41 个测试在 stub 模式下全部 skip
- [x] 已有 654 个测试不受影响，全部 pass
- [x] TypeScript 编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)