### PR TITLE
test: Phase 12 预写测试 — Navigation & Pathfinding (49 tests)

### DIFF
--- a/src/navigation/nav-agent.ts
+++ b/src/navigation/nav-agent.ts
@@ -1,0 +1,49 @@
+/**
+ * NavAgent — path-following navigation agent.
+ *
+ * Attaches to a Node3D and moves it along a sequence of world-space waypoints.
+ * Provides speed control, waypoint callbacks, and arrival detection.
+ *
+ * @see test/unit/navigation/nav-agent.test.ts
+ */
+
+export const __STUB__ = true;
+
+import type { Node3D } from '../core/node3d';
+
+export type AgentCallback = () => void;
+export type WaypointCallback = (index: number) => void;
+
+/** A navigation agent that moves a Node3D along a path of waypoints. */
+export class NavAgent {
+  speed: number;
+  readonly node: Node3D;
+
+  constructor(node: Node3D, speed: number = 5) {
+    this.node = node;
+    this.speed = speed;
+  }
+
+  get isMoving(): boolean { return false; }
+  get currentWaypointIndex(): number { return -1; }
+
+  /**
+   * Set a path of world-space waypoints [x, z] for the agent to follow.
+   * Replaces any existing path and starts moving immediately.
+   */
+  followPath(_waypoints: Array<[number, number]>): void {}
+
+  /**
+   * Update agent position. Call once per frame with delta time (seconds).
+   */
+  update(_dt: number): void {}
+
+  /** Stop movement and clear the current path. */
+  stop(): void {}
+
+  /** Register callback for when the agent reaches the final waypoint. */
+  onArrived(_callback: AgentCallback): void {}
+
+  /** Register callback for each waypoint reached (including the last). */
+  onWaypointReached(_callback: WaypointCallback): void {}
+}

--- a/src/navigation/nav-grid.ts
+++ b/src/navigation/nav-grid.ts
@@ -1,0 +1,48 @@
+/**
+ * NavGrid — 2D grid-based navigation map.
+ *
+ * Represents a walkability grid for A* pathfinding.
+ * Each cell has a walkable flag and a traversal cost.
+ * Supports world ↔ grid coordinate conversion.
+ *
+ * @see test/unit/navigation/nav-grid.test.ts
+ */
+
+export const __STUB__ = true;
+
+/** A 2D grid for navigation — cells are either walkable or blocked. */
+export class NavGrid {
+  readonly width: number;
+  readonly height: number;
+  readonly cellSize: number;
+
+  constructor(width: number, height: number, cellSize: number = 1) {
+    this.width = width;
+    this.height = height;
+    this.cellSize = cellSize;
+  }
+
+  isInBounds(_x: number, _y: number): boolean { return false; }
+  isWalkable(_x: number, _y: number): boolean { return false; }
+  setWalkable(_x: number, _y: number, _walkable: boolean): void {}
+  getCost(_x: number, _y: number): number { return 1; }
+  setCost(_x: number, _y: number, _cost: number): void {}
+
+  /** Convert world coordinates (X, Z) to grid coordinates. */
+  worldToGrid(_worldX: number, _worldZ: number): [number, number] { return [0, 0]; }
+
+  /** Convert grid coordinates to world center coordinates (X, Z). */
+  gridToWorld(_gridX: number, _gridY: number): [number, number] { return [0, 0]; }
+
+  /** Set a rectangle of cells to walkable or blocked. */
+  fillRect(_x: number, _y: number, _w: number, _h: number, _walkable: boolean): void {}
+
+  /**
+   * Get walkable neighbor cells.
+   * @param diagonal - include diagonal neighbors (default: false)
+   */
+  getNeighbors(_x: number, _y: number, _diagonal: boolean = false): Array<[number, number]> { return []; }
+
+  /** Reset all cells to walkable with cost 1. */
+  clear(): void {}
+}

