### PR TITLE
feat: 实现 UIButton 可交互按钮 UI 元素

### DIFF
--- a/src/ui/ui-button.ts
+++ b/src/ui/ui-button.ts
@@ -5,9 +5,7 @@
  * @see test/unit/ui/ui-button.test.ts
  */
 
-export const __STUB__ = true;
-
-import type { Vec3 } from '../math/vec3';
+import { vec3, type Vec3 } from '../math/vec3';
 import type { BitmapFontData } from '../renderer/bitmap-font';
 import { UIElement, type UIElementOptions } from './ui-element';
 
@@ -35,13 +33,51 @@ export class UIButton extends UIElement {
   onClick: (() => void) | null;
   font: BitmapFontData | null;
 
-  constructor(_options?: UIButtonOptions) {
-    super();
-    throw new Error('STUB');
+  constructor(options?: UIButtonOptions) {
+    super({ interactive: true, ...options });
+    this.label = options?.label ?? '';
+    this.fontSize = options?.fontSize ?? 16;
+    this.textColor = options?.textColor ?? vec3(1, 1, 1);
+    this.normalColor = options?.normalColor ?? vec3(0.4, 0.4, 0.4);
+    this.pressedColor = options?.pressedColor ?? vec3(0.2, 0.2, 0.2);
+    this.disabledColor = options?.disabledColor ?? vec3(0.6, 0.6, 0.6);
+    this.disabled = options?.disabled ?? false;
+    this.isPressed = false;
+    this.onClick = options?.onClick ?? null;
+    this.font = options?.font ?? null;
   }
 
-  handlePointerDown(_x: number, _y: number): void { throw new Error('STUB'); }
-  handlePointerUp(_x: number, _y: number): void { throw new Error('STUB'); }
-  getCurrentColor(): Vec3 { throw new Error('STUB'); }
-  getVertices(): Float32Array { throw new Error('STUB'); }
+  handlePointerDown(_x: number, _y: number): void {
+    if (this.disabled) return;
+    this.isPressed = true;
+  }
+
+  handlePointerUp(_x: number, _y: number): void {
+    if (this.disabled) return;
+    this.isPressed = false;
+    this.onClick?.();
+  }
+
+  getCurrentColor(): Vec3 {
+    if (this.disabled) return this.disabledColor;
+    if (this.isPressed) return this.pressedColor;
+    return this.normalColor;
+  }
+
+  getVertices(): Float32Array {
+    const b = this.getScreenBounds();
+    const x0 = b.x;
+    const y0 = b.y;
+    const x1 = b.x + b.width;
+    const y1 = b.y + b.height;
+
+    return new Float32Array([
+      x0, y0, 0, 0,  // 左上
+      x0, y1, 0, 1,  // 左下
+      x1, y0, 1, 0,  // 右上
+      x0, y1, 0, 1,  // 左下
+      x1, y1, 1, 1,  // 右下
+      x1, y0, 1, 0,  // 右上
+    ]);
+  }
 }


### PR DESCRIPTION
## 概述

实现 `UIButton` 类 — 可交互按钮 UI 元素，支持 normal/pressed/disabled 三种视觉状态、标签文字和 onClick 回调。

## 变更

- `src/ui/ui-button.ts`：移除 `__STUB__` 标记，完整实现 UIButton

## 关键实现

- 构造函数通过 `{ interactive: true, ...options }` 默认启用交互
- `handlePointerDown` / `handlePointerUp`：disabled 时忽略，否则设置 isPressed 并触发回调
- `getCurrentColor()`：disabled → pressedColor → normalColor 优先级
- `getVertices()`：6 顶点 × 4 floats，与 UIRect 相同的三角形布局

## 测试

- `test/unit/ui/ui-button.test.ts` 16 个测试全部通过 ✅
- `pnpm run test:all` 全量通过（单元 1059 + 视觉 12）✅

close #140