### PR TITLE
feat: 实现 PhongMaterial 自发光材质属性 (#160)

### DIFF
--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -32,6 +32,10 @@ interface PhongLocations {
   uShininess: WebGLUniformLocation | null;
   uMap: WebGLUniformLocation | null;
   uHasMap: WebGLUniformLocation | null;
+  // 自发光
+  uEmissive: WebGLUniformLocation | null;
+  uEmissiveMap: WebGLUniformLocation | null;
+  uHasEmissiveMap: WebGLUniformLocation | null;
   // 多方向光
   uNumDirLights: WebGLUniformLocation | null;
   uDirLightDirs: Array<WebGLUniformLocation | null>;
@@ -339,6 +343,9 @@ export class WebGLRenderer {
         uShininess:         gl.getUniformLocation(program, 'u_shininess'),
         uMap:               gl.getUniformLocation(program, 'u_map'),
         uHasMap:            gl.getUniformLocation(program, 'u_hasMap'),
+        uEmissive:          gl.getUniformLocation(program, 'u_emissive'),
+        uEmissiveMap:       gl.getUniformLocation(program, 'u_emissiveMap'),
+        uHasEmissiveMap:    gl.getUniformLocation(program, 'u_hasEmissiveMap'),
         uNumDirLights:      gl.getUniformLocation(program, 'u_numDirLights'),
         uDirLightDirs:      dirDirs,
         uDirLightColors:    dirColors,
@@ -603,6 +610,18 @@ export class WebGLRenderer {
         }
       } else {
         if (phong.uHasMap) gl.uniform1f(phong.uHasMap, 0.0);
+      }
+
+      // 自发光
+      if (phong.uEmissive) gl.uniform3fv(phong.uEmissive, mat.emissive);
+      if (mat.emissiveMap != null) {
+        const webglTex = this._getWebGLTexture(mat.emissiveMap);
+        gl.activeTexture(gl.TEXTURE1);
+        gl.bindTexture(gl.TEXTURE_2D, webglTex);
+        if (phong.uEmissiveMap)    gl.uniform1i(phong.uEmissiveMap, 1);
+        if (phong.uHasEmissiveMap) gl.uniform1f(phong.uHasEmissiveMap, 1.0);
+      } else {
+        if (phong.uHasEmissiveMap) gl.uniform1f(phong.uHasEmissiveMap, 0.0);
       }
     }
 


### PR DESCRIPTION
## 变更说明

为 `PhongMaterial` 添加完整的自发光（emissive）渲染支持。

### WebGLRenderer 新增

- `PhongLocations` 接口增加 `uEmissive` / `uEmissiveMap` / `uHasEmissiveMap` 三个 uniform 位置字段
- 编译 PhongMaterial shader program 时查询上述三个 uniform 位置
- `_drawMesh` 中上传 `u_emissive` vec3；当 `mat.emissiveMap != null` 时绑定纹理到 TEXTURE1 并设 `u_hasEmissiveMap = 1.0`

### 已有实现（随 #159 合入）

- `PhongMaterial.emissive: Vec3`（默认 `(0,0,0)`）
- `PhongMaterial.emissiveMap: Texture | null`（默认 `null`）
- Fragment shader 中 `u_emissive` / `u_emissiveMap` / `u_hasEmissiveMap` uniform 声明
- 最终颜色 = ambient + diffuse + specular + emissiveColor

## 测试结果

- `test/unit/renderer/phong-emissive.test.ts`：**12/12 通过**
- 全量测试：**1269/1269 通过**

close #160