--- a/src/navigation/pathfinder.ts
+++ b/src/navigation/pathfinder.ts
@@ -1,0 +1,43 @@
+/**
+ * A* Pathfinder — grid-based shortest path search.
+ *
+ * Finds optimal paths on a NavGrid using the A* algorithm.
+ * Supports 4-direction (cardinal) and 8-direction (diagonal) movement,
+ * custom cell costs, and iteration limits.
+ *
+ * @see test/unit/navigation/pathfinder.test.ts
+ */
+
+export const __STUB__ = true;
+
+import type { NavGrid } from './nav-grid';
+
+export interface PathResult {
+  /** Grid coordinates of the path, from start to end (inclusive). */
+  path: Array<[number, number]>;
+  /** Total traversal cost. */
+  cost: number;
+  /** Whether a valid path was found. */
+  found: boolean;
+}
+
+export interface PathfinderOptions {
+  /** Allow diagonal movement (default: true). */
+  diagonal?: boolean;
+  /** Maximum A* iterations before giving up (default: 10000). */
+  maxIterations?: number;
+  /** Heuristic function (default: octile for diagonal, manhattan otherwise). */
+  heuristic?: 'manhattan' | 'euclidean' | 'octile';
+}
+
+/**
+ * Find the shortest path between two grid cells using A*.
+ */
+export function findPath(
+  _grid: NavGrid,
+  _startX: number, _startY: number,
+  _endX: number, _endY: number,
+  _options?: PathfinderOptions,
+): PathResult {
+  return { path: [], cost: 0, found: false };
+}

