### PR TITLE
feat: 实现 SceneManager 场景生命周期管理器 (#130)

### DIFF
--- a/src/core/scene-manager.ts
+++ b/src/core/scene-manager.ts
@@ -4,9 +4,7 @@
  * @see test/unit/core/scene-manager.test.ts
  */
 
-export const __STUB__ = true;
-
-import type { Node3D } from './node3d';
+import { Node3D } from './node3d';
 
 export interface GameScene {
   name: string;
@@ -16,11 +14,49 @@ export interface GameScene {
 }
 
 export class SceneManager {
-  constructor() { throw new Error('STUB'); }
-  register(_scene: GameScene): void { throw new Error('STUB'); }
-  loadScene(_name: string): void { throw new Error('STUB'); }
-  get activeScene(): GameScene | null { throw new Error('STUB'); }
-  get activeRoot(): Node3D | null { throw new Error('STUB'); }
-  update(_dt: number): void { throw new Error('STUB'); }
-  unloadCurrent(): void { throw new Error('STUB'); }
+  private _scenes: Map<string, GameScene> = new Map();
+  private _activeScene: GameScene | null = null;
+  private _activeRoot: Node3D | null = null;
+
+  register(scene: GameScene): void {
+    if (this._scenes.has(scene.name)) {
+      throw new Error(`场景已注册: ${scene.name}`);
+    }
+    this._scenes.set(scene.name, scene);
+  }
+
+  loadScene(name: string): void {
+    const scene = this._scenes.get(name);
+    if (!scene) {
+      throw new Error(`场景未注册: ${name}`);
+    }
+    // 先卸载当前场景
+    if (this._activeScene) {
+      this._activeScene.cleanup?.();
+    }
+    // 创建新 root 并初始化
+    const root = new Node3D();
+    this._activeScene = scene;
+    this._activeRoot = root;
+    scene.init(root);
+  }
+
+  get activeScene(): GameScene | null {
+    return this._activeScene;
+  }
+
+  get activeRoot(): Node3D | null {
+    return this._activeRoot;
+  }
+
+  update(dt: number): void {
+    this._activeScene?.update?.(dt);
+  }
+
+  unloadCurrent(): void {
+    if (!this._activeScene) return;
+    this._activeScene.cleanup?.();
+    this._activeScene = null;
+    this._activeRoot = null;
+  }
 }


### PR DESCRIPTION
## 概述

实现 `SceneManager` 场景生命周期管理器，支持注册、加载、卸载和切换游戏场景。

## 变更

- 移除 `src/core/scene-manager.ts` 中的 `__STUB__` 标记
- 实现完整的 `SceneManager` 类：
  - `register(scene)` — 注册场景（重复名称抛异常）
  - `loadScene(name)` — 卸载当前场景 → 创建新 Node3D root → 调用 init(root)
  - `activeScene` / `activeRoot` — 返回当前活跃场景和根节点
  - `update(dt)` — 委托给活跃场景的 update
  - `unloadCurrent()` — 调用 cleanup 并重置状态

## 测试结果

`test/unit/core/scene-manager.test.ts` 全部 15 个测试通过。

close #130