### PR TITLE
feat: 实现 StateMachine 泛型有限状态机 (#129)

### DIFF
--- a/src/gameplay/state-machine.ts
+++ b/src/gameplay/state-machine.ts
@@ -4,8 +4,6 @@
  * @see test/unit/gameplay/state-machine.test.ts
  */
 
-export const __STUB__ = true;
-
 export interface StateConfig<S extends string> {
   onEnter?: () => void;
   onExit?: () => void;
@@ -19,14 +17,59 @@ export interface TransitionRule<S extends string> {
 }
 
 export class StateMachine<S extends string> {
-  constructor(_states: Record<S, StateConfig<S>>, _initial: S) {
-    throw new Error('STUB');
+  private _states: Record<S, StateConfig<S>>;
+  private _current: S;
+  private _previous: S | null = null;
+  private _rules: TransitionRule<S>[] = [];
+
+  constructor(states: Record<S, StateConfig<S>>, initial: S) {
+    this._states = states;
+    this._current = initial;
+    states[initial].onEnter?.();
   }
-  get current(): S { throw new Error('STUB'); }
-  get previous(): S | null { throw new Error('STUB'); }
-  transition(_to: S): boolean { throw new Error('STUB'); }
-  canTransition(_to: S): boolean { throw new Error('STUB'); }
-  update(_dt: number): void { throw new Error('STUB'); }
-  addTransition(_from: S, _to: S, _guard?: () => boolean): void { throw new Error('STUB'); }
-  isIn(_state: S): boolean { throw new Error('STUB'); }
+
+  get current(): S {
+    return this._current;
+  }
+
+  get previous(): S | null {
+    return this._previous;
+  }
+
+  canTransition(to: S): boolean {
+    if (to === this._current) return false;
+    // 检查当前状态是否有已注册的转换规则
+    const rulesFromCurrent = this._rules.filter(r => r.from === this._current);
+    if (rulesFromCurrent.length === 0) {
+      // 无规则：自由切换
+      return true;
+    }
+    // 有规则：只允许已注册且 guard 通过的转换
+    const rule = rulesFromCurrent.find(r => r.to === to);
+    if (!rule) return false;
+    if (rule.guard && !rule.guard()) return false;
+    return true;
+  }
+
+  transition(to: S): boolean {
+    if (!this.canTransition(to)) return false;
+    const from = this._current;
+    this._states[from].onExit?.();
+    this._previous = from;
+    this._current = to;
+    this._states[to].onEnter?.();
+    return true;
+  }
+
+  update(dt: number): void {
+    this._states[this._current].onUpdate?.(dt);
+  }
+
+  addTransition(from: S, to: S, guard?: () => boolean): void {
+    this._rules.push({ from, to, guard });
+  }
+
+  isIn(state: S): boolean {
+    return this._current === state;
+  }
 }


### PR DESCRIPTION
## 概述

实现泛型有限状态机（FSM），为游戏实体和游戏流程提供状态管理。

## 变更内容

- 实现 `src/gameplay/state-machine.ts`，移除 `__STUB__` 标记
- 支持构造时调用初始状态 `onEnter`
- 状态切换时先调用旧状态 `onExit`，再调用新状态 `onEnter`
- 无 `addTransition` 规则时：所有状态间自由切换
- 有 `addTransition` 规则时：按当前状态注册的规则限制，guard 返回 false 则拒绝
- `update(dt)` 调用当前状态的 `onUpdate(dt)`
- `isIn(state)` 判断是否在指定状态

## 测试结果

- `test/unit/gameplay/state-machine.test.ts` 全部 16 个测试通过
- 全量回归：967 passed, 0 failed（视觉测试 12/12 全部通过）

close #129