### PR TITLE
test: Phase 13 预写测试 — CubeTexture + Skybox + ParticleRenderer (38 tests)

### DIFF
--- a/src/renderer/cube-texture.ts
+++ b/src/renderer/cube-texture.ts
@@ -1,0 +1,51 @@
+/**
+ * CubeTexture — 6 面立方体贴图，用于天空盒和环境映射。
+ *
+ * 每个面是一张正方形 RGBA 图片（Uint8Array），按标准顺序排列：
+ * +X, -X, +Y, -Y, +Z, -Z（gl.TEXTURE_CUBE_MAP_POSITIVE_X 等）。
+ *
+ * @see test/unit/renderer/cube-texture.test.ts
+ * @module
+ */
+
+export const __STUB__ = true;
+
+/** 立方体贴图的 6 个面索引 */
+export const CubeTextureFace = {
+  PositiveX: 0,
+  NegativeX: 1,
+  PositiveY: 2,
+  NegativeY: 3,
+  PositiveZ: 4,
+  NegativeZ: 5,
+} as const;
+
+export type CubeTextureFaceValue = (typeof CubeTextureFace)[keyof typeof CubeTextureFace];
+
+export class CubeTexture {
+  /** 每个面的像素数据（RGBA），null 表示未设置 */
+  readonly faces: (Uint8Array | null)[] = [null, null, null, null, null, null];
+  /** 每个面的边长（像素） */
+  readonly faceSize: number;
+  /** 是否需要重新上传 GPU */
+  needsUpdate: boolean = false;
+
+  constructor(_faceSize: number) {
+    this.faceSize = _faceSize;
+  }
+
+  /** 设置某个面的像素数据 */
+  setFace(_face: CubeTextureFaceValue, _data: Uint8Array): void {
+    throw new Error('Not implemented — stub');
+  }
+
+  /** 是否所有 6 个面都已设置 */
+  isComplete(): boolean {
+    throw new Error('Not implemented — stub');
+  }
+
+  /** 释放所有面数据 */
+  dispose(): void {
+    throw new Error('Not implemented — stub');
+  }
+}

--- a/src/renderer/particle-renderer.ts
+++ b/src/renderer/particle-renderer.ts
@@ -1,0 +1,48 @@
+/**
+ * ParticleRenderer — GPU 粒子点精灵渲染器。
+ *
+ * 将 ParticleEmitter 的 CPU 粒子数据上传到 GPU，使用 gl.POINTS 模式渲染。
+ * 每个粒子是一个点精灵：vertex shader 设置 gl_PointSize，
+ * fragment shader 使用 gl_PointCoord 做圆形遮罩（软边缘衰减）。
+ *
+ * 渲染时启用 alpha blend (SRC_ALPHA, ONE_MINUS_SRC_ALPHA)，禁用深度写入。
+ *
+ * @see test/unit/renderer/particle-renderer.test.ts
+ * @module
+ */
+
+export const __STUB__ = true;
+
+import type { Mat4 } from '../math/mat4';
+import type { ParticleEmitter } from './particle-emitter';
+
+export class ParticleRenderer {
+  /**
+   * @param gl WebGL 1.0 上下文
+   * @param maxParticles 最大粒子数（预分配缓冲区大小）
+   */
+  constructor(_gl: WebGLRenderingContext, _maxParticles: number) {
+    throw new Error('Not implemented — stub');
+  }
+
+  /**
+   * 从发射器读取存活粒子数据并更新 GPU 缓冲区。
+   * 读取 getPositions() / getSizes() / getColors() / getAlphas()。
+   */
+  update(_emitter: ParticleEmitter): void {
+    throw new Error('Not implemented — stub');
+  }
+
+  /**
+   * 渲染粒子。使用 gl.POINTS + gl_PointSize。
+   * @param viewProj 视图投影矩阵
+   */
+  render(_viewProj: Mat4): void {
+    throw new Error('Not implemented — stub');
+  }
+
+  /** 释放 GPU 资源（shader program, buffers） */
+  dispose(): void {
+    throw new Error('Not implemented — stub');
+  }
+}

