### PR TITLE
feat: 实现 Clone API — Node3D / Geometry / Material 深浅克隆

### DIFF
--- a/src/core/node3d.ts
+++ b/src/core/node3d.ts
@@ -95,4 +95,22 @@ export class Node3D {
     }
     return null;
   }
+
+  /**
+   * 克隆节点。克隆出的节点 parent 为 null（脱离原场景图）。
+   * @param recursive 默认 false — 不克隆子节点；true — 递归深克隆整棵子树
+   */
+  clone(recursive = false): Node3D {
+    const node = new Node3D(this.name);
+    node.position = vec3(this.position[0], this.position[1], this.position[2]);
+    node.rotation = vec3(this.rotation[0], this.rotation[1], this.rotation[2]);
+    node.scale    = vec3(this.scale[0],    this.scale[1],    this.scale[2]);
+    node.visible  = this.visible;
+    if (recursive) {
+      for (const child of this.children) {
+        node.addChild(child.clone(true));
+      }
+    }
+    return node;
+  }
 }

--- a/src/renderer/geometry.ts
+++ b/src/renderer/geometry.ts
@@ -60,6 +60,20 @@ export class Geometry {
     return this.tangents !== null;
   }
 
+  /** 深拷贝所有 buffer，返回独立的 Geometry 副本 */
+  clone(): Geometry {
+    return new Geometry({
+      positions: new Float32Array(this.positions),
+      colors:    new Float32Array(this.colors),
+      normals:   this.normals  ? new Float32Array(this.normals)  : undefined,
+      uvs:       this.uvs      ? new Float32Array(this.uvs)      : undefined,
+      indices:   this.indices  ? new Uint16Array(this.indices)   : undefined,
+      joints:    this.joints   ? new Float32Array(this.joints)   : undefined,
+      weights:   this.weights  ? new Float32Array(this.weights)  : undefined,
+      tangents:  this.tangents ? new Float32Array(this.tangents) : undefined,
+    });
+  }
+
   /**
    * Compute per-vertex tangent vectors from positions, normals, and UVs.
    * Uses Mikktspace-like algorithm. Stores result in this.tangents as vec4

--- a/src/renderer/material.ts
+++ b/src/renderer/material.ts
@@ -38,4 +38,15 @@ export class Material {
     this.opacity      = 1;
     this.transparent  = false;
   }
+
+  /** 克隆材质（拷贝 shader source + opacity/transparent 属性） */
+  clone(): Material {
+    const m = new Material({
+      vertexShader:   this.vertexShader,
+      fragmentShader: this.fragmentShader,
+    });
+    m.opacity     = this.opacity;
+    m.transparent = this.transparent;
+    return m;
+  }
 }

--- a/src/renderer/mesh.ts
+++ b/src/renderer/mesh.ts
@@ -39,4 +39,26 @@ export class Mesh extends Node3D {
     }
     return this._boundingBox;
   }
+
+  /**
+   * 克隆 Mesh。
+   * recursive=false: geometry 和 material 共享引用（浅克隆）
+   * recursive=true: geometry 和 material 也做 clone（深克隆）
+   */
+  override clone(recursive = false): Mesh {
+    const geo = recursive ? this._geometry.clone() : this._geometry;
+    const mat = recursive ? this.material.clone()  : this.material;
+    const m = new Mesh(geo, mat, this.name);
+    m.position = this.position.slice() as import('../math/vec3').Vec3;
+    m.rotation = this.rotation.slice() as import('../math/vec3').Vec3;
+    m.scale    = this.scale.slice()    as import('../math/vec3').Vec3;
+    m.visible  = this.visible;
+    m.frustumCulled = this.frustumCulled;
+    if (recursive) {
+      for (const child of this.children) {
+        m.addChild(child.clone(true));
+      }
+    }
+    return m;
+  }
 }

--- a/src/renderer/phong-material.ts
+++ b/src/renderer/phong-material.ts
@@ -208,4 +208,23 @@ export class PhongMaterial extends Material {
     this.normalScale  = opts.normalScale  ?? 1.0;
     this.specularMap  = opts.specularMap  ?? null;
   }
