### PR TITLE
feat: 实现 Geometry.computeTangents() 切线帧计算

### DIFF
--- a/src/renderer/geometry.ts
+++ b/src/renderer/geometry.ts
@@ -69,8 +69,106 @@ export class Geometry {
   computeTangents(): void {
     if (!this.normals) throw new Error('computeTangents requires normals');
     if (!this.uvs) throw new Error('computeTangents requires uvs');
-    // TODO: implement tangent computation (Phase 23 KR1)
-    throw new Error('computeTangents not yet implemented');
+
+    const positions = this.positions;
+    const normals = this.normals;
+    const uvs = this.uvs;
+    const vertexCount = positions.length / 3;
+
+    // 每顶点切线/副切线累加器
+    const tan1 = new Float32Array(vertexCount * 3);
+    const tan2 = new Float32Array(vertexCount * 3);
+
+    // 构建三角形迭代器
+    const triangleCount = this.indices
+      ? this.indices.length / 3
+      : vertexCount / 3;
+    const getIndex = this.indices
+      ? (i: number) => this.indices![i]
+      : (i: number) => i;
+
+    for (let t = 0; t < triangleCount; t++) {
+      const i0 = getIndex(t * 3 + 0);
+      const i1 = getIndex(t * 3 + 1);
+      const i2 = getIndex(t * 3 + 2);
+
+      const p0x = positions[i0 * 3], p0y = positions[i0 * 3 + 1], p0z = positions[i0 * 3 + 2];
+      const p1x = positions[i1 * 3], p1y = positions[i1 * 3 + 1], p1z = positions[i1 * 3 + 2];
+      const p2x = positions[i2 * 3], p2y = positions[i2 * 3 + 1], p2z = positions[i2 * 3 + 2];
+
+      const uv0u = uvs[i0 * 2], uv0v = uvs[i0 * 2 + 1];
+      const uv1u = uvs[i1 * 2], uv1v = uvs[i1 * 2 + 1];
+      const uv2u = uvs[i2 * 2], uv2v = uvs[i2 * 2 + 1];
+
+      const e1x = p1x - p0x, e1y = p1y - p0y, e1z = p1z - p0z;
+      const e2x = p2x - p0x, e2y = p2y - p0y, e2z = p2z - p0z;
+
+      const duv1u = uv1u - uv0u, duv1v = uv1v - uv0v;
+      const duv2u = uv2u - uv0u, duv2v = uv2v - uv0v;
+
+      const det = duv1u * duv2v - duv2u * duv1v;
+      // 跳过退化三角形（UV 面积近零）
+      if (Math.abs(det) < 1e-8) continue;
+
+      const f = 1.0 / det;
+
+      const tx = f * (e1x * duv2v - e2x * duv1v);
+      const ty = f * (e1y * duv2v - e2y * duv1v);
+      const tz = f * (e1z * duv2v - e2z * duv1v);
+
+      const bx = f * (e2x * duv1u - e1x * duv2u);
+      const by = f * (e2y * duv1u - e1y * duv2u);
+      const bz = f * (e2z * duv1u - e1z * duv2u);
+
+      for (const vi of [i0, i1, i2]) {
+        tan1[vi * 3 + 0] += tx;
+        tan1[vi * 3 + 1] += ty;
+        tan1[vi * 3 + 2] += tz;
+        tan2[vi * 3 + 0] += bx;
+        tan2[vi * 3 + 1] += by;
+        tan2[vi * 3 + 2] += bz;
+      }
+    }
+
+    const tangents = new Float32Array(vertexCount * 4);
+
+    for (let i = 0; i < vertexCount; i++) {
+      const nx = normals[i * 3], ny = normals[i * 3 + 1], nz = normals[i * 3 + 2];
+      const tx = tan1[i * 3],    ty = tan1[i * 3 + 1],    tz = tan1[i * 3 + 2];
+      const bx = tan2[i * 3],    by = tan2[i * 3 + 1],    bz = tan2[i * 3 + 2];
+
+      // Gram-Schmidt 正交化：T' = normalize(T - N * dot(N, T))
+      const dot = nx * tx + ny * ty + nz * tz;
+      let ox = tx - nx * dot;
+      let oy = ty - ny * dot;
+      let oz = tz - nz * dot;
+
+      const len = Math.sqrt(ox * ox + oy * oy + oz * oz);
+      if (len > 1e-8) {
+        ox /= len; oy /= len; oz /= len;
+      } else {
+        // 退化情况：选一个与法线垂直的任意切线
+        const ax = Math.abs(nx) < 0.9 ? 1 : 0;
+        const ay = Math.abs(nx) < 0.9 ? 0 : 1;
+        const d2 = nx * ax + ny * ay;
+        ox = ax - nx * d2; oy = ay - ny * d2; oz = -nz * d2;
+        const l2 = Math.sqrt(ox * ox + oy * oy + oz * oz);
+        ox /= l2; oy /= l2; oz /= l2;
+      }
+
+      // 手性：sign(dot(cross(N, T'), B))
+      const crossX = ny * oz - nz * oy;
+      const crossY = nz * ox - nx * oz;
+      const crossZ = nx * oy - ny * ox;
+      const handedness = (crossX * bx + crossY * by + crossZ * bz) >= 0 ? 1 : -1;
+
+      tangents[i * 4 + 0] = ox;
+      tangents[i * 4 + 1] = oy;
+      tangents[i * 4 + 2] = oz;
+      tangents[i * 4 + 3] = handedness;
+    }
+
+    this.tangents = tangents;
   }
 }
 


### PR DESCRIPTION
## Summary

实现 `Geometry.computeTangents()` 方法，使用 Mikktspace-like 算法从位置、法线和 UV 数据计算每顶点切线向量。

- 遍历每个三角形，通过 UV 梯度求解切线/副切线
- 每顶点累加相邻三角形的贡献，再用 Gram-Schmidt 正交化
- 手性（handedness）存入 vec4.w 分量（±1）
- 支持索引几何体（Uint16Array indices）和非索引几何体
- 自动跳过退化三角形（UV 行列式 < 1e-8）

close #165

## Test Results

- 12/12 `geometry-tangents.test.ts` 全部通过
- 1269/1269 单元测试全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)