### PR TITLE
feat: 实现 UIImage 屏幕空间纹理图片 UI 元素 (#141)

### DIFF
--- a/src/ui/ui-image.ts
+++ b/src/ui/ui-image.ts
@@ -5,11 +5,9 @@
  * @see test/unit/ui/ui-image.test.ts
  */
 
-export const __STUB__ = true;
-
-import type { Vec3 } from '../math/vec3';
 import type { Texture } from '../renderer/texture';
 import { UIElement, type UIElementOptions } from './ui-element';
+import { vec3, type Vec3 } from '../math/vec3';
 
 export interface UVRect {
   u0: number;
@@ -31,10 +29,34 @@ export class UIImage extends UIElement {
   uvRect: UVRect;
   preserveAspect: boolean;
 
-  constructor(_options: UIImageOptions) {
-    super();
-    throw new Error('STUB');
+  constructor(options: UIImageOptions) {
+    super(options);
+    this.texture = options.texture;
+    this.tint = options.tint ?? vec3(1, 1, 1);
+    this.uvRect = options.uvRect ?? { u0: 0, v0: 0, u1: 1, v1: 1 };
+    this.preserveAspect = options.preserveAspect ?? false;
   }
 
-  getVertices(): Float32Array { throw new Error('STUB'); }
+  /**
+   * 生成四边形顶点数据（2 三角形 = 6 顶点）。
+   * 每顶点 4 floats: x, y, u, v。UV 坐标使用 uvRect 区域。
+   * 返回 Float32Array(24)。
+   */
+  getVertices(): Float32Array {
+    const b = this.getScreenBounds();
+    const x0 = b.x;
+    const y0 = b.y;
+    const x1 = b.x + b.width;
+    const y1 = b.y + b.height;
+    const { u0, v0, u1, v1 } = this.uvRect;
+
+    return new Float32Array([
+      x0, y0, u0, v0,  // 左上
+      x0, y1, u0, v1,  // 左下
+      x1, y0, u1, v0,  // 右上
+      x0, y1, u0, v1,  // 左下
+      x1, y1, u1, v1,  // 右下
+      x1, y0, u1, v0,  // 右上
+    ]);
+  }
 }


### PR DESCRIPTION
## 概述

实现 `UIImage` 类 — 屏幕空间纹理图片 UI 元素。

## 实现内容

- `UIImage` 继承 `UIElement`，支持在像素坐标系中显示纹理
- `texture`：必需参数，指定显示的纹理
- `tint`：着色叠加，默认白色 `vec3(1,1,1)`
- `uvRect`：UV 区域裁剪，默认 `{u0:0, v0:0, u1:1, v1:1}`（全纹理），支持 sprite atlas 子区域提取
- `preserveAspect`：是否保持宽高比，默认 `false`
- `getVertices()`：返回 `Float32Array(24)`，6 顶点 × 4 floats (x, y, u, v)，UV 使用 `uvRect` 坐标

## 测试结果

`test/unit/ui/ui-image.test.ts` 12 个测试全部通过。

close #141