--- a/test/unit/navigation/nav-agent.test.ts
+++ b/test/unit/navigation/nav-agent.test.ts
@@ -1,0 +1,159 @@
+/**
+ * NavAgent 导航代理 — 预写测试
+ * Phase 12: Navigation & Pathfinding (Architect)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import * as mod from '../../../src/navigation/nav-agent';
+import { Node3D } from '../../../src/core/node3d';
+
+const isStub = '__STUB__' in mod && (mod as any).__STUB__ === true;
+const describeImpl = isStub ? describe.skip : describe;
+
+const { NavAgent } = mod;
+
+describeImpl('NavAgent', () => {
+  function makeNode(x = 0, z = 0): Node3D {
+    const node = new Node3D();
+    node.position[0] = x;
+    node.position[2] = z;
+    return node;
+  }
+
+  /* ---------- 构造 ---------- */
+
+  it('should create agent with node and default speed', () => {
+    const node = makeNode();
+    const agent = new NavAgent(node);
+    expect(agent.node).toBe(node);
+    expect(agent.speed).toBe(5);
+  });
+
+  it('should accept custom speed', () => {
+    const agent = new NavAgent(makeNode(), 10);
+    expect(agent.speed).toBe(10);
+  });
+
+  it('should not be moving initially', () => {
+    const agent = new NavAgent(makeNode());
+    expect(agent.isMoving).toBe(false);
+    expect(agent.currentWaypointIndex).toBe(-1);
+  });
+
+  /* ---------- 路径跟随 ---------- */
+
+  it('should start moving after followPath', () => {
+    const agent = new NavAgent(makeNode(), 10);
+    agent.followPath([[5, 0], [10, 0]]);
+    expect(agent.isMoving).toBe(true);
+    expect(agent.currentWaypointIndex).toBe(0);
+  });
+
+  it('should move node position toward first waypoint', () => {
+    const node = makeNode(0, 0);
+    const agent = new NavAgent(node, 10);
+    agent.followPath([[10, 0]]);
+    // Move for 0.5 seconds at speed 10 → should advance 5 units in X
+    agent.update(0.5);
+    expect(node.position[0]).toBeCloseTo(5, 1);
+    expect(node.position[2]).toBeCloseTo(0, 1);
+  });
+
+  it('should reach waypoint and advance to next', () => {
+    const node = makeNode(0, 0);
+    const agent = new NavAgent(node, 10);
+    const wpCb = vi.fn();
+    agent.onWaypointReached(wpCb);
+    agent.followPath([[5, 0], [5, 10]]);
+    // Move enough to reach first waypoint
+    agent.update(0.5); // 5 units at speed 10
+    expect(wpCb).toHaveBeenCalledWith(0);
+    expect(agent.currentWaypointIndex).toBe(1);
+  });
+
+  it('should stop and fire onArrived after reaching final waypoint', () => {
+    const node = makeNode(0, 0);
+    const agent = new NavAgent(node, 100); // fast speed
+    const arrivedCb = vi.fn();
+    agent.onArrived(arrivedCb);
+    agent.followPath([[5, 0]]);
+    agent.update(1); // 100 units in 1s, waypoint at 5 → should arrive
+    expect(arrivedCb).toHaveBeenCalledTimes(1);
+    expect(agent.isMoving).toBe(false);
+  });
+
+  it('should set node final position to exact waypoint', () => {
+    const node = makeNode(0, 0);
+    const agent = new NavAgent(node, 100);
+    agent.followPath([[5, 3]]);
+    agent.update(1); // overshoots
+    expect(node.position[0]).toBeCloseTo(5, 5);
+    expect(node.position[2]).toBeCloseTo(3, 5);
+  });
+
+  /* ---------- 停止 ---------- */
+
+  it('should stop movement on stop()', () => {
+    const node = makeNode(0, 0);
+    const agent = new NavAgent(node, 10);
+    agent.followPath([[100, 0]]);
+    agent.update(0.5);
+    const posX = node.position[0];
+    agent.stop();
+    expect(agent.isMoving).toBe(false);
+    agent.update(0.5);
+    // Position should not change after stop
+    expect(node.position[0]).toBeCloseTo(posX, 5);
+  });
+
+  /* ---------- 速度 ---------- */
+
+  it('should respect speed setting', () => {
+    const node1 = makeNode(0, 0);
+    const node2 = makeNode(0, 0);
+    const fast = new NavAgent(node1, 20);
+    const slow = new NavAgent(node2, 5);
+    fast.followPath([[100, 0]]);
+    slow.followPath([[100, 0]]);
+    fast.update(1);
+    slow.update(1);
+    expect(node1.position[0]).toBeCloseTo(20, 1);
+    expect(node2.position[0]).toBeCloseTo(5, 1);
+  });
+
+  /* ---------- 路径替换 ---------- */
+
+  it('should replace path when followPath is called again', () => {
+    const node = makeNode(0, 0);
+    const agent = new NavAgent(node, 10);
+    agent.followPath([[100, 0]]);
+    agent.update(0.5); // move to x=5
+    // Replace with new path going in Z direction
+    agent.followPath([[5, 100]]);
+    expect(agent.currentWaypointIndex).toBe(0);
+    expect(agent.isMoving).toBe(true);
+    agent.update(0.5); // should move in Z now
+    expect(node.position[2]).toBeGreaterThan(0);
+  });
+
+  /* ---------- 空路径 ---------- */
+
+  it('should fire onArrived immediately for empty path', () => {
+    const agent = new NavAgent(makeNode());
+    const arrivedCb = vi.fn();
+    agent.onArrived(arrivedCb);
+    agent.followPath([]);
+    expect(arrivedCb).toHaveBeenCalledTimes(1);
+    expect(agent.isMoving).toBe(false);
+  });
+
+  /* ---------- Node3D Y 轴不受影响 ---------- */
+
+  it('should only update X and Z, leaving Y unchanged', () => {
+    const node = makeNode(0, 0);
+    node.position[1] = 5; // Y = 5
+    const agent = new NavAgent(node, 10);
+    agent.followPath([[10, 10]]);
+    agent.update(0.5);
+    expect(node.position[1]).toBe(5); // Y unchanged
+  });
+});

