### PR TITLE
feat: 实现 LineRenderer — LineGeometry/LineMaterial/Line (#178)

### DIFF
--- a/src/renderer/line-renderer.ts
+++ b/src/renderer/line-renderer.ts
@@ -4,13 +4,34 @@
  * 用于调试可视化（路径/包围盒/射线）和游戏效果（激光/轨迹/连线）。
  */
 
-export const __STUB__ = true;
-
 import { type Vec3, vec3 } from '../math/vec3';
 import { Node3D } from '../core/node3d';
 import { Material } from './material';
 
 export type LineDrawMode = 'LINES' | 'LINE_STRIP' | 'LINE_LOOP';
+
+// 线段顶点着色器：MVP 变换，逐顶点颜色直通
+const LINE_VERT_SRC = `
+attribute vec3 a_position;
+attribute vec3 a_color;
+uniform mat4 u_mvp;
+varying vec3 v_color;
+void main() {
+  gl_Position = u_mvp * vec4(a_position, 1.0);
+  v_color = a_color;
+}
+`.trim();
+
+// 线段片元着色器：v_color * u_color，u_opacity 控制透明度
+const LINE_FRAG_SRC = `
+precision mediump float;
+uniform vec3 u_color;
+uniform float u_opacity;
+varying vec3 v_color;
+void main() {
+  gl_FragColor = vec4(v_color * u_color, u_opacity);
+}
+`.trim();
 
 /**
  * LineGeometry — 线段顶点数据容器。
@@ -20,23 +41,36 @@ export class LineGeometry {
   positions: Float32Array;
   colors: Float32Array;
 
-  constructor(_opts: { points: Vec3[]; colors?: Vec3[] }) {
-    throw new Error('Not implemented');
+  constructor(opts: { points: Vec3[]; colors?: Vec3[] }) {
+    this.positions = LineGeometry._toBuffer(opts.points);
+    this.colors = opts.colors
+      ? LineGeometry._toBuffer(opts.colors)
+      : new Float32Array(opts.points.length * 3).fill(1);
   }
 
   /** 更新点列表（重新分配缓冲区） */
-  setPoints(_points: Vec3[]): void {
-    throw new Error('Not implemented');
+  setPoints(points: Vec3[]): void {
+    this.positions = LineGeometry._toBuffer(points);
   }
 
   /** 更新逐顶点颜色 */
-  setColors(_colors: Vec3[]): void {
-    throw new Error('Not implemented');
+  setColors(colors: Vec3[]): void {
+    this.colors = LineGeometry._toBuffer(colors);
   }
 
   /** 点数量 */
   get pointCount(): number {
-    throw new Error('Not implemented');
+    return this.positions.length / 3;
+  }
+
+  private static _toBuffer(vecs: Vec3[]): Float32Array {
+    const buf = new Float32Array(vecs.length * 3);
+    for (let i = 0; i < vecs.length; i++) {
+      buf[i * 3]     = vecs[i][0];
+      buf[i * 3 + 1] = vecs[i][1];
+      buf[i * 3 + 2] = vecs[i][2];
+    }
+    return buf;
   }
 }
 
@@ -49,9 +83,11 @@ export class LineMaterial extends Material {
   color: Vec3;
   lineWidth: number;
 
-  constructor(_opts?: { color?: Vec3; lineWidth?: number; opacity?: number }) {
-    super();
-    throw new Error('Not implemented');
+  constructor(opts?: { color?: Vec3; lineWidth?: number; opacity?: number }) {
+    super({ vertexShader: LINE_VERT_SRC, fragmentShader: LINE_FRAG_SRC });
+    this.color = opts?.color ?? vec3(1, 1, 1);
+    this.lineWidth = opts?.lineWidth ?? 1;
+    this.opacity = opts?.opacity ?? 1;
   }
 }
 
@@ -65,11 +101,13 @@ export class Line extends Node3D {
   drawMode: LineDrawMode;
 
   constructor(
-    _geometry: LineGeometry,
-    _material?: LineMaterial,
-    _drawMode?: LineDrawMode,
+    geometry: LineGeometry,
+    material?: LineMaterial,
+    drawMode?: LineDrawMode,
   ) {
     super('line');
-    throw new Error('Not implemented');
+    this.geometry = geometry;
+    this.material = material ?? new LineMaterial();
+    this.drawMode = drawMode ?? 'LINE_STRIP';
   }
 }


### PR DESCRIPTION
## Summary

- `LineGeometry`：将 `Vec3[]` 转为 `Float32Array`，支持逐顶点颜色，不指定时默认全白
- `LineMaterial`：继承 `Material`，统一颜色 `u_color`、`lineWidth`、`opacity`，内置 MVP 顶点/片元着色器
- `Line`：继承 `Node3D`，组合 geometry + material + drawMode（默认 `LINE_STRIP`）
- 支持三种绘制模式：`LINES`、`LINE_STRIP`、`LINE_LOOP`

## Test plan

- [x] `test/unit/renderer/line-renderer.test.ts` — 15 个测试全部通过
- [x] 全量单元测试 1296 个通过（85 个测试文件）

close #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)