### PR TITLE
feat: 实现 Texture 采样选项和版本追踪 (#171)

### DIFF
--- a/src/renderer/texture.ts
+++ b/src/renderer/texture.ts
@@ -3,10 +3,36 @@
  * 支持从原始 RGBA 数据构造，以及工厂方法创建常用纹理。
  */
 
+export enum TextureWrap {
+  ClampToEdge    = 'clamp',
+  Repeat         = 'repeat',
+  MirroredRepeat = 'mirror',
+}
+
+export enum TextureFilter {
+  Nearest              = 'nearest',
+  Linear               = 'linear',
+  NearestMipmapNearest = 'nearest-mipmap-nearest',
+  NearestMipmapLinear  = 'nearest-mipmap-linear',
+  LinearMipmapNearest  = 'linear-mipmap-nearest',
+  LinearMipmapLinear   = 'linear-mipmap-linear',
+}
+
 export class Texture {
   readonly width: number;
   readonly height: number;
   readonly data: Uint8Array;
+
+  wrapS: TextureWrap   = TextureWrap.ClampToEdge;
+  wrapT: TextureWrap   = TextureWrap.ClampToEdge;
+  minFilter: TextureFilter = TextureFilter.Nearest;
+  magFilter: TextureFilter = TextureFilter.Nearest;
+  generateMipmaps: boolean = false;
+  flipY: boolean = false;
+
+  private _version: number = 0;
+  get version(): number { return this._version; }
+  needsUpdate(): void { this._version++; }
 
   private constructor(width: number, height: number, data: Uint8Array) {
     this.width  = width;

--- a/test/unit/renderer/texture-sampling.test.ts
+++ b/test/unit/renderer/texture-sampling.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { Texture, TextureWrap, TextureFilter } from '../../../src/renderer/texture';
+
+describe('Texture Sampling Options', () => {
+  describe('defaults', () => {
+    it('should default to ClampToEdge wrap', () => {
+      const tex = Texture.fromData(1, 1, new Uint8Array([255, 0, 0, 255]));
+      expect(tex.wrapS).toBe(TextureWrap.ClampToEdge);
+      expect(tex.wrapT).toBe(TextureWrap.ClampToEdge);
+    });
+
+    it('should default to Nearest filter', () => {
+      const tex = Texture.fromData(1, 1, new Uint8Array([255, 0, 0, 255]));
+      expect(tex.minFilter).toBe(TextureFilter.Nearest);
+      expect(tex.magFilter).toBe(TextureFilter.Nearest);
+    });
+
+    it('should default generateMipmaps to false', () => {
+      const tex = Texture.fromData(1, 1, new Uint8Array([255, 0, 0, 255]));
+      expect(tex.generateMipmaps).toBe(false);
+    });
+
+    it('should default flipY to false', () => {
+      const tex = Texture.fromData(1, 1, new Uint8Array([255, 0, 0, 255]));
+      expect(tex.flipY).toBe(false);
+    });
+  });
+
+  describe('configuration', () => {
+    it('should allow setting wrap modes', () => {
+      const tex = Texture.fromData(2, 2, new Uint8Array(16));
+      tex.wrapS = TextureWrap.Repeat;
+      tex.wrapT = TextureWrap.MirroredRepeat;
+      expect(tex.wrapS).toBe(TextureWrap.Repeat);
+      expect(tex.wrapT).toBe(TextureWrap.MirroredRepeat);
+    });
+
+    it('should allow setting filter modes', () => {
+      const tex = Texture.fromData(2, 2, new Uint8Array(16));
+      tex.minFilter = TextureFilter.LinearMipmapLinear;
+      tex.magFilter = TextureFilter.Linear;
+      expect(tex.minFilter).toBe(TextureFilter.LinearMipmapLinear);
+      expect(tex.magFilter).toBe(TextureFilter.Linear);
+    });
+
+    it('should allow enabling mipmap generation', () => {
+      const tex = Texture.fromData(4, 4, new Uint8Array(64));
+      tex.generateMipmaps = true;
+      expect(tex.generateMipmaps).toBe(true);
+    });
+
+    it('should allow setting flipY', () => {
+      const tex = Texture.fromData(2, 2, new Uint8Array(16));
+      tex.flipY = true;
+      expect(tex.flipY).toBe(true);
+    });
+  });
+
+  describe('version tracking', () => {
+    it('should start at version 0', () => {
+      const tex = Texture.fromData(1, 1, new Uint8Array(4));
+      expect(tex.version).toBe(0);
+    });
+
+    it('should increment version on needsUpdate()', () => {
+      const tex = Texture.fromData(1, 1, new Uint8Array(4));
+      tex.needsUpdate();
+      expect(tex.version).toBe(1);
+      tex.needsUpdate();
+      expect(tex.version).toBe(2);
+    });
+  });
+
+  describe('factory methods preserve defaults', () => {
+    it('defaultWhite should have default sampling options', () => {
+      const tex = Texture.defaultWhite();
+      expect(tex.wrapS).toBe(TextureWrap.ClampToEdge);
+      expect(tex.minFilter).toBe(TextureFilter.Nearest);
+    });
+
+    it('checkerboard should have default sampling options', () => {
+      const tex = Texture.checkerboard(4, 4);
+      expect(tex.wrapS).toBe(TextureWrap.ClampToEdge);
+      expect(tex.minFilter).toBe(TextureFilter.Nearest);
+    });
+  });
+});


### PR DESCRIPTION
## 变更内容

- 新增 `TextureWrap` 枚举：`ClampToEdge` / `Repeat` / `MirroredRepeat`
- 新增 `TextureFilter` 枚举：`Nearest` / `Linear` / 四种 Mipmap 变体
- `Texture` 类新增属性：`wrapS`、`wrapT`、`minFilter`、`magFilter`、`generateMipmaps`、`flipY`，均带默认值，向后兼容
- 新增 `version` getter + `needsUpdate()` 方法，供渲染器检测纹理变化后重新上传 GPU

## 测试

- 新增 `test/unit/renderer/texture-sampling.test.ts`，12 个测试全部通过
- 全量回归：84 个测试文件，1281 个测试，0 失败

close #171