--- a/test/unit/navigation/nav-grid.test.ts
+++ b/test/unit/navigation/nav-grid.test.ts
@@ -1,0 +1,175 @@
+/**
+ * NavGrid 2D 导航网格 — 预写测试
+ * Phase 12: Navigation & Pathfinding (Architect)
+ */
+import { describe, it, expect } from 'vitest';
+import * as mod from '../../../src/navigation/nav-grid';
+
+const isStub = '__STUB__' in mod && (mod as any).__STUB__ === true;
+const describeImpl = isStub ? describe.skip : describe;
+
+const { NavGrid } = mod;
+
+describeImpl('NavGrid', () => {
+  /* ---------- 构造与基础 ---------- */
+
+  it('should create grid with correct dimensions', () => {
+    const grid = new NavGrid(10, 8);
+    expect(grid.width).toBe(10);
+    expect(grid.height).toBe(8);
+    expect(grid.cellSize).toBe(1);
+  });
+
+  it('should accept custom cellSize', () => {
+    const grid = new NavGrid(5, 5, 2);
+    expect(grid.cellSize).toBe(2);
+  });
+
+  it('should default all cells to walkable', () => {
+    const grid = new NavGrid(4, 4);
+    expect(grid.isWalkable(0, 0)).toBe(true);
+    expect(grid.isWalkable(3, 3)).toBe(true);
+    expect(grid.isWalkable(2, 1)).toBe(true);
+  });
+
+  /* ---------- Walkability ---------- */
+
+  it('should set and get walkability', () => {
+    const grid = new NavGrid(5, 5);
+    grid.setWalkable(2, 3, false);
+    expect(grid.isWalkable(2, 3)).toBe(false);
+    expect(grid.isWalkable(2, 2)).toBe(true);
+    grid.setWalkable(2, 3, true);
+    expect(grid.isWalkable(2, 3)).toBe(true);
+  });
+
+  it('should return false for out-of-bounds walkability', () => {
+    const grid = new NavGrid(5, 5);
+    expect(grid.isWalkable(-1, 0)).toBe(false);
+    expect(grid.isWalkable(5, 0)).toBe(false);
+    expect(grid.isWalkable(0, -1)).toBe(false);
+    expect(grid.isWalkable(0, 5)).toBe(false);
+  });
+
+  it('should check bounds correctly', () => {
+    const grid = new NavGrid(3, 3);
+    expect(grid.isInBounds(0, 0)).toBe(true);
+    expect(grid.isInBounds(2, 2)).toBe(true);
+    expect(grid.isInBounds(3, 0)).toBe(false);
+    expect(grid.isInBounds(-1, 0)).toBe(false);
+  });
+
+  /* ---------- Cost ---------- */
+
+  it('should default cost to 1', () => {
+    const grid = new NavGrid(5, 5);
+    expect(grid.getCost(0, 0)).toBe(1);
+    expect(grid.getCost(4, 4)).toBe(1);
+  });
+
+  it('should set and get custom cost', () => {
+    const grid = new NavGrid(5, 5);
+    grid.setCost(1, 1, 3);
+    expect(grid.getCost(1, 1)).toBe(3);
+    expect(grid.getCost(0, 0)).toBe(1);
+  });
+
+  /* ---------- Coordinate conversion ---------- */
+
+  it('should convert world to grid (cellSize=1)', () => {
+    const grid = new NavGrid(10, 10, 1);
+    expect(grid.worldToGrid(0.5, 0.5)).toEqual([0, 0]);
+    expect(grid.worldToGrid(3.7, 5.2)).toEqual([3, 5]);
+    expect(grid.worldToGrid(9.9, 9.9)).toEqual([9, 9]);
+  });
+
+  it('should convert world to grid (cellSize=2)', () => {
+    const grid = new NavGrid(5, 5, 2);
+    // cell 0 spans [0, 2), cell 1 spans [2, 4), etc.
+    expect(grid.worldToGrid(1, 1)).toEqual([0, 0]);
+    expect(grid.worldToGrid(3, 5)).toEqual([1, 2]);
+    expect(grid.worldToGrid(9, 9)).toEqual([4, 4]);
+  });
+
+  it('should convert grid to world center', () => {
+    const grid = new NavGrid(10, 10, 1);
+    // Center of cell (0,0) with cellSize=1 is (0.5, 0.5)
+    expect(grid.gridToWorld(0, 0)).toEqual([0.5, 0.5]);
+    expect(grid.gridToWorld(3, 5)).toEqual([3.5, 5.5]);
+  });
+
+  it('should convert grid to world center (cellSize=2)', () => {
+    const grid = new NavGrid(5, 5, 2);
+    // Center of cell (0,0) with cellSize=2 is (1, 1)
+    expect(grid.gridToWorld(0, 0)).toEqual([1, 1]);
+    expect(grid.gridToWorld(2, 3)).toEqual([5, 7]);
+  });
+
+  /* ---------- Batch operations ---------- */
+
+  it('should fill a rectangle as non-walkable', () => {
+    const grid = new NavGrid(8, 8);
+    grid.fillRect(2, 2, 3, 2, false);
+    // Inside rect
+    expect(grid.isWalkable(2, 2)).toBe(false);
+    expect(grid.isWalkable(4, 3)).toBe(false);
+    // Outside rect
+    expect(grid.isWalkable(1, 2)).toBe(true);
+    expect(grid.isWalkable(5, 2)).toBe(true);
+    expect(grid.isWalkable(2, 4)).toBe(true);
+  });
+
+  /* ---------- Neighbors ---------- */
+
+  it('should return 4 cardinal neighbors for interior cell', () => {
+    const grid = new NavGrid(5, 5);
+    const neighbors = grid.getNeighbors(2, 2, false);
+    expect(neighbors).toHaveLength(4);
+    expect(neighbors).toContainEqual([1, 2]);
+    expect(neighbors).toContainEqual([3, 2]);
+    expect(neighbors).toContainEqual([2, 1]);
+    expect(neighbors).toContainEqual([2, 3]);
+  });
+
+  it('should return 8 neighbors with diagonal for interior cell', () => {
+    const grid = new NavGrid(5, 5);
+    const neighbors = grid.getNeighbors(2, 2, true);
+    expect(neighbors).toHaveLength(8);
+    // Cardinals
+    expect(neighbors).toContainEqual([1, 2]);
+    expect(neighbors).toContainEqual([3, 2]);
+    // Diagonals
+    expect(neighbors).toContainEqual([1, 1]);
+    expect(neighbors).toContainEqual([3, 3]);
+  });
+
+  it('should filter out-of-bounds neighbors at corner', () => {
+    const grid = new NavGrid(3, 3);
+    const neighbors = grid.getNeighbors(0, 0, false);
+    expect(neighbors).toHaveLength(2);
+    expect(neighbors).toContainEqual([1, 0]);
+    expect(neighbors).toContainEqual([0, 1]);
+  });
+
+  it('should filter non-walkable neighbors', () => {
+    const grid = new NavGrid(5, 5);
+    grid.setWalkable(3, 2, false);
+    grid.setWalkable(2, 3, false);
+    const neighbors = grid.getNeighbors(2, 2, false);
+    // Only left (1,2) and up (2,1) are walkable
+    expect(neighbors).toHaveLength(2);
+    expect(neighbors).toContainEqual([1, 2]);
+    expect(neighbors).toContainEqual([2, 1]);
+  });
+
+  /* ---------- Clear ---------- */
+
+  it('should clear all cells to walkable with cost 1', () => {
+    const grid = new NavGrid(4, 4);
+    grid.setWalkable(1, 1, false);
+    grid.setCost(2, 2, 5);
+    grid.clear();
+    expect(grid.isWalkable(1, 1)).toBe(true);
+    expect(grid.getCost(2, 2)).toBe(1);
+  });
+});