--- a/src/renderer/skybox.ts
+++ b/src/renderer/skybox.ts
@@ -1,0 +1,36 @@
+/**
+ * SkyboxRenderer — 天空盒渲染器，使用 CubeTexture 渲染无限远的背景。
+ *
+ * 技术方案：全屏四边形 + 逆 VP 矩阵反投影，采样 samplerCube。
+ * 渲染时去除相机平移（仅保留旋转），深度设为最远（gl_Position.z = gl_Position.w），
+ * 深度函数设为 LEQUAL 以便场景物体覆盖天空盒。
+ *
+ * @see test/unit/renderer/skybox.test.ts
+ * @module
+ */
+
+export const __STUB__ = true;
+
+import type { CubeTexture } from './cube-texture';
+import type { Camera } from '../core/camera';
+
+export class SkyboxRenderer {
+  /** @param gl WebGL 1.0 上下文 */
+  constructor(_gl: WebGLRenderingContext) {
+    throw new Error('Not implemented — stub');
+  }
+
+  /**
+   * 渲染天空盒。应在场景物体之前调用。
+   * @param texture 完整的 6 面 CubeTexture
+   * @param camera  当前相机（使用其 viewProjectionMatrix）
+   */
+  render(_texture: CubeTexture, _camera: Camera): void {
+    throw new Error('Not implemented — stub');
+  }
+
+  /** 释放 GPU 资源 */
+  dispose(): void {
+    throw new Error('Not implemented — stub');
+  }
+}

