### PR TITLE
feat: 实现 Material 混合模式控制 BlendMode (#173)

### DIFF
--- a/src/renderer/bitmap-text.ts
+++ b/src/renderer/bitmap-text.ts
@@ -62,6 +62,8 @@ export class BitmapTextMaterial extends Material {
       fragmentShader: BITMAP_TEXT_FRAGMENT_SHADER,
     });
     this.color = opts?.color ?? vec3(1, 1, 1);
+    // 字体渲染需要 alpha 混合（通过 effectiveBlendMode 驱动）
+    this.transparent = true;
   }
 }
 

--- a/src/renderer/material.ts
+++ b/src/renderer/material.ts
@@ -3,6 +3,13 @@
  * Provides sensible defaults for vertex-colored 3D rendering with MVP transform.
  */
 
+export enum BlendMode {
+  None     = 'none',     // gl.disable(BLEND) — 完全不透明
+  Normal   = 'normal',   // SRC_ALPHA, ONE_MINUS_SRC_ALPHA — 标准 alpha 混合
+  Additive = 'additive', // SRC_ALPHA, ONE — 发光叠加
+  Multiply = 'multiply', // DST_COLOR, ZERO — 颜色相乘
+}
+
 export enum Side {
   Front  = 'front',
   Back   = 'back',
@@ -45,12 +52,27 @@ export class Material {
   depthTest: boolean = true;
   /** 是否渲染该材质的 mesh，默认 true */
   visible: boolean = true;
+  /** 混合模式，默认 None（不透明） */
+  blendMode: BlendMode = BlendMode.None;
 
   constructor(opts?: { vertexShader?: string; fragmentShader?: string }) {
     this.vertexShader   = opts?.vertexShader   ?? DEFAULT_VERTEX_SHADER;
     this.fragmentShader = opts?.fragmentShader ?? DEFAULT_FRAGMENT_SHADER;
     this.opacity      = 1;
     this.transparent  = false;
+  }
+
+  /**
+   * 解析实际生效的混合模式。
+   * 规则：
+   * - 如果 blendMode !== None → 返回 blendMode（显式设置优先）
+   * - 如果 transparent === true 且 blendMode === None → 返回 Normal（向后兼容）
+   * - 否则 → 返回 None
+   */
+  effectiveBlendMode(): BlendMode {
+    if (this.blendMode !== BlendMode.None) return this.blendMode;
+    if (this.transparent) return BlendMode.Normal;
+    return BlendMode.None;
   }
 
   /** 克隆材质（拷贝 shader source + opacity/transparent 属性） */

--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -14,7 +14,7 @@ import { SpotLight } from '../core/spot-light';
 import { Mesh } from './mesh';
 import { SkinnedMesh } from './skinned-mesh';
 import { Geometry } from './geometry';
-import { Material, Side } from './material';
+import { Material, Side, BlendMode } from './material';
 import { TextureMaterial } from './texture-material';
 import { Texture } from './texture';
 import { PhongMaterial } from './phong-material';
@@ -576,6 +576,25 @@ export class WebGLRenderer {
       gl.disable(gl.DEPTH_TEST);
     }
 
+    // 配置混合模式
+    switch (mat.effectiveBlendMode()) {
+      case BlendMode.None:
+        gl.disable(gl.BLEND);
+        break;
+      case BlendMode.Normal:
+        gl.enable(gl.BLEND);
+        gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+        break;
+      case BlendMode.Additive:
+        gl.enable(gl.BLEND);
+        gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+        break;
+      case BlendMode.Multiply:
+        gl.enable(gl.BLEND);
+        gl.blendFunc(gl.DST_COLOR, gl.ZERO);
+        break;
+    }
+
     const compiled  = this._getProgram(mesh.material);
     const uploaded  = this._getGeometry(mesh.geometry);
 
@@ -632,8 +651,6 @@ export class WebGLRenderer {
       }
       const uColor = gl.getUniformLocation(compiled.program, 'u_color');
       gl.uniform3fv(uColor, btMat.color);
-      gl.enable(gl.BLEND);
-      gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
     }
 
     // PhongMaterial 专用：绑定法线 + 传递光照 uniforms

--- a/test/unit/renderer/material-blend-modes.test.ts
+++ b/test/unit/renderer/material-blend-modes.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { Material, BlendMode } from '../../../src/renderer/material';
+import { PhongMaterial } from '../../../src/renderer/phong-material';
+
+describe('Material Blend Modes', () => {
+  describe('defaults', () => {
+    it('should default to BlendMode.None', () => {
+      const mat = new Material();
+      expect(mat.blendMode).toBe(BlendMode.None);
+    });
+  });
+
+  describe('configuration', () => {
+    it('should allow setting Normal blend mode', () => {
+      const mat = new Material();
+      mat.blendMode = BlendMode.Normal;
+      expect(mat.blendMode).toBe(BlendMode.Normal);
+    });
+
+    it('should allow setting Additive blend mode', () => {
+      const mat = new Material();
+      mat.blendMode = BlendMode.Additive;
+      expect(mat.blendMode).toBe(BlendMode.Additive);
+    });
+
+    it('should allow setting Multiply blend mode', () => {
+      const mat = new Material();
+      mat.blendMode = BlendMode.Multiply;
+      expect(mat.blendMode).toBe(BlendMode.Multiply);
+    });
+  });
+
+  describe('effectiveBlendMode()', () => {
+    it('transparent=true should imply Normal blend when blendMode is None', () => {
+      const mat = new Material();
+      mat.transparent = true;
+      expect(mat.effectiveBlendMode()).toBe(BlendMode.Normal);
+    });
+
+    it('explicit blendMode should override transparent flag', () => {
+      const mat = new Material();
+      mat.transparent = true;
+      mat.blendMode = BlendMode.Additive;
+      expect(mat.effectiveBlendMode()).toBe(BlendMode.Additive);
+    });
+
+    it('transparent=false with BlendMode.None should be no blending', () => {
+      const mat = new Material();
+      mat.transparent = false;
+      mat.blendMode = BlendMode.None;
+      expect(mat.effectiveBlendMode()).toBe(BlendMode.None);
+    });
+
+    it('non-transparent with explicit blend mode should use that mode', () => {
+      const mat = new Material();
+      mat.transparent = false;
+      mat.blendMode = BlendMode.Additive;
+      expect(mat.effectiveBlendMode()).toBe(BlendMode.Additive);
+    });
+  });
+
+  describe('inheritance', () => {
+    it('PhongMaterial should inherit blend mode default', () => {
+      const mat = new PhongMaterial();
+      expect(mat.blendMode).toBe(BlendMode.None);
+    });
+
+    it('PhongMaterial can set blend mode', () => {
+      const mat = new PhongMaterial();
+      mat.blendMode = BlendMode.Additive;
+      expect(mat.blendMode).toBe(BlendMode.Additive);
+      expect(mat.effectiveBlendMode()).toBe(BlendMode.Additive);
+    });
+  });
+});


### PR DESCRIPTION
## 变更内容

- 新增 `BlendMode` 枚举（`None` / `Normal` / `Additive` / `Multiply`）到 `src/renderer/material.ts`
- `Material` 基类添加 `blendMode` 属性（默认 `None`）和 `effectiveBlendMode()` 方法
- `effectiveBlendMode()` 向后兼容：`transparent=true` 且 `blendMode=None` 时自动返回 `Normal`
- `WebGLRenderer._drawMesh()` 统一通过 `effectiveBlendMode()` 配置 GL blend 状态（替代各处硬编码）
- `BitmapTextMaterial` 移除硬编码 alpha blend，改为设置 `transparent=true` 由统一机制驱动

## 测试

- 新增 10 个单元测试，全部通过
- 全量回归：1343 单元测试 + 12 视觉回归，0 失败

close #173