+
+  /** 克隆 Phong 材质（Vec3 属性深拷贝，Texture 引用共享） */
+  clone(): PhongMaterial {
+    const m = new PhongMaterial({
+      ambient:     vec3(this.ambient[0],  this.ambient[1],  this.ambient[2]),
+      diffuse:     vec3(this.diffuse[0],  this.diffuse[1],  this.diffuse[2]),
+      specular:    vec3(this.specular[0], this.specular[1], this.specular[2]),
+      shininess:   this.shininess,
+      map:         this.map          ?? undefined,
+      emissive:    vec3(this.emissive[0], this.emissive[1], this.emissive[2]),
+      emissiveMap: this.emissiveMap  ?? undefined,
+      normalMap:   this.normalMap    ?? undefined,
+      normalScale: this.normalScale,
+      specularMap: this.specularMap  ?? undefined,
+    });
+    m.opacity     = this.opacity;
+    m.transparent = this.transparent;
+    return m;
+  }
 }

--- a/test/unit/core/clone.test.ts
+++ b/test/unit/core/clone.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { Node3D } from '../../../src/core/node3d';
+import { Mesh } from '../../../src/renderer/mesh';
+import { Geometry, createCubeGeometry } from '../../../src/renderer/geometry';
+import { Material } from '../../../src/renderer/material';
+import { PhongMaterial } from '../../../src/renderer/phong-material';
+import { Texture } from '../../../src/renderer/texture';
+import { vec3 } from '../../../src/math/vec3';
+
+describe('Clone API', () => {
+  describe('Geometry.clone()', () => {
+    it('deep-copies all buffers', () => {
+      const geo = createCubeGeometry();
+      const cloned = geo.clone();
+      expect(cloned.positions).toEqual(geo.positions);
+      expect(cloned.positions).not.toBe(geo.positions);
+      expect(cloned.colors).not.toBe(geo.colors);
+      expect(cloned.normals).toEqual(geo.normals);
+      expect(cloned.normals).not.toBe(geo.normals);
+      expect(cloned.uvs).toEqual(geo.uvs);
+      expect(cloned.uvs).not.toBe(geo.uvs);
+      expect(cloned.indices).toEqual(geo.indices);
+      expect(cloned.indices).not.toBe(geo.indices);
+    });
+
+    it('handles null optional fields', () => {
+      const geo = new Geometry({ positions: new Float32Array([0, 1, 2]) });
+      const cloned = geo.clone();
+      expect(cloned.positions).toEqual(new Float32Array([0, 1, 2]));
+      expect(cloned.normals).toBeNull();
+      expect(cloned.uvs).toBeNull();
+      expect(cloned.indices).toBeNull();
+      expect(cloned.joints).toBeNull();
+      expect(cloned.weights).toBeNull();
+      expect(cloned.tangents).toBeNull();
+    });
+
+    it('cloned buffers are independent', () => {
+      const geo = createCubeGeometry();
+      const cloned = geo.clone();
+      cloned.positions[0] = 999;
+      expect(geo.positions[0]).not.toBe(999);
+    });
+  });
+
+  describe('Material.clone()', () => {
+    it('creates independent copy with same properties', () => {
+      const mat = new Material();
+      mat.opacity = 0.7;
+      mat.transparent = true;
+      const cloned = mat.clone();
+      expect(cloned.vertexShader).toBe(mat.vertexShader);
+      expect(cloned.fragmentShader).toBe(mat.fragmentShader);
+      expect(cloned.opacity).toBe(0.7);
+      expect(cloned.transparent).toBe(true);
+    });
+
+    it('cloned material is independent', () => {
+      const mat = new Material();
+      const cloned = mat.clone();
+      cloned.opacity = 0.3;
+      expect(mat.opacity).toBe(1);
+    });
+  });
+
+  describe('PhongMaterial.clone()', () => {
+    it('deep-copies all color properties', () => {
+      const tex = Texture.defaultWhite();
+      const mat = new PhongMaterial({
+        diffuse: vec3(1, 0, 0),
+        specular: vec3(0.5, 0.5, 0.5),
+        shininess: 64,
+        map: tex,
+        emissive: vec3(0.1, 0, 0),
+      });
+      const cloned = mat.clone();
+      expect(cloned.diffuse).toEqual(vec3(1, 0, 0));
+      expect(cloned.specular).toEqual(vec3(0.5, 0.5, 0.5));
+      expect(cloned.shininess).toBe(64);
+      expect(cloned.emissive).toEqual(vec3(0.1, 0, 0));
+      // Texture 共享引用
+      expect(cloned.map).toBe(tex);
+    });
+
+    it('color properties are independent', () => {
+      const mat = new PhongMaterial({ diffuse: vec3(1, 0, 0) });
+      const cloned = mat.clone();
+      cloned.diffuse = vec3(0, 1, 0);
+      expect(mat.diffuse).toEqual(vec3(1, 0, 0));
+    });
+
+    it('returns PhongMaterial instance', () => {
+      const mat = new PhongMaterial();
+      const cloned = mat.clone();
+      expect(cloned).toBeInstanceOf(PhongMaterial);
+    });
+  });
+
+  describe('Node3D.clone()', () => {
+    it('shallow clone copies transform but not children', () => {
+      const parent = new Node3D('parent');
+      parent.position = vec3(1, 2, 3);
+      parent.rotation = vec3(0.1, 0.2, 0.3);
+      parent.scale = vec3(2, 2, 2);
+      parent.addChild(new Node3D('child'));
+
+      const cloned = parent.clone(false);
+      expect(cloned.name).toBe('parent');
+      expect(cloned.position).toEqual(vec3(1, 2, 3));
+      expect(cloned.rotation).toEqual(vec3(0.1, 0.2, 0.3));
+      expect(cloned.scale).toEqual(vec3(2, 2, 2));
+      expect(cloned.children.length).toBe(0);
+    });
+
+    it('deep clone includes children recursively', () => {
+      const root = new Node3D('root');
+      const child = new Node3D('child');
+      const grandchild = new Node3D('grandchild');
+      root.addChild(child);
+      child.addChild(grandchild);
+
+      const cloned = root.clone(true);
+      expect(cloned.children.length).toBe(1);
+      expect(cloned.children[0].name).toBe('child');
+      expect(cloned.children[0].children.length).toBe(1);
+      expect(cloned.children[0].children[0].name).toBe('grandchild');
+      expect(cloned.children[0]).not.toBe(child);
+      expect(cloned.children[0].children[0]).not.toBe(grandchild);
+    });
+
+    it('cloned node is detached from original parent', () => {
+      const parent = new Node3D('parent');
+      const child = new Node3D('child');
+      parent.addChild(child);
+
+      const cloned = child.clone();
+      expect(cloned.parent).toBeNull();
+    });
+
+    it('transform values are independent', () => {
+      const node = new Node3D('test');
+      node.position = vec3(1, 0, 0);
+      const cloned = node.clone();
+      cloned.position = vec3(99, 0, 0);
+      expect(node.position[0]).toBe(1);
+    });
+  });
+
+  describe('Mesh.clone()', () => {
+    it('shallow clone shares geometry and material', () => {
+      const geo = createCubeGeometry();
+      const mat = new PhongMaterial();
+      const mesh = new Mesh(geo, mat);
+      mesh.position = vec3(5, 0, 0);
+
+      const cloned = mesh.clone(false) as Mesh;
+      expect(cloned).toBeInstanceOf(Mesh);
+      expect(cloned.geometry).toBe(geo);
+      expect(cloned.material).toBe(mat);
+      expect(cloned.position).toEqual(vec3(5, 0, 0));
+    });
+
+    it('deep clone creates independent geometry and material', () => {
+      const geo = createCubeGeometry();
+      const mat = new PhongMaterial({ diffuse: vec3(1, 0, 0) });
+      const mesh = new Mesh(geo, mat);
+
+      const cloned = mesh.clone(true) as Mesh;
+      expect(cloned.geometry).not.toBe(geo);
+      expect(cloned.material).not.toBe(mat);
+      expect(cloned.geometry.positions).toEqual(geo.positions);
+      expect((cloned.material as PhongMaterial).diffuse).toEqual(vec3(1, 0, 0));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `Geometry.clone()` — 深拷贝所有 buffer（Float32Array/Uint16Array），null 字段保持 null
- `Material.clone()` — 拷贝 shader source + opacity/transparent
- `PhongMaterial.clone()` — Vec3 属性深拷贝，Texture 引用共享，返回 PhongMaterial 实例
- `Node3D.clone(recursive?)` — 值拷贝变换，recursive=true 递归克隆子树，clone 节点 parent=null
- `Mesh.clone(recursive?)` — shallow 共享 geometry/material，deep 时各自 clone

## Test plan

- [x] `test/unit/core/clone.test.ts` 14 个测试全部通过
- [x] 全量单元测试 1295 通过
- [x] 视觉回归测试 12 通过

close #177