### PR TITLE
feat: 实现 MathUtils 集中式数学工具函数 (#182)

### DIFF
--- a/src/math/utils.ts
+++ b/src/math/utils.ts
@@ -3,54 +3,61 @@
  * 纯函数，零依赖，覆盖游戏开发常用的数值操作。
  */
 
-export const __STUB__ = true;
-
 /** 将 value 限制在 [min, max] 范围内 */
-export function clamp(_value: number, _min: number, _max: number): number {
-  throw new Error('Not implemented');
+export function clamp(value: number, min: number, max: number): number {
+  return value < min ? min : value > max ? max : value;
 }
 
 /** 线性插值 a→b，t ∈ [0,1] */
-export function lerp(_a: number, _b: number, _t: number): number {
-  throw new Error('Not implemented');
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
 }
 
-/** 逆线性插值：给定 value 在 [a,b] 中的位置，返回 t */
-export function inverseLerp(_a: number, _b: number, _value: number): number {
-  throw new Error('Not implemented');
+/** 逆线性插值：给定 value 在 [a,b] 中的位置，返回 t；a===b 时返回 0 */
+export function inverseLerp(a: number, b: number, value: number): number {
+  const d = b - a;
+  return d === 0 ? 0 : (value - a) / d;
 }
 
-/** Hermite 平滑插值，edge0→edge1 之间返回 [0,1] */
-export function smoothstep(_edge0: number, _edge1: number, _x: number): number {
-  throw new Error('Not implemented');
+/** Hermite 平滑插值（3t²-2t³），edge0→edge1 之间返回 [0,1] */
+export function smoothstep(edge0: number, edge1: number, x: number): number {
+  const t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
+  return t * t * (3 - 2 * t);
 }
 
 /** 角度转弧度 */
-export function degToRad(_degrees: number): number {
-  throw new Error('Not implemented');
+export function degToRad(degrees: number): number {
+  return degrees * (Math.PI / 180);
 }
 
 /** 弧度转角度 */
-export function radToDeg(_radians: number): number {
-  throw new Error('Not implemented');
+export function radToDeg(radians: number): number {
+  return radians * (180 / Math.PI);
 }
 
 /** 将 value 从 [inMin, inMax] 映射到 [outMin, outMax] */
-export function mapRange(_value: number, _inMin: number, _inMax: number, _outMin: number, _outMax: number): number {
-  throw new Error('Not implemented');
+export function mapRange(value: number, inMin: number, inMax: number, outMin: number, outMax: number): number {
+  return outMin + (outMax - outMin) * ((value - inMin) / (inMax - inMin));
 }
 
 /** 返回 [min, max) 范围内的随机浮点数 */
-export function randomRange(_min: number, _max: number): number {
-  throw new Error('Not implemented');
+export function randomRange(min: number, max: number): number {
+  return min + Math.random() * (max - min);
 }
 
-/** 判断 n 是否为 2 的幂 */
-export function isPowerOfTwo(_n: number): boolean {
-  throw new Error('Not implemented');
+/** 判断 n 是否为 2 的幂（n > 0） */
+export function isPowerOfTwo(n: number): boolean {
+  return n > 0 && (n & (n - 1)) === 0;
 }
 
-/** 返回 ≥ n 的最小 2 的幂 */
-export function nextPowerOfTwo(_n: number): number {
-  throw new Error('Not implemented');
+/** 返回 ≥ n 的最小 2 的幂；nextPowerOfTwo(0) === 1 */
+export function nextPowerOfTwo(n: number): number {
+  if (n <= 1) return 1;
+  n--;
+  n |= n >> 1;
+  n |= n >> 2;
+  n |= n >> 4;
+  n |= n >> 8;
+  n |= n >> 16;
+  return n + 1;
 }


### PR DESCRIPTION
## Summary

实现 `src/math/utils.ts` 中的 10 个集中式数学工具函数：

- `clamp` — 限制值在 [min, max] 范围
- `lerp` — 线性插值
- `inverseLerp` — 逆线性插值（a===b 时返回 0）
- `smoothstep` — Hermite 平滑插值（3t²-2t³）
- `degToRad` / `radToDeg` — 角度弧度互转
- `mapRange` — 区间映射
- `randomRange` — 随机浮点数 [min, max)
- `isPowerOfTwo` — 判断 2 的幂
- `nextPowerOfTwo` — 取上界 2 的幂（0→1）

## Verification

30 个单元测试全部通过：
```
✓ test/unit/math/utils.test.ts (30 tests)
```

close #182