--- a/test/helpers/mock-gl.ts
+++ b/test/helpers/mock-gl.ts
@@ -125,6 +125,13 @@ export function createMockGL(): MockGL & WebGLRenderingContext {
   const NO_ERROR            = 0;
   const UNPACK_FLIP_Y_WEBGL = 0x9240;
   const UNPACK_PREMULTIPLY_ALPHA_WEBGL = 0x9241;
+  const TEXTURE_CUBE_MAP              = 0x8513;
+  const TEXTURE_CUBE_MAP_POSITIVE_X   = 0x8515;
+  const TEXTURE_CUBE_MAP_NEGATIVE_X   = 0x8516;
+  const TEXTURE_CUBE_MAP_POSITIVE_Y   = 0x8517;
+  const TEXTURE_CUBE_MAP_NEGATIVE_Y   = 0x8518;
+  const TEXTURE_CUBE_MAP_POSITIVE_Z   = 0x8519;
+  const TEXTURE_CUBE_MAP_NEGATIVE_Z   = 0x851A;
 
   const gl: any = {
     // ── 追踪属性 ─────────────────────────────────────────────────
@@ -155,6 +162,9 @@ export function createMockGL(): MockGL & WebGLRenderingContext {
     COLOR_ATTACHMENT0, DEPTH_ATTACHMENT, STENCIL_ATTACHMENT, DEPTH_STENCIL_ATTACHMENT,
     FRAMEBUFFER_COMPLETE, DEPTH_COMPONENT16, DEPTH_STENCIL,
     NO_ERROR, UNPACK_FLIP_Y_WEBGL, UNPACK_PREMULTIPLY_ALPHA_WEBGL,
+    TEXTURE_CUBE_MAP, TEXTURE_CUBE_MAP_POSITIVE_X, TEXTURE_CUBE_MAP_NEGATIVE_X,
+    TEXTURE_CUBE_MAP_POSITIVE_Y, TEXTURE_CUBE_MAP_NEGATIVE_Y,
+    TEXTURE_CUBE_MAP_POSITIVE_Z, TEXTURE_CUBE_MAP_NEGATIVE_Z,
 
     // canvas 由 createMockCanvas 注入
     canvas: null as unknown as HTMLCanvasElement,

--- a/test/unit/renderer/cube-texture.test.ts
+++ b/test/unit/renderer/cube-texture.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { CubeTexture, CubeTextureFace } from '../../../src/renderer/cube-texture';
+
+const isStub = '__STUB__' in CubeTexture && (CubeTexture as any).__STUB__ === true;
+
+// re-export 模块级 __STUB__ 检查
+const mod = await import('../../../src/renderer/cube-texture');
+const modIsStub = '__STUB__' in mod && (mod as any).__STUB__ === true;
+const describeImpl = modIsStub ? describe.skip : describe;
+
+describeImpl('CubeTexture', () => {
+  const FACE_SIZE = 2; // 2×2 pixel faces
+  const FACE_BYTES = FACE_SIZE * FACE_SIZE * 4; // RGBA
+
+  function makeFaceData(fill = 0): Uint8Array {
+    return new Uint8Array(FACE_BYTES).fill(fill);
+  }
+
+  // ── 构造函数 ──────────────────────────────────────────────────
+
+  it('should create with specified face size', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    expect(ct.faceSize).toBe(FACE_SIZE);
+  });
+
+  it('should initialize all 6 faces as null', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    expect(ct.faces).toHaveLength(6);
+    for (let i = 0; i < 6; i++) {
+      expect(ct.faces[i]).toBeNull();
+    }
+  });
+
+  it('should start with needsUpdate = false', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    expect(ct.needsUpdate).toBe(false);
+  });
+
+  // ── setFace ───────────────────────────────────────────────────
+
+  it('should store face data at correct index', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    const data = makeFaceData(255);
+    ct.setFace(CubeTextureFace.PositiveX, data);
+    expect(ct.faces[0]).toBe(data);
+  });
+
+  it('should set needsUpdate after setFace', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    ct.setFace(CubeTextureFace.NegativeZ, makeFaceData());
+    expect(ct.needsUpdate).toBe(true);
+  });
+
+  it('should reject face data with wrong byte length', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    const wrongSize = new Uint8Array(10); // not FACE_BYTES
+    expect(() => ct.setFace(CubeTextureFace.PositiveY, wrongSize)).toThrow();
+  });
+
+  it('should allow overwriting a face', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    const data1 = makeFaceData(100);
+    const data2 = makeFaceData(200);
+    ct.setFace(CubeTextureFace.NegativeX, data1);
+    ct.setFace(CubeTextureFace.NegativeX, data2);
+    expect(ct.faces[CubeTextureFace.NegativeX]).toBe(data2);
+  });
+
+  // ── isComplete ────────────────────────────────────────────────
+
+  it('should return false when no faces set', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    expect(ct.isComplete()).toBe(false);
+  });
+
+  it('should return false with partial faces', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    ct.setFace(CubeTextureFace.PositiveX, makeFaceData());
+    ct.setFace(CubeTextureFace.NegativeX, makeFaceData());
+    ct.setFace(CubeTextureFace.PositiveY, makeFaceData());
+    expect(ct.isComplete()).toBe(false);
+  });
+
+  it('should return true when all 6 faces set', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    for (let i = 0; i < 6; i++) {
+      ct.setFace(i as any, makeFaceData(i));
+    }
+    expect(ct.isComplete()).toBe(true);
+  });
+
+  // ── dispose ───────────────────────────────────────────────────
+
+  it('should clear all faces on dispose', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    for (let i = 0; i < 6; i++) {
+      ct.setFace(i as any, makeFaceData());
+    }
+    ct.dispose();
+    for (let i = 0; i < 6; i++) {
+      expect(ct.faces[i]).toBeNull();
+    }
+  });
+
+  it('should be incomplete after dispose', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    for (let i = 0; i < 6; i++) {
+      ct.setFace(i as any, makeFaceData());
+    }
+    ct.dispose();
+    expect(ct.isComplete()).toBe(false);
+  });
+
+  // ── CubeTextureFace 常量 ──────────────────────────────────────
+
+  it('should define face constants 0-5', () => {
+    expect(CubeTextureFace.PositiveX).toBe(0);
+    expect(CubeTextureFace.NegativeX).toBe(1);
+    expect(CubeTextureFace.PositiveY).toBe(2);
+    expect(CubeTextureFace.NegativeY).toBe(3);
+    expect(CubeTextureFace.PositiveZ).toBe(4);
+    expect(CubeTextureFace.NegativeZ).toBe(5);
+  });
+});