--- a/test/unit/navigation/pathfinder.test.ts
+++ b/test/unit/navigation/pathfinder.test.ts
@@ -1,0 +1,210 @@
+/**
+ * A* Pathfinder — 预写测试
+ * Phase 12: Navigation & Pathfinding (Architect)
+ */
+import { describe, it, expect } from 'vitest';
+import * as gridMod from '../../../src/navigation/nav-grid';
+import * as mod from '../../../src/navigation/pathfinder';
+
+const isStubGrid = '__STUB__' in gridMod && (gridMod as any).__STUB__ === true;
+const isStub = '__STUB__' in mod && (mod as any).__STUB__ === true;
+const describeImpl = (isStub || isStubGrid) ? describe.skip : describe;
+
+const { NavGrid } = gridMod;
+const { findPath } = mod;
+
+describeImpl('findPath (A*)', () => {
+  /* ---------- 基本路径 ---------- */
+
+  it('should find straight-line path on empty grid', () => {
+    const grid = new NavGrid(5, 1);
+    const result = findPath(grid, 0, 0, 4, 0);
+    expect(result.found).toBe(true);
+    expect(result.path[0]).toEqual([0, 0]);
+    expect(result.path[result.path.length - 1]).toEqual([4, 0]);
+    expect(result.path).toHaveLength(5); // 0→1→2→3→4
+  });
+
+  it('should return correct cost for straight path', () => {
+    const grid = new NavGrid(5, 1);
+    const result = findPath(grid, 0, 0, 4, 0);
+    // 4 steps, each cost 1
+    expect(result.cost).toBe(4);
+  });
+
+  it('should handle start == end', () => {
+    const grid = new NavGrid(5, 5);
+    const result = findPath(grid, 2, 2, 2, 2);
+    expect(result.found).toBe(true);
+    expect(result.path).toHaveLength(1);
+    expect(result.path[0]).toEqual([2, 2]);
+    expect(result.cost).toBe(0);
+  });
+
+  /* ---------- 障碍物绕行 ---------- */
+
+  it('should find path around single obstacle', () => {
+    // Grid:  S . . . .
+    //        . X X X .
+    //        . . . . E
+    const grid = new NavGrid(5, 3);
+    grid.setWalkable(1, 1, false);
+    grid.setWalkable(2, 1, false);
+    grid.setWalkable(3, 1, false);
+    const result = findPath(grid, 0, 0, 4, 2);
+    expect(result.found).toBe(true);
+    // Path should not go through blocked cells
+    for (const [x, y] of result.path) {
+      expect(grid.isWalkable(x, y)).toBe(true);
+    }
+  });
+
+  it('should find path through narrow corridor', () => {
+    // 5x5 grid with walls, only one gap at (2,2)
+    const grid = new NavGrid(5, 5);
+    // Wall across row 2, gap at x=2
+    for (let x = 0; x < 5; x++) {
+      if (x !== 2) grid.setWalkable(x, 2, false);
+    }
+    const result = findPath(grid, 0, 0, 4, 4);
+    expect(result.found).toBe(true);
+    expect(result.path).toContainEqual([2, 2]); // must go through gap
+  });
+
+  /* ---------- 不可达 ---------- */
+
+  it('should return found=false when fully blocked', () => {
+    const grid = new NavGrid(5, 5);
+    // Block entire row 2
+    for (let x = 0; x < 5; x++) grid.setWalkable(x, 2, false);
+    const result = findPath(grid, 2, 0, 2, 4);
+    expect(result.found).toBe(false);
+    expect(result.path).toHaveLength(0);
+  });
+
+  it('should return found=false for out-of-bounds start', () => {
+    const grid = new NavGrid(5, 5);
+    const result = findPath(grid, -1, 0, 4, 4);
+    expect(result.found).toBe(false);
+  });
+
+  it('should return found=false for out-of-bounds end', () => {
+    const grid = new NavGrid(5, 5);
+    const result = findPath(grid, 0, 0, 5, 5);
+    expect(result.found).toBe(false);
+  });
+
+  it('should return found=false when start is non-walkable', () => {
+    const grid = new NavGrid(5, 5);
+    grid.setWalkable(0, 0, false);
+    const result = findPath(grid, 0, 0, 4, 4);
+    expect(result.found).toBe(false);
+  });
+
+  it('should return found=false when end is non-walkable', () => {
+    const grid = new NavGrid(5, 5);
+    grid.setWalkable(4, 4, false);
+    const result = findPath(grid, 0, 0, 4, 4);
+    expect(result.found).toBe(false);
+  });
+
+  /* ---------- 方向模式 ---------- */
+
+  it('should find diagonal path (8-direction)', () => {
+    const grid = new NavGrid(5, 5);
+    const result = findPath(grid, 0, 0, 4, 4, { diagonal: true });
+    expect(result.found).toBe(true);
+    // Diagonal path from (0,0) to (4,4) should be shorter than cardinal
+    expect(result.path.length).toBeLessThanOrEqual(5); // 4 diagonal steps + start
+  });
+
+  it('should find cardinal-only path (4-direction)', () => {
+    const grid = new NavGrid(5, 5);
+    const result = findPath(grid, 0, 0, 4, 4, { diagonal: false });
+    expect(result.found).toBe(true);
+    // Cardinal path: 4 right + 4 down = 8 steps + start = 9 nodes
+    expect(result.path).toHaveLength(9);
+    expect(result.cost).toBe(8);
+  });
+
+  /* ---------- 代价权重 ---------- */
+
+  it('should prefer low-cost cells', () => {
+    // 3x3 grid: top-right path has cost 10 cells, bottom-left is normal
+    const grid = new NavGrid(3, 3);
+    // Make row 0 expensive (except start)
+    grid.setCost(1, 0, 10);
+    grid.setCost(2, 0, 10);
+    const result = findPath(grid, 0, 0, 2, 0, { diagonal: false });
+    expect(result.found).toBe(true);
+    // Optimal path avoids row 0: go down, right, right, up
+    // Total: 4 steps, cost 4, vs direct: 2 steps, cost 20
+    if (result.cost < 20) {
+      // Path should go via row 1 or row 2 to avoid expensive cells
+      const hasExpensiveCell = result.path.some(([x, y]) => x > 0 && y === 0);
+      expect(hasExpensiveCell).toBe(false);
+    }
+  });
+
+  /* ---------- 迭代限制 ---------- */
+
+  it('should respect maxIterations limit', () => {
+    const grid = new NavGrid(100, 100);
+    // With very low iteration limit, should fail to find long path
+    const result = findPath(grid, 0, 0, 99, 99, { maxIterations: 5 });
+    expect(result.found).toBe(false);
+  });
+
+  /* ---------- 大网格性能 ---------- */
+
+  it('should handle 100x100 grid within reasonable time', () => {
+    const grid = new NavGrid(100, 100);
+    const start = performance.now();
+    const result = findPath(grid, 0, 0, 99, 99);
+    const elapsed = performance.now() - start;
+    expect(result.found).toBe(true);
+    expect(elapsed).toBeLessThan(500); // should finish well within 500ms
+  });
+
+  /* ---------- 动态障碍 ---------- */
+
+  it('should find new path after obstacle update', () => {
+    const grid = new NavGrid(5, 3);
+    // Initial: clear path
+    const result1 = findPath(grid, 0, 0, 4, 0);
+    expect(result1.found).toBe(true);
+    const originalLen = result1.path.length;
+
+    // Block the direct path
+    grid.setWalkable(2, 0, false);
+    const result2 = findPath(grid, 0, 0, 4, 0);
+    expect(result2.found).toBe(true);
+    // New path must be longer (detour)
+    expect(result2.path.length).toBeGreaterThan(originalLen);
+    // And must not go through blocked cell
+    expect(result2.path).not.toContainEqual([2, 0]);
+  });
+
+  /* ---------- 启发函数 ---------- */
+
+  it('should accept manhattan heuristic option', () => {
+    const grid = new NavGrid(10, 10);
+    const result = findPath(grid, 0, 0, 9, 9, {
+      diagonal: false,
+      heuristic: 'manhattan',
+    });
+    expect(result.found).toBe(true);
+    expect(result.cost).toBe(18); // 9 + 9
+  });
+
+  it('should accept euclidean heuristic option', () => {
+    const grid = new NavGrid(10, 10);
+    const result = findPath(grid, 0, 0, 9, 9, {
+      diagonal: true,
+      heuristic: 'euclidean',
+    });
+    expect(result.found).toBe(true);
+    // Euclidean admits diagonal; path should be optimal
+    expect(result.path.length).toBeLessThanOrEqual(10);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 12: Navigation & Pathfinding 的预写测试和 stub 文件。

- **NavGrid** (18 tests): 2D 导航网格 — walkability/cost/坐标转换/邻居查询
- **A* Pathfinder** (18 tests): 网格最短路径搜索 — 绕障/方向模式/代价权重/性能
- **NavAgent** (13 tests): 路径跟随代理 — waypoint 跟踪/到达检测/速度控制

共 49 个预写测试（当前 stub 状态下自动跳过）。

此 Phase 为里程碑 2（3D 塔防）的前置条件，解锁敌方单位自动寻路能力。

## Files

- `src/navigation/nav-grid.ts` — NavGrid stub
- `src/navigation/pathfinder.ts` — A* Pathfinder stub
- `src/navigation/nav-agent.ts` — NavAgent stub
- `test/unit/navigation/nav-grid.test.ts` — 18 tests
- `test/unit/navigation/pathfinder.test.ts` — 18 tests
- `test/unit/navigation/nav-agent.test.ts` — 13 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)