### PR TITLE
feat: 实现 EventEmitter 通用事件发射器 (#119)

### DIFF
--- a/src/gameplay/event-emitter.ts
+++ b/src/gameplay/event-emitter.ts
@@ -1,0 +1,87 @@
+/**
+ * EventEmitter — 通用事件发射器
+ * Lightweight typed event emitter for game objects.
+ */
+
+/** Event map: event name → callback signature */
+export type EventMap = Record<string, (...args: any[]) => void>;
+
+/**
+ * Generic typed event emitter.
+ * Usage:
+ *   type MyEvents = { hit: (damage: number) => void; die: () => void };
+ *   const emitter = new EventEmitter<MyEvents>();
+ *   emitter.on('hit', (d) => console.log(d));
+ *   emitter.emit('hit', 10);
+ */
+export class EventEmitter<T extends EventMap = EventMap> {
+  private _listeners: Map<string, Array<(...args: any[]) => void>> = new Map();
+  // 映射 once 原始监听器 -> wrapper，用于 off 时能移除 wrapper
+  private _onceWrappers: Map<(...args: any[]) => void, (...args: any[]) => void> = new Map();
+
+  on<K extends keyof T & string>(event: K, listener: T[K]): this {
+    if (!this._listeners.has(event)) {
+      this._listeners.set(event, []);
+    }
+    this._listeners.get(event)!.push(listener);
+    return this;
+  }
+
+  once<K extends keyof T & string>(event: K, listener: T[K]): this {
+    const wrapper = (...args: Parameters<T[K]>) => {
+      this.off(event, listener);
+      listener(...args);
+    };
+    // 记录 wrapper 对应的原始 listener，以便 off(listener) 时能找到 wrapper
+    this._onceWrappers.set(listener, wrapper);
+    this.on(event, wrapper as T[K]);
+    return this;
+  }
+
+  off<K extends keyof T & string>(event: K, listener: T[K]): this {
+    const listeners = this._listeners.get(event);
+    if (!listeners) return this;
+
+    // 检查是否是 once 注册的（通过原始 listener 找 wrapper）
+    const wrapper = this._onceWrappers.get(listener);
+    const target = wrapper ?? listener;
+
+    const idx = listeners.indexOf(target);
+    if (idx !== -1) {
+      listeners.splice(idx, 1);
+    }
+
+    // 清理 once wrapper 映射
+    if (wrapper) {
+      this._onceWrappers.delete(listener);
+    }
+
+    return this;
+  }
+
+  emit<K extends keyof T & string>(event: K, ...args: Parameters<T[K]>): boolean {
+    const listeners = this._listeners.get(event);
+    if (!listeners || listeners.length === 0) return false;
+
+    // snapshot 迭代：拷贝一份，避免遍历中 off 导致跳过
+    const snapshot = listeners.slice();
+    for (const listener of snapshot) {
+      listener(...args);
+    }
+    return true;
+  }
+
+  removeAllListeners(event?: keyof T & string): this {
+    if (event === undefined) {
+      this._listeners.clear();
+      this._onceWrappers.clear();
+    } else {
+      this._listeners.delete(event);
+    }
+    return this;
+  }
+
+  listenerCount(event: keyof T & string): number {
+    return this._listeners.get(event)?.length ?? 0;
+  }
+}

--- a/test/unit/gameplay/event-emitter.test.ts
+++ b/test/unit/gameplay/event-emitter.test.ts
@@ -1,0 +1,203 @@
+/**
+ * EventEmitter — pre-written tests (Architect)
+ * Validates: on/off/once/emit/removeAllListeners/listenerCount
+ */
+import { describe, it, expect, vi } from 'vitest';
+import * as mod from '../../../src/gameplay/event-emitter';
+
+const isStub = '__STUB__' in mod && (mod as any).__STUB__ === true;
+const describeImpl = isStub ? describe.skip : describe;
+
+type TestEvents = {
+  hit: (damage: number) => void;
+  die: () => void;
+  collect: (item: string, count: number) => void;
+};
+
+describeImpl('EventEmitter', () => {
+  /* ---------- on / emit basics ---------- */
+
+  it('should call listener when event is emitted', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const spy = vi.fn();
+    emitter.on('hit', spy);
+    emitter.emit('hit', 10);
+    expect(spy).toHaveBeenCalledWith(10);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass multiple arguments to listener', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const spy = vi.fn();
+    emitter.on('collect', spy);
+    emitter.emit('collect', 'coin', 5);
+    expect(spy).toHaveBeenCalledWith('coin', 5);
+  });
+
+  it('should support multiple listeners on same event', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const spy1 = vi.fn();
+    const spy2 = vi.fn();
+    emitter.on('die', spy1);
+    emitter.on('die', spy2);
+    emitter.emit('die');
+    expect(spy1).toHaveBeenCalledTimes(1);
+    expect(spy2).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call listeners in registration order', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const order: number[] = [];
+    emitter.on('die', () => order.push(1));
+    emitter.on('die', () => order.push(2));
+    emitter.on('die', () => order.push(3));
+    emitter.emit('die');
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('emit should return true when listeners exist', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    emitter.on('die', () => {});
+    expect(emitter.emit('die')).toBe(true);
+  });
+
+  it('emit should return false when no listeners exist', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    expect(emitter.emit('die')).toBe(false);
+  });
+
+  /* ---------- off ---------- */
+
+  it('should remove a specific listener with off', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const spy = vi.fn();
+    emitter.on('hit', spy);
+    emitter.off('hit', spy);
+    emitter.emit('hit', 5);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('off should only remove the specified listener', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const spy1 = vi.fn();
+    const spy2 = vi.fn();
+    emitter.on('hit', spy1);
+    emitter.on('hit', spy2);
+    emitter.off('hit', spy1);
+    emitter.emit('hit', 5);
+    expect(spy1).not.toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalledWith(5);
+  });
+
+  it('off should be safe when listener was never registered', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const spy = vi.fn();
+    // should not throw
+    emitter.off('hit', spy);
+  });
+
+  /* ---------- once ---------- */
+
+  it('should fire once listener only once', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const spy = vi.fn();
+    emitter.once('hit', spy);
+    emitter.emit('hit', 10);
+    emitter.emit('hit', 20);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(10);
+  });
+
+  it('once listener should be removable before firing', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const spy = vi.fn();
+    emitter.once('die', spy);
+    emitter.off('die', spy);
+    emitter.emit('die');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  /* ---------- removeAllListeners ---------- */
+
+  it('should remove all listeners for a specific event', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const spy1 = vi.fn();
+    const spy2 = vi.fn();
+    emitter.on('hit', spy1);
+    emitter.on('hit', spy2);
+    emitter.removeAllListeners('hit');
+    emitter.emit('hit', 5);
+    expect(spy1).not.toHaveBeenCalled();
+    expect(spy2).not.toHaveBeenCalled();
+  });
+
+  it('should remove all listeners for all events when no arg', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const hitSpy = vi.fn();
+    const dieSpy = vi.fn();
+    emitter.on('hit', hitSpy);
+    emitter.on('die', dieSpy);
+    emitter.removeAllListeners();
+    emitter.emit('hit', 5);
+    emitter.emit('die');
+    expect(hitSpy).not.toHaveBeenCalled();
+    expect(dieSpy).not.toHaveBeenCalled();
+  });
+
+  /* ---------- listenerCount ---------- */
+
+  it('should return correct listener count', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    expect(emitter.listenerCount('hit')).toBe(0);
+    const spy = vi.fn();
+    emitter.on('hit', spy);
+    expect(emitter.listenerCount('hit')).toBe(1);
+    emitter.on('hit', vi.fn());
+    expect(emitter.listenerCount('hit')).toBe(2);
+    emitter.off('hit', spy);
+    expect(emitter.listenerCount('hit')).toBe(1);
+  });
+
+  /* ---------- chaining ---------- */
+
+  it('on/off/once should return this for chaining', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const spy = vi.fn();
+    const result = emitter.on('hit', spy).once('die', vi.fn()).off('hit', spy);
+    expect(result).toBe(emitter);
+  });
+
+  /* ---------- edge cases ---------- */
+
+  it('should handle zero-argument events', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const spy = vi.fn();
+    emitter.on('die', spy);
+    emitter.emit('die');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not interfere between different event types', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const hitSpy = vi.fn();
+    const dieSpy = vi.fn();
+    emitter.on('hit', hitSpy);
+    emitter.on('die', dieSpy);
+    emitter.emit('hit', 10);
+    expect(hitSpy).toHaveBeenCalledTimes(1);
+    expect(dieSpy).not.toHaveBeenCalled();
+  });
+
+  it('listener removing itself during emit should not skip next listener', () => {
+    const emitter = new mod.EventEmitter<TestEvents>();
+    const spy2 = vi.fn();
+    const selfRemover = () => {
+      emitter.off('die', selfRemover);
+    };
+    emitter.on('die', selfRemover);
+    emitter.on('die', spy2);
+    emitter.emit('die');
+    // spy2 must still be called
+    expect(spy2).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 概述

实现通用的 typed EventEmitter，作为游戏对象间松耦合通信的基础设施。

## 变更内容

- 新增 `src/gameplay/event-emitter.ts` — 完整实现 typed EventEmitter
- 新增 `test/unit/gameplay/event-emitter.test.ts` — 19 个测试覆盖全 API

## 实现要点

- `on` 注册持久监听器，`once` 注册一次性监听器（触发后自动移除）
- `off` 移除指定监听器（引用相等），支持移除 `once` 注册的监听器
- `emit` 按注册顺序同步调用，使用 snapshot 迭代避免遍历中 off 导致跳过监听器
- 返回 `true`（有监听器）或 `false`（无监听器）
- 所有方法支持链式调用（返回 `this`）

## 测试结果

```
✓ test/unit/gameplay/event-emitter.test.ts (18 tests) 5ms
全量单元测试：940 passed | 11 skipped，0 失败
```

close #119