### PR TITLE
feat: 实现 UIText 屏幕空间文字 UI 元素 (#136)

### DIFF
--- a/src/ui/ui-text.ts
+++ b/src/ui/ui-text.ts
@@ -5,11 +5,9 @@
  * @see test/unit/ui/ui-text.test.ts
  */
 
-export const __STUB__ = true;
-
 import { UIElement, type UIElementOptions } from './ui-element';
 import type { BitmapFontData } from '../renderer/bitmap-font';
-import type { Vec3 } from '../math/vec3';
+import { vec3, type Vec3 } from '../math/vec3';
 
 export type TextAlign = 'left' | 'center' | 'right';
 
@@ -28,11 +26,30 @@ export class UIText extends UIElement {
   color: Vec3;
   align: TextAlign;
 
-  constructor(_options: UITextOptions) {
-    super(_options);
-    throw new Error('STUB');
+  constructor(options: UITextOptions) {
+    super(options);
+    this.font = options.font;
+    this.text = options.text ?? '';
+    this.fontSize = options.fontSize ?? options.font.lineHeight;
+    this.color = options.color ?? vec3(1, 1, 1);
+    this.align = options.align ?? 'left';
   }
 
   /** 计算当前文本的像素宽度（基于 font metrics × fontSize 缩放） */
-  measureWidth(): number { throw new Error('STUB'); }
+  measureWidth(): number {
+    let cursor = 0;
+    let lastVisibleEndX = 0;
+
+    for (const ch of this.text) {
+      const charData = this.font.chars.get(ch.charCodeAt(0));
+      if (!charData) continue;
+      if (charData.width > 0) {
+        lastVisibleEndX = cursor + charData.xoffset + charData.width;
+      }
+      cursor += charData.xadvance;
+    }
+
+    const scale = this.fontSize / this.font.lineHeight;
+    return lastVisibleEndX * scale;
+  }
 }


### PR DESCRIPTION
## 概述

实现 `UIText` 屏幕空间文字 UI 元素，继承 `UIElement`，使用 `BitmapFontData` 在像素坐标系中渲染文字。

## 变更

- `src/ui/ui-text.ts`：移除 `__STUB__`，实现完整的 `UIText` 类
  - 构造函数接受 `font`、`text`、`fontSize`、`color`、`align` 参数
  - `fontSize` 默认 = `font.lineHeight`
  - `color` 默认白色 `vec3(1,1,1)`
  - `align` 默认 `'left'`
  - `measureWidth()` 遍历字符累计 xadvance，最后一个可见字符用 xoffset+width，乘以 fontSize/lineHeight 缩放

## 测试结果

- 单元测试：1054 passed（含 UIText 11 tests）
- 视觉回归：12/12 passed

close #136