### PR TITLE
feat: PhongMaterial 漫反射纹理贴图 (#158)

### DIFF
--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -31,6 +31,8 @@ interface PhongLocations {
   uDiffuse: WebGLUniformLocation | null;
   uSpecular: WebGLUniformLocation | null;
   uShininess: WebGLUniformLocation | null;
+  uMap: WebGLUniformLocation | null;
+  uHasMap: WebGLUniformLocation | null;
 }
 
 interface CompiledProgram {
@@ -278,6 +280,8 @@ export class WebGLRenderer {
         uDiffuse:      gl.getUniformLocation(program, 'u_diffuse'),
         uSpecular:     gl.getUniformLocation(program, 'u_specular'),
         uShininess:    gl.getUniformLocation(program, 'u_shininess'),
+        uMap:          gl.getUniformLocation(program, 'u_map'),
+        uHasMap:       gl.getUniformLocation(program, 'u_hasMap'),
       };
     }
 
@@ -496,6 +500,23 @@ export class WebGLRenderer {
       if (phong.uDiffuse)   gl.uniform3fv(phong.uDiffuse, mat.diffuse);
       if (phong.uSpecular)  gl.uniform3fv(phong.uSpecular, mat.specular);
       if (phong.uShininess) gl.uniform1f(phong.uShininess, mat.shininess);
+
+      // 漫反射纹理贴图
+      if (mat.map != null) {
+        const webglTex = this._getOrUploadTexture(mat.map);
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, webglTex);
+        if (phong.uMap)    gl.uniform1i(phong.uMap, 0);
+        if (phong.uHasMap) gl.uniform1f(phong.uHasMap, 1.0);
+        // 绑定 UV attribute
+        if (compiled.aUv >= 0 && uploaded.uvBuffer) {
+          gl.bindBuffer(gl.ARRAY_BUFFER, uploaded.uvBuffer);
+          gl.enableVertexAttribArray(compiled.aUv);
+          gl.vertexAttribPointer(compiled.aUv, 2, gl.FLOAT, false, 0, 0);
+        }
+      } else {
+        if (phong.uHasMap) gl.uniform1f(phong.uHasMap, 0.0);
+      }
     }
 
     // Draw


### PR DESCRIPTION
## 概述

为 PhongMaterial 增加漫反射纹理贴图（`map` 属性）支持，实现带纹理的受光照物体渲染。

## 变更内容

- `PhongMaterialOptions` 新增 `map?: Texture`
- `PhongMaterial` 新增 `map: Texture | null`（默认 null）
- 顶点着色器：新增 `attribute vec2 a_uv` 和 `varying vec2 v_uv`
- 片元着色器：新增 `u_map sampler2D`、`u_hasMap float` uniform，通过 `texture2D(u_map, v_uv).rgb * u_diffuse` 计算漫反射颜色
- 渲染器：自动检测 `mat.map`，绑定 UV buffer 和纹理 unit，设置相关 uniform

## 测试

`test/unit/renderer/phong-diffuse-map.test.ts` 全部通过（12 tests）

close #158