### PR TITLE
feat: 实现 NavAgent 路径跟随导航代理 (#101)

### DIFF
--- a/src/navigation/nav-agent.ts
+++ b/src/navigation/nav-agent.ts
@@ -7,8 +7,6 @@
  * @see test/unit/navigation/nav-agent.test.ts
  */
 
-export const __STUB__ = true;
-
 import type { Node3D } from '../core/node3d';
 
 export type AgentCallback = () => void;
@@ -19,31 +17,91 @@ export class NavAgent {
   speed: number;
   readonly node: Node3D;
 
+  private _waypoints: Array<[number, number]> = [];
+  private _currentIndex: number = -1;
+  private _arrivedCallback: AgentCallback | null = null;
+  private _waypointCallback: WaypointCallback | null = null;
+
   constructor(node: Node3D, speed: number = 5) {
     this.node = node;
     this.speed = speed;
   }
 
-  get isMoving(): boolean { return false; }
-  get currentWaypointIndex(): number { return -1; }
+  get isMoving(): boolean {
+    return this._currentIndex >= 0 && this._currentIndex < this._waypoints.length;
+  }
+
+  get currentWaypointIndex(): number {
+    return this._currentIndex;
+  }
 
   /**
    * Set a path of world-space waypoints [x, z] for the agent to follow.
    * Replaces any existing path and starts moving immediately.
+   * Empty path triggers onArrived immediately.
    */
-  followPath(_waypoints: Array<[number, number]>): void {}
+  followPath(waypoints: Array<[number, number]>): void {
+    if (waypoints.length === 0) {
+      this._waypoints = [];
+      this._currentIndex = -1;
+      this._arrivedCallback?.();
+      return;
+    }
+    this._waypoints = waypoints;
+    this._currentIndex = 0;
+  }
 
   /**
    * Update agent position. Call once per frame with delta time (seconds).
+   * Only modifies X and Z; Y is left unchanged.
    */
-  update(_dt: number): void {}
+  update(dt: number): void {
+    if (!this.isMoving) return;
+
+    const [wx, wz] = this._waypoints[this._currentIndex];
+    const px = this.node.position[0];
+    const pz = this.node.position[2];
+
+    const dx = wx - px;
+    const dz = wz - pz;
+    const dist = Math.sqrt(dx * dx + dz * dz);
+    const step = this.speed * dt;
+
+    if (dist <= step) {
+      // 精确到达：snap 到 waypoint 位置
+      this.node.position[0] = wx;
+      this.node.position[2] = wz;
+
+      const reachedIndex = this._currentIndex;
+      this._waypointCallback?.(reachedIndex);
+
+      if (this._currentIndex === this._waypoints.length - 1) {
+        // 最终 waypoint 到达
+        this._currentIndex = -1;
+        this._arrivedCallback?.();
+      } else {
+        this._currentIndex++;
+      }
+    } else {
+      // 向当前 waypoint 方向移动
+      this.node.position[0] += (dx / dist) * step;
+      this.node.position[2] += (dz / dist) * step;
+    }
+  }
 
   /** Stop movement and clear the current path. */
-  stop(): void {}
+  stop(): void {
+    this._currentIndex = -1;
+    this._waypoints = [];
+  }
 
   /** Register callback for when the agent reaches the final waypoint. */
-  onArrived(_callback: AgentCallback): void {}
+  onArrived(callback: AgentCallback): void {
+    this._arrivedCallback = callback;
+  }
 
   /** Register callback for each waypoint reached (including the last). */
-  onWaypointReached(_callback: WaypointCallback): void {}
+  onWaypointReached(callback: WaypointCallback): void {
+    this._waypointCallback = callback;
+  }
 }


### PR DESCRIPTION
## 概述

实现 `NavAgent` 路径跟随导航代理，将 waypoint 数组转化为 Node3D 的实时移动。

## 变更

- `src/navigation/nav-agent.ts`：完整实现（移除 stub）

## 功能要点

- **speed** 控制移动速度（默认 5）
- **只修改 X/Z 轴**，Y 轴由外部系统控制
- **精确到达**：当距离 waypoint ≤ dt×speed 时 snap 到精确坐标
- **空路径**：`followPath([])` 立即触发 `onArrived`
- **路径替换**：新 `followPath` 立即替换旧路径
- **回调分离**：`onWaypointReached` 每个 waypoint 触发，`onArrived` 仅最终到达触发

## 测试结果

```
✓ test/unit/navigation/nav-agent.test.ts (13 tests) 4ms
Tests  862 passed | 35 skipped (897)
```

close #101