### PR TITLE
feat: 实现 PositionalAudio 3D 定位音频源 (#117)

### DIFF
--- a/src/audio/audio-listener.ts
+++ b/src/audio/audio-listener.ts
@@ -1,6 +1,58 @@
 /**
- * AudioListener — 3D 空间音频监听器（stub）。
- * AI must implement to make test/unit/audio/audio-listener.test.ts pass.
+ * AudioListener — 3D 空间音频监听器。
+ * 继承 Node3D，通过 Web Audio API 的 AudioListener 同步空间位置和朝向。
  */
 
-export const __STUB__ = true;
+import { Node3D } from '../core/node3d';
+
+export class AudioListener extends Node3D {
+  readonly context: AudioContext;
+  readonly gain: GainNode;
+
+  constructor(context?: AudioContext) {
+    super('AudioListener');
+    this.context = context ?? new AudioContext();
+    this.gain = this.context.createGain();
+    this.gain.gain.value = 1;
+    this.gain.connect(this.context.destination as unknown as AudioNode);
+  }
+
+  setMasterVolume(value: number): void {
+    this.gain.gain.value = Math.max(0, Math.min(1, value));
+  }
+
+  getMasterVolume(): number {
+    return this.gain.gain.value;
+  }
+
+  /** 返回音频源连接的输入节点（gain node）。 */
+  getInput(): GainNode {
+    return this.gain;
+  }
+
+  /**
+   * 同步 Web Audio API listener 的位置和朝向到节点世界矩阵。
+   * 使用 setPosition/setOrientation（WeChat 兼容）。
+   * 每帧调用一次。
+   */
+  updateMatrixWorld(): void {
+    const m = this.worldMatrix;
+    // 列优先：位置在列 3，索引 [12],[13],[14]
+    const x = m[12];
+    const y = m[13];
+    const z = m[14];
+    // 前向方向：-Z 轴（列 2 取负），索引 [8],[9],[10]
+    const fx = -m[8];
+    const fy = -m[9];
+    const fz = -m[10];
+
+    const nativeListener = (this.context as any).listener;
+    nativeListener.setPosition(x, y, z);
+    nativeListener.setOrientation(fx, fy, fz, 0, 1, 0);
+  }
+
+  dispose(): void {
+    this.gain.disconnect();
+    this.context.close();
+  }
+}

--- a/src/audio/positional-audio.ts
+++ b/src/audio/positional-audio.ts
@@ -1,6 +1,141 @@
 /**
- * PositionalAudio — 3D 定位音频源（stub）。
- * AI must implement to make test/unit/audio/positional-audio.test.ts pass.
+ * PositionalAudio — 3D 定位音频源。
+ * 继承 Node3D，通过 Web Audio PannerNode 实现 3D 空间定位声音。
+ * 音频链路：source → gainNode → panner → listener.getInput()
  */
 
-export const __STUB__ = true;
+import { Node3D } from '../core/node3d';
+import type { AudioListener } from './audio-listener';
+
+export type DistanceModel = 'linear' | 'inverse' | 'exponential';
+
+export interface PositionalAudioOptions {
+  refDistance?: number;
+  maxDistance?: number;
+  rolloffFactor?: number;
+  distanceModel?: DistanceModel;
+}
+
+export interface AudioClip {
+  name: string;
+  buffer: AudioBuffer;
+  duration: number;
+}
+
+export class PositionalAudio extends Node3D {
+  readonly panner: PannerNode;
+  readonly context: AudioContext;
+
+  private _gainNode: GainNode;
+  private _source: AudioBufferSourceNode | null = null;
+  private _playing = false;
+  private _loop = false;
+
+  constructor(listener: AudioListener, options?: PositionalAudioOptions) {
+    super('PositionalAudio');
+
+    this.context = listener.context;
+    this._gainNode = this.context.createGain();
+    this.panner = this.context.createPanner();
+
+    // 配置 PannerNode 属性
+    (this.panner as any).panningModel = 'HRTF';
+    this.panner.distanceModel = (options?.distanceModel ?? 'inverse') as DistanceModelType;
+    this.panner.refDistance = options?.refDistance ?? 1;
+    this.panner.maxDistance = options?.maxDistance ?? 10000;
+    this.panner.rolloffFactor = options?.rolloffFactor ?? 1;
+
+    // 连接音频链路：gainNode → panner → listener.getInput()
+    this._gainNode.connect(this.panner as unknown as AudioNode);
+    this.panner.connect(listener.getInput() as unknown as AudioNode);
+  }
+
+  play(clip: AudioClip): void {
+    if (this._playing) {
+      this.stop();
+    }
+
+    this._source = this.context.createBufferSource();
+    this._source.buffer = clip.buffer;
+    this._source.loop = this._loop;
+    this._source.connect(this._gainNode as unknown as AudioNode);
+
+    this._source.onended = () => {
+      this._playing = false;
+    };
+
+    this._source.start();
+    this._playing = true;
+  }
+
+  stop(): void {
+    if (this._source) {
+      this._source.onended = null;
+      try {
+        this._source.stop();
+      } catch {
+        // 忽略已停止的源节点抛出的错误
+      }
+      this._source = null;
+    }
+    this._playing = false;
+  }
+
+  setVolume(value: number): void {
+    this._gainNode.gain.value = value;
+  }
+
+  getVolume(): number {
+    return this._gainNode.gain.value;
+  }
+
+  setLoop(value: boolean): void {
+    this._loop = value;
+    if (this._source) {
+      this._source.loop = value;
+    }
+  }
+
+  getLoop(): boolean {
+    return this._loop;
+  }
+
+  isPlaying(): boolean {
+    return this._playing;
+  }
+
+  setRefDistance(value: number): void {
+    this.panner.refDistance = value;
+  }
+
+  setMaxDistance(value: number): void {
+    this.panner.maxDistance = value;
+  }
+
+  setRolloffFactor(value: number): void {
+    this.panner.rolloffFactor = value;
+  }
+
+  setDistanceModel(model: DistanceModel): void {
+    this.panner.distanceModel = model as DistanceModelType;
+  }
+
+  /**
+   * 同步 panner 位置到节点世界坐标。每帧调用一次。
+   * 使用 setPosition（WeChat 兼容）。
+   */
+  updateMatrixWorld(): void {
+    const m = this.worldMatrix;
+    // 列优先：位置在列 3，索引 [12],[13],[14]
+    const x = m[12];
+    const y = m[13];
+    const z = m[14];
+    (this.panner as any).setPosition(x, y, z);
+  }
+
+  dispose(): void {
+    this.stop();
+    this._gainNode.disconnect();
+    this.panner.disconnect();
+  }
+}


### PR DESCRIPTION
## 概述

实现 Phase 15 3D 空间音频 KR2：`PositionalAudio` — 基于 Web Audio PannerNode 的 3D 定位音频源。

顺带实现了依赖模块 `AudioListener`（KR1）的 stub 实现。

## 变更

### `src/audio/audio-listener.ts`
- 继承 `Node3D`，管理 `AudioContext` 和主增益节点
- `getInput()` 返回 GainNode 供音频源连接
- `updateMatrixWorld()` 从世界矩阵提取位置和朝向，同步到 Web Audio API listener
- `setMasterVolume()` 带 [0,1] 范围钳位
- `dispose()` 断开连接并关闭 AudioContext

### `src/audio/positional-audio.ts`
- 继承 `Node3D`，PannerNode 使用 HRTF 模式
- 音频链路：`source → gainNode → panner → listener.getInput()`
- `updateMatrixWorld()` 使用 `setPosition()` 同步空间位置（WeChat 兼容）
- 支持 `play()` / `stop()` 播放控制，`source.onended` 自动清除播放状态
- 支持音量、循环、refDistance、maxDistance、rolloffFactor、distanceModel 配置

## 测试

- `test/unit/audio/audio-listener.test.ts` — 11 tests ✅
- `test/unit/audio/positional-audio.test.ts` — 14 tests ✅
- 全量单元测试 887 passed, 0 failed ✅

close #117