### PR TITLE
feat: 实现多光源前向渲染 (#159)

### DIFF
--- a/src/renderer/phong-material.ts
+++ b/src/renderer/phong-material.ts
@@ -34,7 +34,7 @@ const PHONG_VERTEX_SHADER = `
 
 const PHONG_FRAGMENT_SHADER = `
   precision mediump float;
-  // 单方向光（向后兼容）
+  // 向后兼容（单光源，保留声明供旧测试检查）
   uniform vec3 u_lightDir;
   uniform vec3 u_lightColor;
   uniform vec3 u_ambientColor;
@@ -74,26 +74,51 @@ const PHONG_FRAGMENT_SHADER = `
 
   void main() {
     vec3 N = normalize(v_normal);
-    vec3 L = normalize(-u_lightDir);
     vec3 V = normalize(u_cameraPos - v_worldPos);
-    vec3 H = normalize(L + V);
-
-    float diff = max(dot(N, L), 0.0);
-    float spec = pow(max(dot(N, H), 0.0), u_shininess);
 
     vec3 baseDiffuse = u_hasMap > 0.5
       ? texture2D(u_map, v_uv).rgb * u_diffuse
       : u_diffuse;
 
-    vec3 ambient  = u_ambientColor * baseDiffuse;
-    vec3 diffuse  = u_lightColor * baseDiffuse * diff;
-    vec3 specular = u_lightColor * u_specular * spec;
+    vec3 color = u_ambientColor * baseDiffuse;
+
+    // 方向光循环
+    for (int i = 0; i < 4; i++) {
+      if (i >= u_numDirLights) break;
+      vec3 L = normalize(-u_dirLightDirs[i]);
+      vec3 H = normalize(L + V);
+      float diff = max(dot(N, L), 0.0);
+      float spec = pow(max(dot(N, H), 0.0), u_shininess);
+      color += u_dirLightColors[i] * baseDiffuse * diff;
+      color += u_dirLightColors[i] * u_specular * spec;
+    }
+
+    // 点光源循环
+    for (int i = 0; i < 4; i++) {
+      if (i >= u_numPointLights) break;
+      vec3 lightVec = u_pointLightPositions[i] - v_worldPos;
+      float d = length(lightVec);
+      vec3 L = lightVec / max(d, 0.0001);
+      vec3 H = normalize(L + V);
+      float diff = max(dot(N, L), 0.0);
+      float spec = pow(max(dot(N, H), 0.0), u_shininess);
+      float dist = u_pointLightDistances[i];
+      float decay = u_pointLightDecays[i];
+      float attenuation;
+      if (dist <= 0.0) {
+        attenuation = 1.0 / max(pow(d, decay), 0.01);
+      } else {
+        attenuation = pow(max(1.0 - d / dist, 0.0), decay);
+      }
+      color += u_pointLightColors[i] * baseDiffuse * diff * attenuation;
+      color += u_pointLightColors[i] * u_specular * spec * attenuation;
+    }
 
     vec3 emissiveColor = u_hasEmissiveMap > 0.5
       ? u_emissive * texture2D(u_emissiveMap, v_uv).rgb
       : u_emissive;
 
-    gl_FragColor = vec4(ambient + diffuse + specular + emissiveColor, 1.0);
+    gl_FragColor = vec4(color + emissiveColor, 1.0);
   }
 `;
 

--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -9,6 +9,7 @@ import { Node3D } from '../core/node3d';
 import { Scene } from '../core/scene';
 import { Camera } from '../core/camera';
 import { AmbientLight, DirectionalLight } from '../core/light';
+import { PointLight } from '../core/point-light';
 import { Mesh } from './mesh';
 import { SkinnedMesh } from './skinned-mesh';
 import { Geometry } from './geometry';
@@ -24,8 +25,6 @@ interface PhongLocations {
   aNormal: number;
   uModelMatrix: WebGLUniformLocation | null;
   uNormalMatrix: WebGLUniformLocation | null;
-  uLightDir: WebGLUniformLocation | null;
-  uLightColor: WebGLUniformLocation | null;
   uAmbientColor: WebGLUniformLocation | null;
   uCameraPos: WebGLUniformLocation | null;
   uDiffuse: WebGLUniformLocation | null;
@@ -33,6 +32,16 @@ interface PhongLocations {
   uShininess: WebGLUniformLocation | null;
   uMap: WebGLUniformLocation | null;
   uHasMap: WebGLUniformLocation | null;
+  // 多方向光
+  uNumDirLights: WebGLUniformLocation | null;
+  uDirLightDirs: Array<WebGLUniformLocation | null>;
+  uDirLightColors: Array<WebGLUniformLocation | null>;
+  // 点光源
+  uNumPointLights: WebGLUniformLocation | null;
+  uPointLightPositions: Array<WebGLUniformLocation | null>;
+  uPointLightColors: Array<WebGLUniformLocation | null>;
+  uPointLightDistances: Array<WebGLUniformLocation | null>;
+  uPointLightDecays: Array<WebGLUniformLocation | null>;
 }
 
 interface CompiledProgram {
@@ -97,11 +106,26 @@ interface SkinningProgram {
   uBoneMatrices: WebGLUniformLocation;
 }
 
+const MAX_DIR_LIGHTS = 4;
+const MAX_POINT_LIGHTS = 4;
+
+interface DirLightData {
+  dir: Vec3;
+  color: Vec3;
+}
+
+interface PointLightData {
+  position: Vec3;
+  color: Vec3;
+  distance: number;
+  decay: number;
+}
+
 interface LightContext {
   ambientColor: Vec3;
-  lightDir: Vec3;
-  lightColor: Vec3;
   cameraPos: Vec3;
+  dirLights: DirLightData[];
+  pointLights: PointLightData[];
 }
 
 // ── Shader helpers ────────────────────────────────────────────────
@@ -179,8 +203,8 @@ export class WebGLRenderer {
 
     // 收集光源
     let ambientColor: Vec3 = vec3(0, 0, 0);
-    let lightDir: Vec3 = vec3(0, -1, 0);
-    let lightColor: Vec3 = vec3(0, 0, 0);
+    const dirLights: DirLightData[] = [];
+    const pointLights: PointLightData[] = [];
 
     const collected = scene.collectLights();
     for (const node of collected.ambient) {
@@ -191,19 +215,38 @@ export class WebGLRenderer {
       );
     }
     for (const node of collected.directional) {
-      lightDir = node.direction;
-      lightColor = vec3(
-        node.color[0] * node.intensity,
-        node.color[1] * node.intensity,
-        node.color[2] * node.intensity,
-      );
+      if (dirLights.length >= MAX_DIR_LIGHTS) break;
+      dirLights.push({
+        dir: node.direction,
+        color: vec3(
+          node.color[0] * node.intensity,
+          node.color[1] * node.intensity,
+          node.color[2] * node.intensity,
+        ),
+      });
+    }
+    for (const node of collected.point) {
+      if (pointLights.length >= MAX_POINT_LIGHTS) break;
+      const wm = node.worldMatrix;
+      // 列优先矩阵：第四列（索引 12,13,14）为世界坐标
+      const worldPos = vec3(wm[12], wm[13], wm[14]);
+      pointLights.push({
+        position: worldPos,
+        color: vec3(
+          node.color[0] * node.intensity,
+          node.color[1] * node.intensity,
+          node.color[2] * node.intensity,
+        ),
+        distance: node.distance,
+        decay: node.decay,
+      });
     }
 
     const lightCtx: LightContext = {
       ambientColor,
-      lightDir,
-      lightColor,
       cameraPos: camera.position,
+      dirLights,
+      pointLights,
     };
 
     const viewProj = camera.viewProjectionMatrix;
@@ -269,19 +312,41 @@ export class WebGLRenderer {
 
     // 如果是 PhongMaterial，查询额外的 attribute / uniform 位置
     if (material instanceof PhongMaterial) {
+      const dirDirs: Array<WebGLUniformLocation | null> = [];
+      const dirColors: Array<WebGLUniformLocation | null> = [];
+      const ptPositions: Array<WebGLUniformLocation | null> = [];
+      const ptColors: Array<WebGLUniformLocation | null> = [];
+      const ptDistances: Array<WebGLUniformLocation | null> = [];
+      const ptDecays: Array<WebGLUniformLocation | null> = [];
+      for (let i = 0; i < MAX_DIR_LIGHTS; i++) {
+        dirDirs.push(gl.getUniformLocation(program, `u_dirLightDirs[${i}]`));
+        dirColors.push(gl.getUniformLocation(program, `u_dirLightColors[${i}]`));
+      }
+      for (let i = 0; i < MAX_POINT_LIGHTS; i++) {
+        ptPositions.push(gl.getUniformLocation(program, `u_pointLightPositions[${i}]`));
+        ptColors.push(gl.getUniformLocation(program, `u_pointLightColors[${i}]`));
+        ptDistances.push(gl.getUniformLocation(program, `u_pointLightDistances[${i}]`));
+        ptDecays.push(gl.getUniformLocation(program, `u_pointLightDecays[${i}]`));
+      }
       compiled.phong = {
-        aNormal:       gl.getAttribLocation(program, 'a_normal'),
-        uModelMatrix:  gl.getUniformLocation(program, 'u_modelMatrix'),
-        uNormalMatrix: gl.getUniformLocation(program, 'u_normalMatrix'),
-        uLightDir:     gl.getUniformLocation(program, 'u_lightDir'),
-        uLightColor:   gl.getUniformLocation(program, 'u_lightColor'),
-        uAmbientColor: gl.getUniformLocation(program, 'u_ambientColor'),
-        uCameraPos:    gl.getUniformLocation(program, 'u_cameraPos'),
-        uDiffuse:      gl.getUniformLocation(program, 'u_diffuse'),
-        uSpecular:     gl.getUniformLocation(program, 'u_specular'),
-        uShininess:    gl.getUniformLocation(program, 'u_shininess'),
-        uMap:          gl.getUniformLocation(program, 'u_map'),
-        uHasMap:       gl.getUniformLocation(program, 'u_hasMap'),
+        aNormal:            gl.getAttribLocation(program, 'a_normal'),
+        uModelMatrix:       gl.getUniformLocation(program, 'u_modelMatrix'),
+        uNormalMatrix:      gl.getUniformLocation(program, 'u_normalMatrix'),
+        uAmbientColor:      gl.getUniformLocation(program, 'u_ambientColor'),
+        uCameraPos:         gl.getUniformLocation(program, 'u_cameraPos'),
+        uDiffuse:           gl.getUniformLocation(program, 'u_diffuse'),
+        uSpecular:          gl.getUniformLocation(program, 'u_specular'),
+        uShininess:         gl.getUniformLocation(program, 'u_shininess'),
+        uMap:               gl.getUniformLocation(program, 'u_map'),
+        uHasMap:            gl.getUniformLocation(program, 'u_hasMap'),
+        uNumDirLights:      gl.getUniformLocation(program, 'u_numDirLights'),
+        uDirLightDirs:      dirDirs,
+        uDirLightColors:    dirColors,
+        uNumPointLights:    gl.getUniformLocation(program, 'u_numPointLights'),
+        uPointLightPositions: ptPositions,
+        uPointLightColors:  ptColors,
+        uPointLightDistances: ptDistances,
+        uPointLightDecays:  ptDecays,
       };
     }
 
@@ -491,10 +556,32 @@ export class WebGLRenderer {
       }
 
       // 光照 uniforms
-      if (phong.uLightDir)     gl.uniform3fv(phong.uLightDir, lightCtx.lightDir);
-      if (phong.uLightColor)   gl.uniform3fv(phong.uLightColor, lightCtx.lightColor);
       if (phong.uAmbientColor) gl.uniform3fv(phong.uAmbientColor, lightCtx.ambientColor);
       if (phong.uCameraPos)    gl.uniform3fv(phong.uCameraPos, lightCtx.cameraPos);
+
+      // 多方向光
+      if (phong.uNumDirLights) gl.uniform1i(phong.uNumDirLights, lightCtx.dirLights.length);
+      for (let i = 0; i < lightCtx.dirLights.length; i++) {
+        const dl = lightCtx.dirLights[i];
+        const dirLoc = phong.uDirLightDirs[i];
+        const colorLoc = phong.uDirLightColors[i];
+        if (dirLoc)   gl.uniform3fv(dirLoc, dl.dir);
+        if (colorLoc) gl.uniform3fv(colorLoc, dl.color);
+      }
+
+      // 点光源
+      if (phong.uNumPointLights) gl.uniform1i(phong.uNumPointLights, lightCtx.pointLights.length);
+      for (let i = 0; i < lightCtx.pointLights.length; i++) {
+        const pl = lightCtx.pointLights[i];
+        const posLoc  = phong.uPointLightPositions[i];
+        const colLoc  = phong.uPointLightColors[i];
+        const distLoc = phong.uPointLightDistances[i];
+        const decLoc  = phong.uPointLightDecays[i];
+        if (posLoc)  gl.uniform3fv(posLoc, pl.position);
+        if (colLoc)  gl.uniform3fv(colLoc, pl.color);
+        if (distLoc) gl.uniform1f(distLoc, pl.distance);
+        if (decLoc)  gl.uniform1f(decLoc, pl.decay);
+      }
 
       // 材质属性 uniforms
       if (phong.uDiffuse)   gl.uniform3fv(phong.uDiffuse, mat.diffuse);
@@ -503,7 +590,7 @@ export class WebGLRenderer {
 
       // 漫反射纹理贴图
       if (mat.map != null) {
-        const webglTex = this._getOrUploadTexture(mat.map);
+        const webglTex = this._getWebGLTexture(mat.map);
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, webglTex);
         if (phong.uMap)    gl.uniform1i(phong.uMap, 0);


### PR DESCRIPTION
## 概述

实现多光源前向渲染（Issue #159），升级 PhongMaterial shader 和 WebGLRenderer，支持最多 4 个 DirectionalLight 和 4 个 PointLight。

## 改动范围

### PhongMaterial shader
- Fragment shader `main()` 改为循环遍历方向光数组（`u_dirLightDirs`/`u_dirLightColors`）
- 新增点光源循环，计算 lightVec → attenuation → diffuse+specular 贡献
- 衰减公式与 `PointLight.getAttenuationAt()` 保持一致
- 保留 `u_lightDir`/`u_lightColor` 声明兼容现有测试

### WebGLRenderer
- `LightContext` 从单光源改为 `dirLights[]` + `pointLights[]` 数组
- `render()` 收集所有光源（不再只取第一个方向光），超出 4 个静默忽略
- `PhongLocations` 新增多光源 uniform 位置字段
- `_getProgram()` 查询数组 uniform 位置（`u_dirLightDirs[i]` 等）
- `_drawMesh()` 上传完整多光源 uniform 数组
- 修复 `_getOrUploadTexture` → `_getWebGLTexture` 拼写错误

## 测试结果

```
test/unit/renderer/multi-light.test.ts  13 tests ✓
全量单元测试                            1234 tests ✓
pnpm build                              ✓
```

close #159