--- a/test/unit/renderer/particle-renderer.test.ts
+++ b/test/unit/renderer/particle-renderer.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ParticleRenderer } from '../../../src/renderer/particle-renderer';
+import { ParticleEmitter } from '../../../src/renderer/particle-emitter';
+import { identity } from '../../../src/math/mat4';
+import { vec3 } from '../../../src/math/vec3';
+import { createMockGL, type MockGL } from '../../helpers/mock-gl';
+
+const mod = await import('../../../src/renderer/particle-renderer');
+const modIsStub = '__STUB__' in mod && (mod as any).__STUB__ === true;
+const describeImpl = modIsStub ? describe.skip : describe;
+
+function makeEmitter(count = 10): ParticleEmitter {
+  return new ParticleEmitter({
+    maxParticles: count,
+    emissionRate: 0,
+    lifetime: { min: 2, max: 2 },
+    speed: { min: 1, max: 1 },
+    size: { min: 4, max: 8 },
+    color: vec3(1, 0.5, 0),
+    colorEnd: vec3(1, 0, 0),
+    gravity: vec3(0, 0, 0),
+    seed: 42,
+  });
+}
+
+describeImpl('ParticleRenderer', () => {
+  let gl: MockGL & WebGLRenderingContext;
+  let renderer: ParticleRenderer;
+  const MAX = 100;
+
+  beforeEach(() => {
+    gl = createMockGL();
+    renderer = new ParticleRenderer(gl, MAX);
+  });
+
+  // ── 构造 ──────────────────────────────────────────────────────
+
+  it('should compile point sprite shader program', () => {
+    expect(gl._programs).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should create attribute buffers (position, size, color, alpha)', () => {
+    // 至少 4 个缓冲区
+    expect(gl._buffers).toBeGreaterThanOrEqual(4);
+  });
+
+  // ── update ────────────────────────────────────────────────────
+
+  it('should read particle data from emitter', () => {
+    const emitter = makeEmitter(20);
+    emitter.emit(5);
+
+    // update 不应抛出
+    renderer.update(emitter);
+  });
+
+  it('should handle zero active particles', () => {
+    const emitter = makeEmitter(10);
+    // 不 emit，activeCount = 0
+
+    renderer.update(emitter);
+    // 不抛出即可
+  });
+
+  it('should upload buffer data via bufferSubData or bufferData', () => {
+    const emitter = makeEmitter(20);
+    emitter.emit(10);
+
+    const before = (gl._calls['bufferSubData'] ?? 0) + (gl._calls['bufferData'] ?? 0);
+    renderer.update(emitter);
+    const after = (gl._calls['bufferSubData'] ?? 0) + (gl._calls['bufferData'] ?? 0);
+
+    // 至少 4 次缓冲区更新（pos, size, color, alpha）
+    expect(after - before).toBeGreaterThanOrEqual(4);
+  });
+
+  // ── render ────────────────────────────────────────────────────
+
+  it('should draw with gl.POINTS mode', () => {
+    const emitter = makeEmitter(20);
+    emitter.emit(5);
+    renderer.update(emitter);
+
+    gl._drawCalls.length = 0;
+    const vp = identity();
+    renderer.render(vp);
+
+    expect(gl._drawCalls).toHaveLength(1);
+    expect(gl._drawCalls[0].type).toBe('drawArrays');
+  });
+
+  it('should draw correct number of particles', () => {
+    const emitter = makeEmitter(20);
+    emitter.emit(7);
+    renderer.update(emitter);
+
+    gl._drawCalls.length = 0;
+    renderer.render(identity());
+
+    expect(gl._drawCalls[0].count).toBe(7);
+  });
+
+  it('should skip draw when no active particles', () => {
+    const emitter = makeEmitter(10);
+    renderer.update(emitter);
+
+    gl._drawCalls.length = 0;
+    renderer.render(identity());
+
+    // 0 个粒子不应产生 draw call
+    expect(gl._drawCalls).toHaveLength(0);
+  });
+
+  it('should enable alpha blending', () => {
+    const emitter = makeEmitter(10);
+    emitter.emit(3);
+    renderer.update(emitter);
+
+    let blendEnabled = false;
+    const origEnable = gl.enable.bind(gl);
+    gl.enable = (cap: number) => {
+      if (cap === gl.BLEND) blendEnabled = true;
+      origEnable(cap);
+    };
+
+    renderer.render(identity());
+
+    expect(blendEnabled).toBe(true);
+  });
+
+  it('should disable depth write during particle rendering', () => {
+    const emitter = makeEmitter(10);
+    emitter.emit(3);
+    renderer.update(emitter);
+
+    let depthMaskArgs: boolean[] = [];
+    const origDepthMask = gl.depthMask.bind(gl);
+    gl.depthMask = (flag: boolean) => {
+      depthMaskArgs.push(flag);
+      origDepthMask(flag);
+    };
+
+    renderer.render(identity());
+
+    // 先禁用深度写入 (false)，渲染后恢复 (true)
+    expect(depthMaskArgs).toContain(false);
+    expect(depthMaskArgs[depthMaskArgs.length - 1]).toBe(true);
+  });
+
+  it('should upload viewProj matrix as uniform', () => {
+    const emitter = makeEmitter(10);
+    emitter.emit(3);
+    renderer.update(emitter);
+
+    const before = gl._calls['uniformMatrix4fv'] ?? 0;
+    renderer.render(identity());
+    const after = gl._calls['uniformMatrix4fv'] ?? 0;
+
+    expect(after).toBeGreaterThan(before);
+  });
+
+  // ── dispose ───────────────────────────────────────────────────
+
+  it('should delete program on dispose', () => {
+    renderer.dispose();
+    expect(gl._calls['deleteProgram']).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should delete buffers on dispose', () => {
+    renderer.dispose();
+    expect(gl._calls['deleteBuffer']).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/test/unit/renderer/skybox.test.ts
+++ b/test/unit/renderer/skybox.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SkyboxRenderer } from '../../../src/renderer/skybox';
+import { CubeTexture, CubeTextureFace } from '../../../src/renderer/cube-texture';
+import { PerspectiveCamera } from '../../../src/core/camera';
+import { createMockGL, type MockGL } from '../../helpers/mock-gl';
+
+const mod = await import('../../../src/renderer/skybox');
+const modIsStub = '__STUB__' in mod && (mod as any).__STUB__ === true;
+const describeImpl = modIsStub ? describe.skip : describe;
+
+/** 创建一个完整的 2×2 CubeTexture */
+function makeCompleteCubeTexture(): CubeTexture {
+  const ct = new CubeTexture(2);
+  const bytes = 2 * 2 * 4; // RGBA
+  for (let i = 0; i < 6; i++) {
+    ct.setFace(i as any, new Uint8Array(bytes).fill(i * 40));
+  }
+  return ct;
+}
+
+describeImpl('SkyboxRenderer', () => {
+  let gl: MockGL & WebGLRenderingContext;
+  let skybox: SkyboxRenderer;
+
+  beforeEach(() => {
+    gl = createMockGL();
+    skybox = new SkyboxRenderer(gl);
+  });
+
+  // ── 构造 ──────────────────────────────────────────────────────
+
+  it('should compile shader program on construction', () => {
+    expect(gl._programs).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should create vertex buffer for full-screen quad', () => {
+    expect(gl._buffers).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── render ────────────────────────────────────────────────────
+
+  it('should issue one draw call per render', () => {
+    const camera = new PerspectiveCamera({ fov: 60, aspect: 1, near: 0.1, far: 100 });
+    const texture = makeCompleteCubeTexture();
+
+    gl._drawCalls.length = 0;
+    skybox.render(texture, camera);
+
+    expect(gl._drawCalls).toHaveLength(1);
+  });
+
+  it('should draw 6 vertices (full-screen quad as 2 triangles)', () => {
+    const camera = new PerspectiveCamera({ fov: 60, aspect: 1, near: 0.1, far: 100 });
+    const texture = makeCompleteCubeTexture();
+
+    gl._drawCalls.length = 0;
+    skybox.render(texture, camera);
+
+    // 全屏四边形 = 2 个三角形 = 6 个顶点
+    expect(gl._drawCalls[0].count).toBe(6);
+  });
+
+  it('should set depth function to LEQUAL', () => {
+    const camera = new PerspectiveCamera({ fov: 60, aspect: 1, near: 0.1, far: 100 });
+    const texture = makeCompleteCubeTexture();
+
+    // 追踪 depthFunc 调用
+    let depthFuncCalled = false;
+    let depthFuncArg = 0;
+    const origDepthFunc = gl.depthFunc.bind(gl);
+    gl.depthFunc = (func: number) => {
+      depthFuncCalled = true;
+      depthFuncArg = func;
+      origDepthFunc(func);
+    };
+
+    skybox.render(texture, camera);
+
+    expect(depthFuncCalled).toBe(true);
+    expect(depthFuncArg).toBe(gl.LEQUAL);
+  });
+
+  it('should disable depth write during skybox rendering', () => {
+    const camera = new PerspectiveCamera({ fov: 60, aspect: 1, near: 0.1, far: 100 });
+    const texture = makeCompleteCubeTexture();
+
+    let depthMaskArgs: boolean[] = [];
+    const origDepthMask = gl.depthMask.bind(gl);
+    gl.depthMask = (flag: boolean) => {
+      depthMaskArgs.push(flag);
+      origDepthMask(flag);
+    };
+
+    skybox.render(texture, camera);
+
+    // 应该先禁用 (false)，渲染后恢复 (true)
+    expect(depthMaskArgs).toContain(false);
+    expect(depthMaskArgs[depthMaskArgs.length - 1]).toBe(true);
+  });
+
+  it('should bind cube map texture', () => {
+    const camera = new PerspectiveCamera({ fov: 60, aspect: 1, near: 0.1, far: 100 });
+    const texture = makeCompleteCubeTexture();
+
+    skybox.render(texture, camera);
+
+    // 至少创建了一个纹理（cube map）
+    expect(gl._textures).toBeGreaterThanOrEqual(1);
+    expect(gl._calls['bindTexture']).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should use the skybox shader program', () => {
+    const camera = new PerspectiveCamera({ fov: 60, aspect: 1, near: 0.1, far: 100 });
+    const texture = makeCompleteCubeTexture();
+
+    skybox.render(texture, camera);
+
+    expect(gl._calls['useProgram']).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should upload inverse view-rotation matrix as uniform', () => {
+    const camera = new PerspectiveCamera({ fov: 60, aspect: 1, near: 0.1, far: 100 });
+    camera.position = [0, 5, 10];
+    camera.lookAt([0, 0, 0]);
+    const texture = makeCompleteCubeTexture();
+
+    skybox.render(texture, camera);
+
+    // 至少上传了一个 mat4 uniform（inverse view-rotation）
+    expect(gl._calls['uniformMatrix4fv']).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── restore state ─────────────────────────────────────────────
+
+  it('should restore depth function to LESS after render', () => {
+    const camera = new PerspectiveCamera({ fov: 60, aspect: 1, near: 0.1, far: 100 });
+    const texture = makeCompleteCubeTexture();
+
+    let lastDepthFunc = 0;
+    gl.depthFunc = (func: number) => { lastDepthFunc = func; };
+
+    skybox.render(texture, camera);
+
+    // 最后恢复为 LESS
+    expect(lastDepthFunc).toBe(gl.LESS);
+  });
+
+  // ── dispose ───────────────────────────────────────────────────
+
+  it('should delete program on dispose', () => {
+    skybox.dispose();
+    expect(gl._calls['deleteProgram']).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should delete buffers on dispose', () => {
+    skybox.dispose();
+    expect(gl._calls['deleteBuffer']).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary
- CubeTexture: 6 面立方体贴图数据结构 (13 tests)
- SkyboxRenderer: 天空盒渲染器，全屏四边形 + samplerCube (12 tests)
- ParticleRenderer: GPU 粒子点精灵渲染器，gl.POINTS 模式 (13 tests)
- mock-gl 增加 TEXTURE_CUBE_MAP 系列常量

所有测试在 stub 模式下跳过，等待实现。

## Test plan
- [x] `npx vitest run` — 38 tests skipped (stub mode)
- [ ] 实现后所有测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)