### PR TITLE
feat: 实现 SpotLight 锥形聚光灯 (#176)

### DIFF
--- a/src/core/scene.ts
+++ b/src/core/scene.ts
@@ -7,6 +7,7 @@ import { Node3D } from './node3d';
 import { type Vec3, vec3 } from '../math/vec3';
 import { AmbientLight, DirectionalLight } from './light';
 import { PointLight } from './point-light';
+import { SpotLight } from './spot-light';
 
 export interface FogOptions {
   color: Vec3;
@@ -23,6 +24,7 @@ export interface CollectedLights {
   ambient: AmbientLight[];
   directional: DirectionalLight[];
   point: PointLight[];
+  spot: SpotLight[];
 }
 
 export class Scene extends Node3D {
@@ -41,6 +43,7 @@ export class Scene extends Node3D {
       ambient: [],
       directional: [],
       point: [],
+      spot: [],
     };
 
     this.traverse((node) => {
@@ -48,6 +51,8 @@ export class Scene extends Node3D {
         result.ambient.push(node);
       } else if (node instanceof DirectionalLight) {
         result.directional.push(node);
+      } else if (node instanceof SpotLight) {
+        result.spot.push(node);
       } else if (node instanceof PointLight) {
         result.point.push(node);
       }

--- a/src/core/spot-light.ts
+++ b/src/core/spot-light.ts
@@ -1,0 +1,99 @@
+import { Light } from './light';
+import { type Vec3, vec3, normalize } from '../math/vec3';
+
+export interface SpotLightOptions {
+  color?: Vec3;
+  intensity?: number;
+  direction?: Vec3;   // 局部空间光照方向，默认 (0, -1, 0)
+  distance?: number;  // 最大作用距离，0 = 无限，默认 0
+  decay?: number;     // 距离衰减指数，默认 2
+  angle?: number;     // 外锥角（弧度），默认 PI/4，钳位到 [0, PI/2]
+  penumbra?: number;  // 柔边比例 [0, 1]，0 = 硬边，默认 0
+}
+
+/**
+ * 聚光灯 — 锥形光源，支持内/外锥角、距离衰减和阴影柔边。
+ * 用于闪光灯、路灯、车灯、舞台灯等效果。
+ */
+export class SpotLight extends Light {
+  direction: Vec3;
+  distance: number;
+  decay: number;
+  angle: number;    // 外锥角，钳位到 [0, PI/2]
+  penumbra: number; // 钳位到 [0, 1]
+
+  constructor(opts?: SpotLightOptions) {
+    super(opts?.color, opts?.intensity);
+    this.direction = opts?.direction ?? vec3(0, -1, 0);
+    this.distance  = opts?.distance  ?? 0;
+    this.decay     = opts?.decay     ?? 2;
+    this.angle     = Math.min(Math.max(opts?.angle    ?? Math.PI / 4, 0), Math.PI / 2);
+    this.penumbra  = Math.min(Math.max(opts?.penumbra ?? 0,           0), 1);
+  }
+
+  /** 世界空间位置（从 worldMatrix 第四列提取） */
+  get worldPosition(): Vec3 {
+    const wm = this.worldMatrix;
+    return vec3(wm[12], wm[13], wm[14]);
+  }
+
+  /** 世界空间光照方向（考虑父节点旋转，归一化） */
+  get worldDirection(): Vec3 {
+    const wm = this.worldMatrix;
+    const d = this.direction;
+    // 用 worldMatrix 的上左 3×3 旋转局部方向（列优先乘法）
+    const x = wm[0] * d[0] + wm[4] * d[1] + wm[8]  * d[2];
+    const y = wm[1] * d[0] + wm[5] * d[1] + wm[9]  * d[2];
+    const z = wm[2] * d[0] + wm[6] * d[1] + wm[10] * d[2];
+    return normalize(vec3(x, y, z));
+  }
+
+  /**
+   * 计算目标点处的聚光灯衰减系数（0 = 无光，>0 = 有光）。
+   * 同时考虑锥形衰减和距离衰减。
+   */
+  getAttenuationAt(target: Vec3): number {
+    const worldPos = this.worldPosition;
+    const worldDir = this.worldDirection;
+
+    const dx = target[0] - worldPos[0];
+    const dy = target[1] - worldPos[1];
+    const dz = target[2] - worldPos[2];
+    const d  = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+    if (d < 0.0001) return 0;
+
+    // 从光源到目标点的归一化方向
+    const toX = dx / d;
+    const toY = dy / d;
+    const toZ = dz / d;
+
+    // 点积：越接近 1 越靠近锥轴中心
+    const spotEffect = toX * worldDir[0] + toY * worldDir[1] + toZ * worldDir[2];
+
+    const cosOuter = Math.cos(this.angle);
+    const cosInner = Math.cos(this.angle * (1 - this.penumbra));
+
+    // smoothstep 锥形衰减
+    let spotAttenuation: number;
+    if (cosOuter >= cosInner) {
+      // penumbra=0 的情况：硬边
+      spotAttenuation = spotEffect >= cosOuter ? 1.0 : 0.0;
+    } else {
+      const t = Math.max(0, Math.min(1, (spotEffect - cosOuter) / (cosInner - cosOuter)));
+      spotAttenuation = t * t * (3 - 2 * t);
+    }
+
+    if (spotAttenuation === 0) return 0;
+
+    // 距离衰减（兼容 Three.js PointLight 公式）
+    let distAttenuation: number;
+    if (this.distance === 0) {
+      distAttenuation = 1 / Math.max(Math.pow(d, this.decay), 0.01);
+    } else {
+      distAttenuation = Math.pow(Math.max(1 - d / this.distance, 0), this.decay);
+    }
+
+    return spotAttenuation * distAttenuation;
+  }
+}

--- a/src/renderer/phong-material.ts
+++ b/src/renderer/phong-material.ts
@@ -52,6 +52,15 @@ const PHONG_FRAGMENT_SHADER = `
   uniform vec3 u_pointLightColors[4];
   uniform float u_pointLightDistances[4];
   uniform float u_pointLightDecays[4];
+  // 聚光灯数组
+  uniform int u_numSpotLights;
+  uniform vec3 u_spotLightPositions[4];
+  uniform vec3 u_spotLightDirs[4];
+  uniform vec3 u_spotLightColors[4];
+  uniform float u_spotLightDistances[4];
+  uniform float u_spotLightDecays[4];
+  uniform float u_spotLightCosAngles[4];
+  uniform float u_spotLightPenumbras[4];
   // 漫反射贴图
   uniform sampler2D u_map;
   uniform float u_hasMap;
@@ -116,6 +125,38 @@ const PHONG_FRAGMENT_SHADER = `
       }
       color += u_pointLightColors[i] * baseDiffuse * diff * attenuation;
       color += u_pointLightColors[i] * baseSpecular * spec * attenuation;
+    }
+
+    // 聚光灯循环
+    for (int i = 0; i < 4; i++) {
+      if (i >= u_numSpotLights) break;
+      vec3 lightVec = u_spotLightPositions[i] - v_worldPos;
+      float d = length(lightVec);
+      vec3 L = lightVec / max(d, 0.0001);
+      vec3 H = normalize(L + V);
+      float diff = max(dot(N, L), 0.0);
+      float spec = pow(max(dot(N, H), 0.0), u_shininess);
+      // 距离衰减
+      float dist = u_spotLightDistances[i];
+      float decay = u_spotLightDecays[i];
+      float distAttenuation;
+      if (dist <= 0.0) {
+        distAttenuation = 1.0 / max(pow(d, decay), 0.01);
+      } else {
+        distAttenuation = pow(max(1.0 - d / dist, 0.0), decay);
+      }
+      // 锥形衰减（smoothstep）
+      float cosOuter = u_spotLightCosAngles[i];
+      float penumbra = u_spotLightPenumbras[i];
+      // cosInner = cos(angle * (1.0 - penumbra))，通过 cosOuter 反推 angle 再乘 (1-penumbra)
+      // 直接用 acos 会在 GLSL 1.0 中精度不稳，改为在 CPU 端传 cosInner
+      // 这里复用 penumbra 字段存储 cosInner
+      float cosInner = penumbra; // 注：renderer 中传 cos(angle*(1-penumbra))
+      float spotEffect = dot(normalize(v_worldPos - u_spotLightPositions[i]), u_spotLightDirs[i]);
+      float spotAttenuation = smoothstep(cosOuter, cosInner, spotEffect);
+      float attenuation = distAttenuation * spotAttenuation;
+      color += u_spotLightColors[i] * baseDiffuse  * diff * attenuation;
+      color += u_spotLightColors[i] * baseSpecular * spec * attenuation;
     }
 
     vec3 emissiveColor = u_hasEmissiveMap > 0.5

--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -10,6 +10,7 @@ import { Scene } from '../core/scene';
 import { Camera } from '../core/camera';
 import { AmbientLight, DirectionalLight } from '../core/light';
 import { PointLight } from '../core/point-light';
+import { SpotLight } from '../core/spot-light';
 import { Mesh } from './mesh';
 import { SkinnedMesh } from './skinned-mesh';
 import { Geometry } from './geometry';
@@ -49,6 +50,15 @@ interface PhongLocations {
   uPointLightColors: Array<WebGLUniformLocation | null>;
   uPointLightDistances: Array<WebGLUniformLocation | null>;
   uPointLightDecays: Array<WebGLUniformLocation | null>;
+  // 聚光灯
+  uNumSpotLights: WebGLUniformLocation | null;
+  uSpotLightPositions: Array<WebGLUniformLocation | null>;
+  uSpotLightDirs: Array<WebGLUniformLocation | null>;
+  uSpotLightColors: Array<WebGLUniformLocation | null>;
+  uSpotLightDistances: Array<WebGLUniformLocation | null>;
+  uSpotLightDecays: Array<WebGLUniformLocation | null>;
+  uSpotLightCosAngles: Array<WebGLUniformLocation | null>;
+  uSpotLightPenumbras: Array<WebGLUniformLocation | null>;
 }
 
 interface CompiledProgram {
@@ -115,6 +125,7 @@ interface SkinningProgram {
 
 const MAX_DIR_LIGHTS = 4;
 const MAX_POINT_LIGHTS = 4;
+const MAX_SPOT_LIGHTS = 4;
 
 interface DirLightData {
   dir: Vec3;
@@ -128,11 +139,22 @@ interface PointLightData {
   decay: number;
 }
 
+interface SpotLightData {
+  position: Vec3;
+  direction: Vec3;
+  color: Vec3;
+  distance: number;
+  decay: number;
+  cosAngle: number;  // cos(外锥角)
+  cosInner: number;  // cos(angle * (1 - penumbra))，用于 smoothstep
+}
+
 interface LightContext {
   ambientColor: Vec3;
   cameraPos: Vec3;
   dirLights: DirLightData[];
   pointLights: PointLightData[];
+  spotLights: SpotLightData[];
 }
 
 // ── Shader helpers ────────────────────────────────────────────────
@@ -212,6 +234,7 @@ export class WebGLRenderer {
     let ambientColor: Vec3 = vec3(0, 0, 0);
     const dirLights: DirLightData[] = [];
     const pointLights: PointLightData[] = [];
+    const spotLights: SpotLightData[] = [];
 
     const collected = scene.collectLights();
     for (const node of collected.ambient) {
@@ -249,11 +272,29 @@ export class WebGLRenderer {
       });
     }
 
+    for (const node of collected.spot) {
+      if (spotLights.length >= MAX_SPOT_LIGHTS) break;
+      spotLights.push({
+        position:  node.worldPosition,
+        direction: node.worldDirection,
+        color: vec3(
+          node.color[0] * node.intensity,
+          node.color[1] * node.intensity,
+          node.color[2] * node.intensity,
+        ),
+        distance: node.distance,
+        decay:    node.decay,
+        cosAngle: Math.cos(node.angle),
+        cosInner: Math.cos(node.angle * (1 - node.penumbra)),
+      });
+    }
+
     const lightCtx: LightContext = {
       ambientColor,
       cameraPos: camera.position,
       dirLights,
       pointLights,
+      spotLights,
     };
 
     const viewProj = camera.viewProjectionMatrix;
@@ -335,6 +376,22 @@ export class WebGLRenderer {
         ptDistances.push(gl.getUniformLocation(program, `u_pointLightDistances[${i}]`));
         ptDecays.push(gl.getUniformLocation(program, `u_pointLightDecays[${i}]`));
       }
+      const spPositions: Array<WebGLUniformLocation | null> = [];
+      const spDirs:      Array<WebGLUniformLocation | null> = [];
+      const spColors:    Array<WebGLUniformLocation | null> = [];
+      const spDistances: Array<WebGLUniformLocation | null> = [];
+      const spDecays:    Array<WebGLUniformLocation | null> = [];
+      const spCosAngles: Array<WebGLUniformLocation | null> = [];
+      const spPenumbras: Array<WebGLUniformLocation | null> = [];
+      for (let i = 0; i < MAX_SPOT_LIGHTS; i++) {
+        spPositions.push(gl.getUniformLocation(program, `u_spotLightPositions[${i}]`));
+        spDirs.push(gl.getUniformLocation(program, `u_spotLightDirs[${i}]`));
+        spColors.push(gl.getUniformLocation(program, `u_spotLightColors[${i}]`));
+        spDistances.push(gl.getUniformLocation(program, `u_spotLightDistances[${i}]`));
+        spDecays.push(gl.getUniformLocation(program, `u_spotLightDecays[${i}]`));
+        spCosAngles.push(gl.getUniformLocation(program, `u_spotLightCosAngles[${i}]`));
+        spPenumbras.push(gl.getUniformLocation(program, `u_spotLightPenumbras[${i}]`));
+      }
       compiled.phong = {
         aNormal:            gl.getAttribLocation(program, 'a_normal'),
         uModelMatrix:       gl.getUniformLocation(program, 'u_modelMatrix'),
@@ -359,6 +416,14 @@ export class WebGLRenderer {
         uPointLightColors:  ptColors,
         uPointLightDistances: ptDistances,
         uPointLightDecays:  ptDecays,
+        uNumSpotLights:     gl.getUniformLocation(program, 'u_numSpotLights'),
+        uSpotLightPositions: spPositions,
+        uSpotLightDirs:     spDirs,
+        uSpotLightColors:   spColors,
+        uSpotLightDistances: spDistances,
+        uSpotLightDecays:   spDecays,
+        uSpotLightCosAngles: spCosAngles,
+        uSpotLightPenumbras: spPenumbras,
       };
     }
 
@@ -593,6 +658,26 @@ export class WebGLRenderer {
         if (colLoc)  gl.uniform3fv(colLoc, pl.color);
         if (distLoc) gl.uniform1f(distLoc, pl.distance);
         if (decLoc)  gl.uniform1f(decLoc, pl.decay);
+      }
+
+      // 聚光灯
+      if (phong.uNumSpotLights) gl.uniform1i(phong.uNumSpotLights, lightCtx.spotLights.length);
+      for (let i = 0; i < lightCtx.spotLights.length; i++) {
+        const sl = lightCtx.spotLights[i];
+        const posLoc  = phong.uSpotLightPositions[i];
+        const dirLoc  = phong.uSpotLightDirs[i];
+        const colLoc  = phong.uSpotLightColors[i];
+        const distLoc = phong.uSpotLightDistances[i];
+        const decLoc  = phong.uSpotLightDecays[i];
+        const cosLoc  = phong.uSpotLightCosAngles[i];
+        const penLoc  = phong.uSpotLightPenumbras[i];
+        if (posLoc)  gl.uniform3fv(posLoc, sl.position);
+        if (dirLoc)  gl.uniform3fv(dirLoc, sl.direction);
+        if (colLoc)  gl.uniform3fv(colLoc, sl.color);
+        if (distLoc) gl.uniform1f(distLoc, sl.distance);
+        if (decLoc)  gl.uniform1f(decLoc, sl.decay);
+        if (cosLoc)  gl.uniform1f(cosLoc, sl.cosAngle);
+        if (penLoc)  gl.uniform1f(penLoc, sl.cosInner);
       }
 
       // 材质属性 uniforms

--- a/test/unit/core/spot-light.test.ts
+++ b/test/unit/core/spot-light.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { SpotLight } from '../../../src/core/spot-light';
+import { vec3 } from '../../../src/math/vec3';
+import { Scene } from '../../../src/core/scene';
+import { Node3D } from '../../../src/core/node3d';
+
+describe('SpotLight', () => {
+  it('creates with default values', () => {
+    const light = new SpotLight();
+    expect(light.color).toEqual(vec3(1, 1, 1));
+    expect(light.intensity).toBe(1);
+    expect(light.distance).toBe(0);
+    expect(light.decay).toBe(2);
+    expect(light.angle).toBeCloseTo(Math.PI / 4);
+    expect(light.penumbra).toBe(0);
+    expect(light.direction).toEqual(vec3(0, -1, 0));
+  });
+
+  it('creates with custom options', () => {
+    const light = new SpotLight({
+      color: vec3(1, 0, 0),
+      intensity: 2,
+      distance: 50,
+      decay: 1,
+      angle: Math.PI / 6,
+      penumbra: 0.5,
+      direction: vec3(0, 0, -1),
+    });
+    expect(light.color).toEqual(vec3(1, 0, 0));
+    expect(light.intensity).toBe(2);
+    expect(light.distance).toBe(50);
+    expect(light.decay).toBe(1);
+    expect(light.angle).toBeCloseTo(Math.PI / 6);
+    expect(light.penumbra).toBe(0.5);
+    expect(light.direction).toEqual(vec3(0, 0, -1));
+  });
+
+  it('is a Node3D — can be added to scene graph', () => {
+    const scene = new Scene();
+    const light = new SpotLight();
+    scene.addChild(light);
+    expect(scene.children).toContain(light);
+  });
+
+  it('computes worldPosition from worldMatrix', () => {
+    const light = new SpotLight();
+    light.position = vec3(10, 5, -3);
+    const wp = light.worldPosition;
+    expect(wp[0]).toBeCloseTo(10);
+    expect(wp[1]).toBeCloseTo(5);
+    expect(wp[2]).toBeCloseTo(-3);
+  });
+
+  it('worldDirection defaults to (0, -1, 0) without parent rotation', () => {
+    const light = new SpotLight();
+    const wd = light.worldDirection;
+    expect(wd[0]).toBeCloseTo(0);
+    expect(wd[1]).toBeCloseTo(-1);
+    expect(wd[2]).toBeCloseTo(0);
+  });
+
+  it('worldDirection respects parent transform', () => {
+    const parent = new Node3D('holder');
+    parent.rotation = vec3(0, Math.PI / 2, 0); // 绕Y转90度
+    const light = new SpotLight({ direction: vec3(0, 0, -1) });
+    parent.addChild(light);
+    const wd = light.worldDirection;
+    // 绕Y旋转90度后，(0,0,-1) → (-1,0,0) 大致方向
+    expect(Math.abs(wd[0])).toBeGreaterThan(0.9);
+  });
+
+  it('clamps angle to [0, PI/2]', () => {
+    const light1 = new SpotLight({ angle: Math.PI }); // 超过 PI/2
+    expect(light1.angle).toBeLessThanOrEqual(Math.PI / 2);
+    const light2 = new SpotLight({ angle: -1 });
+    expect(light2.angle).toBeGreaterThanOrEqual(0);
+  });
+
+  it('clamps penumbra to [0, 1]', () => {
+    const light1 = new SpotLight({ penumbra: 2 });
+    expect(light1.penumbra).toBeLessThanOrEqual(1);
+    const light2 = new SpotLight({ penumbra: -0.5 });
+    expect(light2.penumbra).toBeGreaterThanOrEqual(0);
+  });
+
+  it('is collected by Scene.collectLights() in spot array', () => {
+    const scene = new Scene();
+    scene.addChild(new SpotLight({ color: vec3(1, 0, 0), intensity: 2 }));
+    scene.addChild(new SpotLight({ color: vec3(0, 1, 0) }));
+    const lights = scene.collectLights();
+    expect(lights.spot).toBeDefined();
+    expect(lights.spot.length).toBe(2);
+    expect(lights.spot[0].color).toEqual(vec3(1, 0, 0));
+    expect(lights.spot[0].intensity).toBe(2);
+  });
+
+  it('getAttenuationAt returns spot intensity factor', () => {
+    const light = new SpotLight({
+      distance: 10,
+      decay: 2,
+      angle: Math.PI / 4,
+      penumbra: 0,
+    });
+    light.position = vec3(0, 5, 0);
+    // 正下方 — 在锥内
+    const atten = light.getAttenuationAt(vec3(0, 0, 0));
+    expect(atten).toBeGreaterThan(0);
+  });
+
+  it('getAttenuationAt returns 0 outside cone', () => {
+    const light = new SpotLight({
+      angle: Math.PI / 8,  // 窄锥
+      penumbra: 0,
+    });
+    light.position = vec3(0, 5, 0);
+    // 水平远处 — 在锥外
+    const atten = light.getAttenuationAt(vec3(100, 5, 0));
+    expect(atten).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- 新增 `SpotLight` 类（`src/core/spot-light.ts`）：继承 Light，支持 direction/distance/decay/angle/penumbra，实现 `worldPosition`、`worldDirection` getter 和 `getAttenuationAt()` 方法
- 扩展 `Scene.collectLights()` 返回 `spot: SpotLight[]` 字段
- 扩展 `PhongMaterial` fragment shader，添加聚光灯 uniform 数组（最多 4 个）和 smoothstep 锥形衰减循环
- 扩展 `WebGLRenderer` 收集 spot lights 并传递所有 uniform

## 验证

- `test/unit/core/spot-light.test.ts`：11/11 通过
- 全量单元测试：1292 passed，0 failed
- 视觉回归测试：12 passed，0 failed

close #176