### PR TITLE
feat: 实现 TextureLoader 图片数据解码 (#147)

### DIFF
--- a/src/loader/texture-loader.ts
+++ b/src/loader/texture-loader.ts
@@ -4,19 +4,26 @@
  * @see test/unit/loader/texture-loader.test.ts
  */
 
-export const __STUB__ = true;
-
 import { Texture } from '../renderer/texture';
 
 export class TextureLoader {
   /** 从 ImageData（canvas getImageData 结果）同步创建 Texture */
-  static fromImageData(_imageData: { width: number; height: number; data: Uint8ClampedArray }): Texture {
-    throw new Error('STUB: TextureLoader.fromImageData not implemented');
+  static fromImageData(imageData: { width: number; height: number; data: Uint8ClampedArray }): Texture {
+    // 拷贝为 Uint8Array，不共享引用
+    const data = new Uint8Array(imageData.data);
+    return Texture.fromData(imageData.width, imageData.height, data);
   }
 
   /** 从原始 RGBA 字节创建 Texture，带维度验证 */
-  static fromRGBA(_width: number, _height: number, _data: Uint8Array): Texture {
-    throw new Error('STUB: TextureLoader.fromRGBA not implemented');
+  static fromRGBA(width: number, height: number, data: Uint8Array): Texture {
+    if (width <= 0 || height <= 0) {
+      throw new Error(`TextureLoader.fromRGBA: 宽高必须大于 0，得到 ${width}x${height}`);
+    }
+    const expected = width * height * 4;
+    if (data.length !== expected) {
+      throw new Error(`TextureLoader.fromRGBA: 数据长度不匹配，期望 ${expected}，实际 ${data.length}`);
+    }
+    return Texture.fromData(width, height, data);
   }
 
   /**
@@ -24,9 +31,27 @@ export class TextureLoader {
    * 使用 createImageBitmap（浏览器）或传入的 decode 函数。
    */
   static async fromArrayBuffer(
-    _data: ArrayBuffer,
-    _decode?: (ab: ArrayBuffer) => Promise<{ width: number; height: number; data: Uint8ClampedArray }>,
+    data: ArrayBuffer,
+    decode?: (ab: ArrayBuffer) => Promise<{ width: number; height: number; data: Uint8ClampedArray }>,
   ): Promise<Texture> {
-    throw new Error('STUB: TextureLoader.fromArrayBuffer not implemented');
+    if (decode) {
+      const imageData = await decode(data);
+      return TextureLoader.fromImageData(imageData);
+    }
+
+    // 浏览器环境：使用 createImageBitmap + OffscreenCanvas
+    if (typeof createImageBitmap !== 'undefined' && typeof OffscreenCanvas !== 'undefined') {
+      const blob = new Blob([data]);
+      const bitmap = await createImageBitmap(blob);
+      const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+      const ctx = canvas.getContext('2d') as OffscreenCanvasRenderingContext2D;
+      ctx.drawImage(bitmap, 0, 0);
+      const imageData = ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+      return TextureLoader.fromImageData(imageData);
+    }
+
+    throw new Error(
+      'TextureLoader.fromArrayBuffer: 无法解码图片，请提供 decode 函数或在支持 createImageBitmap 的环境中运行',
+    );
   }
 }


### PR DESCRIPTION
## Summary

- 实现 `TextureLoader.fromRGBA`：验证 `width > 0`, `height > 0`, `data.length === width * height * 4`
- 实现 `TextureLoader.fromImageData`：拷贝 `Uint8ClampedArray` 为 `Uint8Array`（不共享引用）
- 实现 `TextureLoader.fromArrayBuffer`：优先用 `decode` 回调，回退到 `createImageBitmap + OffscreenCanvas`，否则抛错

## Test plan

- [x] `npx vitest run test/unit/loader/texture-loader.test.ts` — 9/9 通过
- [x] `pnpm run test` — 1118 tests passed

close #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)