### PR TITLE
feat: 实现 ParticleRenderer GPU 粒子点精灵渲染器 (#106)

### DIFF
--- a/src/renderer/particle-renderer.ts
+++ b/src/renderer/particle-renderer.ts
@@ -1,0 +1,231 @@
+/**
+ * ParticleRenderer — GPU 粒子点精灵渲染器。
+ * 使用 gl.POINTS 原语和 gl_PointCoord 实现圆形点精灵。
+ * 4 个独立顶点属性缓冲区：position、size、color、alpha。
+ */
+
+import { type Mat4 } from '../math/mat4';
+import { type ParticleEmitter } from './particle-emitter';
+
+// ── Shaders ──────────────────────────────────────────────────────
+
+const VERT_SRC = `
+  precision mediump float;
+  attribute vec3 a_position;
+  attribute float a_size;
+  attribute vec3 a_color;
+  attribute float a_alpha;
+  uniform mat4 u_viewProj;
+  varying vec3 v_color;
+  varying float v_alpha;
+
+  void main() {
+    gl_Position = u_viewProj * vec4(a_position, 1.0);
+    gl_PointSize = a_size;
+    v_color = a_color;
+    v_alpha = a_alpha;
+  }
+`;
+
+const FRAG_SRC = `
+  precision mediump float;
+  varying vec3 v_color;
+  varying float v_alpha;
+
+  void main() {
+    vec2 coord = gl_PointCoord - vec2(0.5);
+    if (length(coord) > 0.5) {
+      discard;
+    }
+    gl_FragColor = vec4(v_color, v_alpha);
+  }
+`;
+
+// ── ParticleRenderer ─────────────────────────────────────────────
+
+export class ParticleRenderer {
+  private gl: WebGLRenderingContext;
+  private program: WebGLProgram;
+
+  // 4 个独立顶点属性缓冲区
+  private positionBuffer: WebGLBuffer;
+  private sizeBuffer: WebGLBuffer;
+  private colorBuffer: WebGLBuffer;
+  private alphaBuffer: WebGLBuffer;
+
+  // Attribute locations
+  private aPosition: number;
+  private aSize: number;
+  private aColor: number;
+  private aAlpha: number;
+
+  // Uniform location
+  private uViewProj: WebGLUniformLocation | null;
+
+  private maxParticles: number;
+  private activeCount: number = 0;
+  private disposed: boolean = false;
+
+  constructor(gl: WebGLRenderingContext, maxParticles: number) {
+    this.gl = gl;
+    this.maxParticles = maxParticles;
+
+    // ── 编译 shader ──────────────────────────────────────────────
+    const vs = this._compileShader(gl.VERTEX_SHADER, VERT_SRC);
+    const fs = this._compileShader(gl.FRAGMENT_SHADER, FRAG_SRC);
+
+    const program = gl.createProgram()!;
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    gl.detachShader(program, vs);
+    gl.detachShader(program, fs);
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      const info = gl.getProgramInfoLog(program);
+      gl.deleteProgram(program);
+      throw new Error(`ParticleRenderer: shader 链接失败 — ${info}`);
+    }
+
+    this.program = program;
+
+    // ── Attribute / uniform 位置 ─────────────────────────────────
+    this.aPosition = gl.getAttribLocation(program, 'a_position');
+    this.aSize     = gl.getAttribLocation(program, 'a_size');
+    this.aColor    = gl.getAttribLocation(program, 'a_color');
+    this.aAlpha    = gl.getAttribLocation(program, 'a_alpha');
+    this.uViewProj = gl.getUniformLocation(program, 'u_viewProj');
+
+    // ── 预分配 4 个独立缓冲区 ─────────────────────────────────────
+    this.positionBuffer = this._allocBuffer(maxParticles * 3); // vec3
+    this.sizeBuffer     = this._allocBuffer(maxParticles * 1); // float
+    this.colorBuffer    = this._allocBuffer(maxParticles * 3); // vec3
+    this.alphaBuffer    = this._allocBuffer(maxParticles * 1); // float
+  }
+
+  /**
+   * 从 emitter 拉取粒子数据，分别上传到 4 个 GPU 缓冲区。
+   */
+  update(emitter: ParticleEmitter): void {
+    this.activeCount = emitter.activeCount;
+    if (this.activeCount === 0) return;
+
+    const gl = this.gl;
+
+    // 上传 position（vec3 per particle）
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, emitter.getPositions());
+
+    // 上传 size（float per particle）
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.sizeBuffer);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, emitter.getSizes());
+
+    // 上传 color（vec3 per particle）
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.colorBuffer);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, emitter.getColors());
+
+    // 上传 alpha（float per particle）
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.alphaBuffer);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, emitter.getAlphas());
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  }
+
+  /**
+   * 渲染所有活跃粒子。
+   */
+  render(viewProj: Mat4): void {
+    if (this.activeCount === 0) return;
+
+    const gl = this.gl;
+
+    // Alpha 混合
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+    // 禁用深度写入
+    gl.depthMask(false);
+
+    gl.useProgram(this.program);
+    gl.uniformMatrix4fv(this.uViewProj, false, viewProj);
+
+    // 绑定各属性缓冲区
+    if (this.aPosition >= 0) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+      gl.enableVertexAttribArray(this.aPosition);
+      gl.vertexAttribPointer(this.aPosition, 3, gl.FLOAT, false, 0, 0);
+    }
+    if (this.aSize >= 0) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.sizeBuffer);
+      gl.enableVertexAttribArray(this.aSize);
+      gl.vertexAttribPointer(this.aSize, 1, gl.FLOAT, false, 0, 0);
+    }
+    if (this.aColor >= 0) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.colorBuffer);
+      gl.enableVertexAttribArray(this.aColor);
+      gl.vertexAttribPointer(this.aColor, 3, gl.FLOAT, false, 0, 0);
+    }
+    if (this.aAlpha >= 0) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.alphaBuffer);
+      gl.enableVertexAttribArray(this.aAlpha);
+      gl.vertexAttribPointer(this.aAlpha, 1, gl.FLOAT, false, 0, 0);
+    }
+
+    gl.drawArrays(gl.POINTS, 0, this.activeCount);
+
+    // 清理
+    if (this.aPosition >= 0) gl.disableVertexAttribArray(this.aPosition);
+    if (this.aSize >= 0)     gl.disableVertexAttribArray(this.aSize);
+    if (this.aColor >= 0)    gl.disableVertexAttribArray(this.aColor);
+    if (this.aAlpha >= 0)    gl.disableVertexAttribArray(this.aAlpha);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+    // 恢复深度写入
+    gl.depthMask(true);
+  }
+
+  /**
+   * 释放 GPU 资源。可安全多次调用。
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    const gl = this.gl;
+    gl.deleteProgram(this.program);
+    gl.deleteBuffer(this.positionBuffer);
+    gl.deleteBuffer(this.sizeBuffer);
+    gl.deleteBuffer(this.colorBuffer);
+    gl.deleteBuffer(this.alphaBuffer);
+  }
+
+  // ── 私有辅助 ─────────────────────────────────────────────────────
+
+  private _compileShader(type: number, src: string): WebGLShader {
+    const gl = this.gl;
+    const shader = gl.createShader(type)!;
+    gl.shaderSource(shader, src);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      const info = gl.getShaderInfoLog(shader);
+      gl.deleteShader(shader);
+      throw new Error(`ParticleRenderer: shader 编译失败 — ${info}`);
+    }
+    return shader;
+  }
+
+  private _allocBuffer(floatCount: number): WebGLBuffer {
+    const gl = this.gl;
+    const buf = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      floatCount * Float32Array.BYTES_PER_ELEMENT,
+      gl.DYNAMIC_DRAW,
+    );
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    return buf;
+  }
+}

--- a/test/unit/renderer/particle-renderer.test.ts
+++ b/test/unit/renderer/particle-renderer.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ParticleRenderer } from '../../../src/renderer/particle-renderer';
+import { ParticleEmitter } from '../../../src/renderer/particle-emitter';
+import { identity } from '../../../src/math/mat4';
+import { vec3 } from '../../../src/math/vec3';
+import { createMockGL, type MockGL } from '../../helpers/mock-gl';
+
+const mod = await import('../../../src/renderer/particle-renderer');
+const modIsStub = '__STUB__' in mod && (mod as any).__STUB__ === true;
+const describeImpl = modIsStub ? describe.skip : describe;
+
+function makeEmitter(count = 10): ParticleEmitter {
+  return new ParticleEmitter({
+    maxParticles: count,
+    emissionRate: 0,
+    lifetime: { min: 2, max: 2 },
+    speed: { min: 1, max: 1 },
+    size: { min: 4, max: 8 },
+    color: vec3(1, 0.5, 0),
+    colorEnd: vec3(1, 0, 0),
+    gravity: vec3(0, 0, 0),
+    seed: 42,
+  });
+}
+
+describeImpl('ParticleRenderer', () => {
+  let gl: MockGL & WebGLRenderingContext;
+  let renderer: ParticleRenderer;
+  const MAX = 100;
+
+  beforeEach(() => {
+    gl = createMockGL();
+    renderer = new ParticleRenderer(gl, MAX);
+  });
+
+  // ── 构造 ──────────────────────────────────────────────────────
+
+  it('should compile point sprite shader program', () => {
+    expect(gl._programs).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should create attribute buffers (position, size, color, alpha)', () => {
+    // 至少 4 个缓冲区
+    expect(gl._buffers).toBeGreaterThanOrEqual(4);
+  });
+
+  // ── update ────────────────────────────────────────────────────
+
+  it('should read particle data from emitter', () => {
+    const emitter = makeEmitter(20);
+    emitter.emit(5);
+
+    // update 不应抛出
+    renderer.update(emitter);
+  });
+
+  it('should handle zero active particles', () => {
+    const emitter = makeEmitter(10);
+    // 不 emit，activeCount = 0
+
+    renderer.update(emitter);
+    // 不抛出即可
+  });
+
+  it('should upload buffer data via bufferSubData or bufferData', () => {
+    const emitter = makeEmitter(20);
+    emitter.emit(10);
+
+    const before = (gl._calls['bufferSubData'] ?? 0) + (gl._calls['bufferData'] ?? 0);
+    renderer.update(emitter);
+    const after = (gl._calls['bufferSubData'] ?? 0) + (gl._calls['bufferData'] ?? 0);
+
+    // 至少 4 次缓冲区更新（pos, size, color, alpha）
+    expect(after - before).toBeGreaterThanOrEqual(4);
+  });
+
+  // ── render ────────────────────────────────────────────────────
+
+  it('should draw with gl.POINTS mode', () => {
+    const emitter = makeEmitter(20);
+    emitter.emit(5);
+    renderer.update(emitter);
+
+    gl._drawCalls.length = 0;
+    const vp = identity();
+    renderer.render(vp);
+
+    expect(gl._drawCalls).toHaveLength(1);
+    expect(gl._drawCalls[0].type).toBe('drawArrays');
+  });
+
+  it('should draw correct number of particles', () => {
+    const emitter = makeEmitter(20);
+    emitter.emit(7);
+    renderer.update(emitter);
+
+    gl._drawCalls.length = 0;
+    renderer.render(identity());
+
+    expect(gl._drawCalls[0].count).toBe(7);
+  });
+
+  it('should skip draw when no active particles', () => {
+    const emitter = makeEmitter(10);
+    renderer.update(emitter);
+
+    gl._drawCalls.length = 0;
+    renderer.render(identity());
+
+    // 0 个粒子不应产生 draw call
+    expect(gl._drawCalls).toHaveLength(0);
+  });
+
+  it('should enable alpha blending', () => {
+    const emitter = makeEmitter(10);
+    emitter.emit(3);
+    renderer.update(emitter);
+
+    let blendEnabled = false;
+    const origEnable = gl.enable.bind(gl);
+    gl.enable = (cap: number) => {
+      if (cap === gl.BLEND) blendEnabled = true;
+      origEnable(cap);
+    };
+
+    renderer.render(identity());
+
+    expect(blendEnabled).toBe(true);
+  });
+
+  it('should disable depth write during particle rendering', () => {
+    const emitter = makeEmitter(10);
+    emitter.emit(3);
+    renderer.update(emitter);
+
+    let depthMaskArgs: boolean[] = [];
+    const origDepthMask = gl.depthMask.bind(gl);
+    gl.depthMask = (flag: boolean) => {
+      depthMaskArgs.push(flag);
+      origDepthMask(flag);
+    };
+
+    renderer.render(identity());
+
+    // 先禁用深度写入 (false)，渲染后恢复 (true)
+    expect(depthMaskArgs).toContain(false);
+    expect(depthMaskArgs[depthMaskArgs.length - 1]).toBe(true);
+  });
+
+  it('should upload viewProj matrix as uniform', () => {
+    const emitter = makeEmitter(10);
+    emitter.emit(3);
+    renderer.update(emitter);
+
+    const before = gl._calls['uniformMatrix4fv'] ?? 0;
+    renderer.render(identity());
+    const after = gl._calls['uniformMatrix4fv'] ?? 0;
+
+    expect(after).toBeGreaterThan(before);
+  });
+
+  // ── dispose ───────────────────────────────────────────────────
+
+  it('should delete program on dispose', () => {
+    renderer.dispose();
+    expect(gl._calls['deleteProgram']).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should delete buffers on dispose', () => {
+    renderer.dispose();
+    expect(gl._calls['deleteBuffer']).toBeGreaterThanOrEqual(4);
+  });
+});


### PR DESCRIPTION
## 概述

GPU 粒子点精灵渲染器，将 ParticleEmitter 的 CPU 粒子数据通过 WebGL gl.POINTS 渲染。

## 实现细节

- **着色器**：顶点着色器使用 gl_PointSize，片元着色器通过 gl_PointCoord 实现圆形遮罩
- **4 个独立缓冲区**：position(vec3)、size(float)、color(vec3)、alpha(float)
- **Alpha 混合**：SRC_ALPHA / ONE_MINUS_SRC_ALPHA
- **深度写入**：render() 期间 depthMask(false)，结束后恢复 true
- **update()**：调用 4 次 bufferSubData 分别上传各属性
- **空帧跳过**：activeCount=0 时不发起 drawArrays
- **dispose()**：释放 1 个 program + 4 个 buffer

## 测试

```
✓ test/unit/renderer/particle-renderer.test.ts (13/13 tests)
全量: 784 passed | 31 skipped (0 failed)
```

close #106