### PR TITLE
feat: 实现 CubeTexture 立方体贴图数据结构 (#104)

### DIFF
--- a/src/renderer/cube-texture.ts
+++ b/src/renderer/cube-texture.ts
@@ -1,0 +1,58 @@
+/**
+ * CubeTexture — 6 面立方体贴图，用于天空盒和环境映射。
+ *
+ * 每个面是一张正方形 RGBA 图片（Uint8Array），按标准顺序排列：
+ * +X, -X, +Y, -Y, +Z, -Z（gl.TEXTURE_CUBE_MAP_POSITIVE_X 等）。
+ *
+ * @see test/unit/renderer/cube-texture.test.ts
+ * @module
+ */
+
+/** 立方体贴图的 6 个面索引 */
+export const CubeTextureFace = {
+  PositiveX: 0,
+  NegativeX: 1,
+  PositiveY: 2,
+  NegativeY: 3,
+  PositiveZ: 4,
+  NegativeZ: 5,
+} as const;
+
+export type CubeTextureFaceValue = (typeof CubeTextureFace)[keyof typeof CubeTextureFace];
+
+export class CubeTexture {
+  /** 每个面的像素数据（RGBA），null 表示未设置 */
+  readonly faces: (Uint8Array | null)[] = [null, null, null, null, null, null];
+  /** 每个面的边长（像素） */
+  readonly faceSize: number;
+  /** 是否需要重新上传 GPU */
+  needsUpdate: boolean = false;
+
+  constructor(faceSize: number) {
+    this.faceSize = faceSize;
+  }
+
+  /** 设置某个面的像素数据 */
+  setFace(face: CubeTextureFaceValue, data: Uint8Array): void {
+    const expected = this.faceSize * this.faceSize * 4;
+    if (data.byteLength !== expected) {
+      throw new Error(
+        `CubeTexture.setFace: 数据长度不正确。期望 ${expected} 字节，实际 ${data.byteLength} 字节。`
+      );
+    }
+    this.faces[face] = data;
+    this.needsUpdate = true;
+  }
+
+  /** 是否所有 6 个面都已设置 */
+  isComplete(): boolean {
+    return this.faces.every((f) => f !== null);
+  }
+
+  /** 释放所有面数据 */
+  dispose(): void {
+    for (let i = 0; i < 6; i++) {
+      this.faces[i] = null;
+    }
+  }
+}

--- a/test/unit/renderer/cube-texture.test.ts
+++ b/test/unit/renderer/cube-texture.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { CubeTexture, CubeTextureFace } from '../../../src/renderer/cube-texture';
+
+const isStub = '__STUB__' in CubeTexture && (CubeTexture as any).__STUB__ === true;
+
+// re-export 模块级 __STUB__ 检查
+const mod = await import('../../../src/renderer/cube-texture');
+const modIsStub = '__STUB__' in mod && (mod as any).__STUB__ === true;
+const describeImpl = modIsStub ? describe.skip : describe;
+
+describeImpl('CubeTexture', () => {
+  const FACE_SIZE = 2; // 2×2 pixel faces
+  const FACE_BYTES = FACE_SIZE * FACE_SIZE * 4; // RGBA
+
+  function makeFaceData(fill = 0): Uint8Array {
+    return new Uint8Array(FACE_BYTES).fill(fill);
+  }
+
+  // ── 构造函数 ──────────────────────────────────────────────────
+
+  it('should create with specified face size', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    expect(ct.faceSize).toBe(FACE_SIZE);
+  });
+
+  it('should initialize all 6 faces as null', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    expect(ct.faces).toHaveLength(6);
+    for (let i = 0; i < 6; i++) {
+      expect(ct.faces[i]).toBeNull();
+    }
+  });
+
+  it('should start with needsUpdate = false', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    expect(ct.needsUpdate).toBe(false);
+  });
+
+  // ── setFace ───────────────────────────────────────────────────
+
+  it('should store face data at correct index', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    const data = makeFaceData(255);
+    ct.setFace(CubeTextureFace.PositiveX, data);
+    expect(ct.faces[0]).toBe(data);
+  });
+
+  it('should set needsUpdate after setFace', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    ct.setFace(CubeTextureFace.NegativeZ, makeFaceData());
+    expect(ct.needsUpdate).toBe(true);
+  });
+
+  it('should reject face data with wrong byte length', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    const wrongSize = new Uint8Array(10); // not FACE_BYTES
+    expect(() => ct.setFace(CubeTextureFace.PositiveY, wrongSize)).toThrow();
+  });
+
+  it('should allow overwriting a face', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    const data1 = makeFaceData(100);
+    const data2 = makeFaceData(200);
+    ct.setFace(CubeTextureFace.NegativeX, data1);
+    ct.setFace(CubeTextureFace.NegativeX, data2);
+    expect(ct.faces[CubeTextureFace.NegativeX]).toBe(data2);
+  });
+
+  // ── isComplete ────────────────────────────────────────────────
+
+  it('should return false when no faces set', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    expect(ct.isComplete()).toBe(false);
+  });
+
+  it('should return false with partial faces', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    ct.setFace(CubeTextureFace.PositiveX, makeFaceData());
+    ct.setFace(CubeTextureFace.NegativeX, makeFaceData());
+    ct.setFace(CubeTextureFace.PositiveY, makeFaceData());
+    expect(ct.isComplete()).toBe(false);
+  });
+
+  it('should return true when all 6 faces set', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    for (let i = 0; i < 6; i++) {
+      ct.setFace(i as any, makeFaceData(i));
+    }
+    expect(ct.isComplete()).toBe(true);
+  });
+
+  // ── dispose ───────────────────────────────────────────────────
+
+  it('should clear all faces on dispose', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    for (let i = 0; i < 6; i++) {
+      ct.setFace(i as any, makeFaceData());
+    }
+    ct.dispose();
+    for (let i = 0; i < 6; i++) {
+      expect(ct.faces[i]).toBeNull();
+    }
+  });
+
+  it('should be incomplete after dispose', () => {
+    const ct = new CubeTexture(FACE_SIZE);
+    for (let i = 0; i < 6; i++) {
+      ct.setFace(i as any, makeFaceData());
+    }
+    ct.dispose();
+    expect(ct.isComplete()).toBe(false);
+  });
+
+  // ── CubeTextureFace 常量 ──────────────────────────────────────
+
+  it('should define face constants 0-5', () => {
+    expect(CubeTextureFace.PositiveX).toBe(0);
+    expect(CubeTextureFace.NegativeX).toBe(1);
+    expect(CubeTextureFace.PositiveY).toBe(2);
+    expect(CubeTextureFace.NegativeY).toBe(3);
+    expect(CubeTextureFace.PositiveZ).toBe(4);
+    expect(CubeTextureFace.NegativeZ).toBe(5);
+  });
+});


### PR DESCRIPTION
## 概述

实现 6 面立方体贴图纯数据结构，用于天空盒和环境映射。

## 变更

- `src/renderer/cube-texture.ts` — 移除 stub，实现完整逻辑
- `test/unit/renderer/cube-texture.test.ts` — 从 phase-13 分支检出

## 实现细节

- `CubeTextureFace` 常量按标准顺序定义 +X/-X/+Y/-Y/+Z/-Z 六面索引（0-5）
- `setFace()` 校验数据长度 = faceSize² × 4（RGBA），设置后标记 `needsUpdate = true`
- `isComplete()` 检查所有 6 个面均非 null
- `dispose()` 清空所有面数据
- 纯数据结构，零 GL 依赖

## 测试

全量：784 passed | 31 skipped

close #104