### PR TITLE
feat: 实现 BoxCollider AABB 盒碰撞体 (#110)

### DIFF
--- a/src/physics/box-collider.ts
+++ b/src/physics/box-collider.ts
@@ -7,4 +7,105 @@
  * @see test/unit/physics/box-collider.test.ts
  */
 
-export const __STUB__ = true;
+import { type Vec3, vec3 } from '../math/vec3';
+import { AABB } from '../math/aabb';
+import { type SphereCollider } from './collision';
+
+export class BoxCollider {
+  center: Vec3;
+  halfExtents: Vec3;
+
+  constructor(halfExtents?: Vec3, center?: Vec3) {
+    this.halfExtents = halfExtents
+      ? vec3(halfExtents[0], halfExtents[1], halfExtents[2])
+      : vec3(0.5, 0.5, 0.5);
+    this.center = center
+      ? vec3(center[0], center[1], center[2])
+      : vec3(0, 0, 0);
+  }
+
+  /** 3 轴 AABB 重叠检测，触碰（边界接触）也算相交。 */
+  intersectsBox(other: BoxCollider): boolean {
+    for (let i = 0; i < 3; i++) {
+      const aMin = this.center[i] - this.halfExtents[i];
+      const aMax = this.center[i] + this.halfExtents[i];
+      const bMin = other.center[i] - other.halfExtents[i];
+      const bMax = other.center[i] + other.halfExtents[i];
+      if (aMax < bMin || bMax < aMin) return false;
+    }
+    return true;
+  }
+
+  /** 求 box 上离球心最近的点，比较距离与半径。 */
+  intersectsSphere(sphere: SphereCollider): boolean {
+    let sqDist = 0;
+    for (let i = 0; i < 3; i++) {
+      const min = this.center[i] - this.halfExtents[i];
+      const max = this.center[i] + this.halfExtents[i];
+      const v = sphere.center[i];
+      if (v < min) sqDist += (min - v) * (min - v);
+      else if (v > max) sqDist += (v - max) * (v - max);
+    }
+    return sqDist <= sphere.radius * sphere.radius;
+  }
+
+  /** SAT 最小穿透深度：正数=重叠，0=恰好接触，负数=分离。 */
+  overlapBox(other: BoxCollider): number {
+    let minOverlap = Infinity;
+    for (let i = 0; i < 3; i++) {
+      const aMin = this.center[i] - this.halfExtents[i];
+      const aMax = this.center[i] + this.halfExtents[i];
+      const bMin = other.center[i] - other.halfExtents[i];
+      const bMax = other.center[i] + other.halfExtents[i];
+      const overlap = Math.min(aMax, bMax) - Math.max(aMin, bMin);
+      if (overlap < minOverlap) minOverlap = overlap;
+    }
+    return minOverlap;
+  }
+
+  /** 重叠深度 = radius - dist(closestPointOnBox, sphereCenter)。 */
+  overlapSphere(sphere: SphereCollider): number {
+    let sqDist = 0;
+    for (let i = 0; i < 3; i++) {
+      const min = this.center[i] - this.halfExtents[i];
+      const max = this.center[i] + this.halfExtents[i];
+      const v = sphere.center[i];
+      if (v < min) sqDist += (min - v) * (min - v);
+      else if (v > max) sqDist += (v - max) * (v - max);
+    }
+    return sphere.radius - Math.sqrt(sqDist);
+  }
+
+  /** 检查点是否在 box 内（边界算含）。 */
+  containsPoint(point: Vec3): boolean {
+    for (let i = 0; i < 3; i++) {
+      const min = this.center[i] - this.halfExtents[i];
+      const max = this.center[i] + this.halfExtents[i];
+      if (point[i] < min || point[i] > max) return false;
+    }
+    return true;
+  }
+
+  /** 返回 AABB(center - halfExtents, center + halfExtents)。 */
+  toAABB(): AABB {
+    return new AABB(
+      vec3(
+        this.center[0] - this.halfExtents[0],
+        this.center[1] - this.halfExtents[1],
+        this.center[2] - this.halfExtents[2],
+      ),
+      vec3(
+        this.center[0] + this.halfExtents[0],
+        this.center[1] + this.halfExtents[1],
+        this.center[2] + this.halfExtents[2],
+      ),
+    );
+  }
+
+  clone(): BoxCollider {
+    return new BoxCollider(
+      vec3(this.halfExtents[0], this.halfExtents[1], this.halfExtents[2]),
+      vec3(this.center[0], this.center[1], this.center[2]),
+    );
+  }
+}

--- a/src/physics/collision.ts
+++ b/src/physics/collision.ts
@@ -3,7 +3,7 @@
  * 支持碰撞事件回调（enter/stay/exit）和空间查询。
  * @see test/unit/physics/collision.test.ts
  */
-import { type Vec3, vec3, add, sub, scale, length, normalize } from '../math/vec3';
+import { type Vec3, vec3, add, sub, scale, length, normalize, dot } from '../math/vec3';
 import { type AABB } from '../math/aabb';
 import { type Node3D } from '../core/node3d';
 
@@ -102,6 +102,12 @@ function pairKey(a: Node3D, b: Node3D): string {
   const idA = (a as any).__collisionId as number;
   const idB = (b as any).__collisionId as number;
   return idA < idB ? `${idA}-${idB}` : `${idB}-${idA}`;
+}
+
+export interface CollisionRaycastHit {
+  node: Node3D;
+  distance: number;
+  point: Vec3;
 }
 
 /* ---------- CollisionWorld ---------- */
@@ -253,6 +259,69 @@ export class CollisionWorld {
 
   get size(): number {
     return this._bodies.size;
+  }
+
+  /**
+   * 光线投射，返回按距离排序的命中列表。
+   * 支持 SphereCollider（解析法）和 BoxCollider（slab 法）。
+   */
+  raycast(
+    origin: Vec3,
+    direction: Vec3,
+    maxDistance = Infinity,
+    layerMask = 0xFFFFFFFF,
+  ): CollisionRaycastHit[] {
+    const hits: CollisionRaycastHit[] = [];
+
+    for (const [node, entry] of this._bodies) {
+      if ((entry.layer & layerMask) === 0) continue;
+      const shape = entry.shape;
+
+      if (shape instanceof SphereCollider) {
+        // 解析法：求解 |origin + t*dir - center|² = r²
+        const center = add(node.position, shape.center);
+        const oc = sub(origin, center);
+        const a = dot(direction, direction);
+        const b = 2 * dot(oc, direction);
+        const c = dot(oc, oc) - shape.radius * shape.radius;
+        const disc = b * b - 4 * a * c;
+        if (disc < 0) continue;
+        const sqrtD = Math.sqrt(disc);
+        const t1 = (-b - sqrtD) / (2 * a);
+        const t2 = (-b + sqrtD) / (2 * a);
+        const t = t1 >= 0 ? t1 : t2;
+        if (t < 0 || t > maxDistance) continue;
+        hits.push({ node, distance: t, point: add(origin, scale(direction, t)) });
+      } else {
+        // Slab 法：ray-AABB 交叉（duck type BoxCollider）
+        const box = shape as { center: Vec3; halfExtents: Vec3 };
+        let tEnter = -Infinity;
+        let tExit = Infinity;
+        let miss = false;
+        for (let i = 0; i < 3; i++) {
+          const mn = node.position[i] + box.center[i] - box.halfExtents[i];
+          const mx = node.position[i] + box.center[i] + box.halfExtents[i];
+          const d = direction[i];
+          if (Math.abs(d) < 1e-10) {
+            if (origin[i] < mn || origin[i] > mx) { miss = true; break; }
+          } else {
+            const t1 = (mn - origin[i]) / d;
+            const t2 = (mx - origin[i]) / d;
+            const tLo = Math.min(t1, t2);
+            const tHi = Math.max(t1, t2);
+            if (tLo > tEnter) tEnter = tLo;
+            if (tHi < tExit) tExit = tHi;
+          }
+        }
+        if (miss || tEnter > tExit || tExit < 0) continue;
+        const t = tEnter >= 0 ? tEnter : tExit;
+        if (t > maxDistance) continue;
+        hits.push({ node, distance: t, point: add(origin, scale(direction, t)) });
+      }
+    }
+
+    hits.sort((a, b) => a.distance - b.distance);
+    return hits;
   }
 
   private _fireEvent(


### PR DESCRIPTION
## 概述

实现 `BoxCollider` — 轴对齐包围盒（AABB）碰撞体。

## 实现内容

- `BoxCollider` 类（`src/physics/box-collider.ts`）
  - `intersectsBox()` — 3 轴 AABB 重叠检测，边界接触算相交
  - `intersectsSphere()` — 最近点法 box-sphere 相交检测
  - `overlapBox()` — SAT 最小穿透深度（正=重叠，0=接触，负=分离）
  - `overlapSphere()` — radius - dist 重叠深度
  - `containsPoint()` — 点包含检测（含边界）
  - `toAABB()` — 转换为 AABB(center-halfExtents, center+halfExtents)
  - `clone()` — 独立深拷贝
- `collision.ts` 新增 `CollisionRaycastHit` 接口和 `raycast()` 方法

## 测试结果

`test/unit/physics/box-collider.test.ts` 全部 22 个断言通过，单元测试 897 passed。

close #110