### PR TITLE
feat: 实现 UICanvas + UIElement + UIRect 屏幕空间 2D 覆盖层

### DIFF
--- a/src/ui/ui-canvas.ts
+++ b/src/ui/ui-canvas.ts
@@ -6,33 +6,70 @@
  * @see test/unit/ui/ui-canvas.test.ts
  */
 
-export const __STUB__ = true;
-
-import type { Mat4 } from '../math/mat4';
-import type { UIElement } from './ui-element';
+import { ortho, type Mat4 } from '../math/mat4';
+import { UIElement } from './ui-element';
 
 export class UICanvas {
   width: number;
   height: number;
   children: UIElement[];
+  private _projection: Mat4;
 
-  constructor(_width: number, _height: number) {
-    throw new Error('STUB');
+  constructor(width: number, height: number) {
+    this.width = width;
+    this.height = height;
+    this.children = [];
+    this._projection = ortho(0, width, height, 0, -1, 1);
   }
 
   /** 正交投影矩阵：ortho(0, width, height, 0, -1, 1)，Y 轴向下 */
-  get projectionMatrix(): Mat4 { throw new Error('STUB'); }
+  get projectionMatrix(): Mat4 {
+    return this._projection;
+  }
 
-  add(_child: UIElement): void { throw new Error('STUB'); }
-  remove(_child: UIElement): void { throw new Error('STUB'); }
-  clear(): void { throw new Error('STUB'); }
+  add(child: UIElement): void {
+    this.children.push(child);
+  }
+
+  remove(child: UIElement): void {
+    const idx = this.children.indexOf(child);
+    if (idx !== -1) {
+      this.children.splice(idx, 1);
+    }
+  }
+
+  clear(): void {
+    this.children.length = 0;
+  }
 
   /** 按名称查找元素（深度优先搜索） */
-  findByName(_name: string): UIElement | null { throw new Error('STUB'); }
+  findByName(name: string): UIElement | null {
+    const search = (els: UIElement[]): UIElement | null => {
+      for (const el of els) {
+        if (el.name === name) return el;
+        const found = search(el.children);
+        if (found) return found;
+      }
+      return null;
+    };
+    return search(this.children);
+  }
 
-  /** 命中测试：返回坐标处最前方的 interactive 元素，无命中返回 null */
-  hitTest(_x: number, _y: number): UIElement | null { throw new Error('STUB'); }
+  /** 命中测试：返回坐标处最前方（最后添加）的 interactive+visible 元素，无命中返回 null */
+  hitTest(x: number, y: number): UIElement | null {
+    for (let i = this.children.length - 1; i >= 0; i--) {
+      const el = this.children[i];
+      if (el.interactive && el.visible && el.containsPoint(x, y)) {
+        return el;
+      }
+    }
+    return null;
+  }
 
   /** 更新视口尺寸 */
-  resize(_width: number, _height: number): void { throw new Error('STUB'); }
+  resize(width: number, height: number): void {
+    this.width = width;
+    this.height = height;
+    this._projection = ortho(0, width, height, 0, -1, 1);
+  }
 }

--- a/src/ui/ui-element.ts
+++ b/src/ui/ui-element.ts
@@ -5,8 +5,6 @@
  * @see test/unit/ui/ui-canvas.test.ts (UICanvas 测试中覆盖 UIElement 行为)
  */
 
-export const __STUB__ = true;
-
 import type { Vec3 } from '../math/vec3';
 
 export type Anchor =
@@ -49,16 +47,62 @@ export class UIElement {
   onPointerDown: ((e: { x: number; y: number }) => void) | null;
   onPointerUp: ((e: { x: number; y: number }) => void) | null;
 
-  constructor(_options?: UIElementOptions) {
-    throw new Error('STUB');
+  constructor(options?: UIElementOptions) {
+    this.x = options?.x ?? 0;
+    this.y = options?.y ?? 0;
+    this.width = options?.width ?? 0;
+    this.height = options?.height ?? 0;
+    this.anchor = options?.anchor ?? 'topLeft';
+    this.visible = options?.visible ?? true;
+    this.opacity = options?.opacity ?? 1;
+    this.interactive = options?.interactive ?? false;
+    this.name = options?.name ?? '';
+    this.parent = null;
+    this.children = [];
+    this.onPointerDown = null;
+    this.onPointerUp = null;
   }
 
-  add(_child: UIElement): void { throw new Error('STUB'); }
-  remove(_child: UIElement): void { throw new Error('STUB'); }
+  add(child: UIElement): void {
+    child.parent = this;
+    this.children.push(child);
+  }
+
+  remove(child: UIElement): void {
+    const idx = this.children.indexOf(child);
+    if (idx !== -1) {
+      this.children.splice(idx, 1);
+      child.parent = null;
+    }
+  }
 
   /** 计算屏幕空间包围框（考虑锚点偏移） */
-  getScreenBounds(): ScreenBounds { throw new Error('STUB'); }
+  getScreenBounds(): ScreenBounds {
+    const w = this.width;
+    const h = this.height;
+    let ox = 0;
+    let oy = 0;
+
+    // 水平偏移
+    if (this.anchor === 'topCenter' || this.anchor === 'center' || this.anchor === 'bottomCenter') {
+      ox = -w / 2;
+    } else if (this.anchor === 'topRight' || this.anchor === 'centerRight' || this.anchor === 'bottomRight') {
+      ox = -w;
+    }
+
+    // 垂直偏移
+    if (this.anchor === 'centerLeft' || this.anchor === 'center' || this.anchor === 'centerRight') {
+      oy = -h / 2;
+    } else if (this.anchor === 'bottomLeft' || this.anchor === 'bottomCenter' || this.anchor === 'bottomRight') {
+      oy = -h;
+    }
+
+    return { x: this.x + ox, y: this.y + oy, width: w, height: h };
+  }
 
   /** 判断屏幕坐标是否在此元素内 */
-  containsPoint(_px: number, _py: number): boolean { throw new Error('STUB'); }
+  containsPoint(px: number, py: number): boolean {
+    const b = this.getScreenBounds();
+    return px >= b.x && px < b.x + b.width && py >= b.y && py < b.y + b.height;
+  }
 }

--- a/src/ui/ui-rect.ts
+++ b/src/ui/ui-rect.ts
@@ -4,10 +4,8 @@
  * @see test/unit/ui/ui-rect.test.ts
  */
 
-export const __STUB__ = true;
-
 import { UIElement, type UIElementOptions } from './ui-element';
-import type { Vec3 } from '../math/vec3';
+import { vec3, type Vec3 } from '../math/vec3';
 import type { Texture } from '../renderer/texture';
 
 export interface UIRectOptions extends UIElementOptions {
@@ -19,9 +17,10 @@ export class UIRect extends UIElement {
   color: Vec3;
   texture: Texture | null;
 
-  constructor(_options?: UIRectOptions) {
-    super(_options);
-    throw new Error('STUB');
+  constructor(options?: UIRectOptions) {
+    super({ width: 100, height: 100, ...options });
+    this.color = options?.color ?? vec3(1, 1, 1);
+    this.texture = options?.texture ?? null;
   }
 
   /**
@@ -29,5 +28,23 @@ export class UIRect extends UIElement {
    * 每顶点 4 floats: x, y, u, v。
    * 返回 Float32Array(24)。
    */
-  getVertices(): Float32Array { throw new Error('STUB'); }
+  getVertices(): Float32Array {
+    const b = this.getScreenBounds();
+    const x0 = b.x;
+    const y0 = b.y;
+    const x1 = b.x + b.width;
+    const y1 = b.y + b.height;
+
+    // 2 三角形，逆时针（webgl 前面）
+    // 三角形1: 左上、左下、右上
+    // 三角形2: 左下、右下、右上
+    return new Float32Array([
+      x0, y0, 0, 0,  // 左上
+      x0, y1, 0, 1,  // 左下
+      x1, y0, 1, 0,  // 右上
+      x0, y1, 0, 1,  // 左下
+      x1, y1, 1, 1,  // 右下
+      x1, y0, 1, 0,  // 右上
+    ]);
+  }
 }


### PR DESCRIPTION
## 概述

实现 Issue #135 要求的屏幕空间 2D UI overlay 系统，为 HUD（分数、血量、菜单、按钮）提供基础。

## 实现内容

- **UIElement** (`src/ui/ui-element.ts`)：UI 元素基类，支持 9 种锚点（topLeft/center/bottomRight 等）、子元素树管理、`getScreenBounds()` 考虑锚点偏移、`containsPoint()` 点击判断、onPointerDown/onPointerUp 回调
- **UICanvas** (`src/ui/ui-canvas.ts`)：容器，`ortho(0, width, height, 0, -1, 1)` Y 轴向下正交投影矩阵、`hitTest()` 从后往前遍历返回最前方 interactive+visible 元素、`findByName()` 深度优先搜索、`resize()` 更新视口
- **UIRect** (`src/ui/ui-rect.ts`)：继承 UIElement，支持 Vec3 颜色和 Texture，`getVertices()` 生成 2 三角形 6 顶点 Float32Array(24)，每顶点 (x, y, u, v)

## 测试结果

- `test/unit/ui/ui-canvas.test.ts`：13/13 通过
- `test/unit/ui/ui-rect.test.ts`：12/12 通过
- 全量单元测试：1043 通过，0 失败

close #135