### PR TITLE
feat: 实现 UIFlexContainer 自动布局容器 (#142)

### DIFF
--- a/src/ui/ui-flex-container.ts
+++ b/src/ui/ui-flex-container.ts
@@ -5,8 +5,6 @@
  * @see test/unit/ui/ui-flex-container.test.ts
  */
 
-export const __STUB__ = true;
-
 import { UIElement, type UIElementOptions } from './ui-element';
 
 export interface UIFlexContainerOptions extends UIElementOptions {
@@ -20,12 +18,35 @@ export class UIFlexContainer extends UIElement {
   gap: number;
   padding: number;
 
-  constructor(_options?: UIFlexContainerOptions) {
-    super();
-    throw new Error('STUB');
+  constructor(options?: UIFlexContainerOptions) {
+    super(options);
+    this.direction = options?.direction ?? 'horizontal';
+    this.gap = options?.gap ?? 0;
+    this.padding = options?.padding ?? 0;
   }
 
-  layout(): void { throw new Error('STUB'); }
-  override add(_child: UIElement): void { throw new Error('STUB'); }
-  override remove(_child: UIElement): void { throw new Error('STUB'); }
+  layout(): void {
+    let cursor = this.padding;
+    for (const child of this.children) {
+      if (this.direction === 'horizontal') {
+        child.x = this.x + cursor;
+        child.y = this.y + this.padding;
+        cursor += child.width + this.gap;
+      } else {
+        child.x = this.x + this.padding;
+        child.y = this.y + cursor;
+        cursor += child.height + this.gap;
+      }
+    }
+  }
+
+  override add(child: UIElement): void {
+    super.add(child);
+    this.layout();
+  }
+
+  override remove(child: UIElement): void {
+    super.remove(child);
+    this.layout();
+  }
 }


### PR DESCRIPTION
## 概述

实现 `UIFlexContainer` — 自动布局容器 UI 元素，将子元素按水平或垂直方向自动排列。

## 变更内容

- 实现 `UIFlexContainer` 类，继承 `UIElement`
- 支持 `direction: 'horizontal' | 'vertical'` 排列方向（默认 horizontal）
- 支持 `gap` 元素间距（默认 0）
- 支持 `padding` 内边距（默认 0）
- `add()` / `remove()` 后自动调用 `layout()` 重新计算子元素位置

## 测试结果

- `test/unit/ui/ui-flex-container.test.ts` — **13/13 通过**
- 全量单元测试 — **1081 通过，0 失败**

close #142