### PR TITLE
feat: 实现 AnimationAction 权重混合与淡入淡出过渡

### DIFF
--- a/src/animation/animation-action.ts
+++ b/src/animation/animation-action.ts
@@ -1,13 +1,12 @@
 /**
- * AnimationAction — weight-based animation playback with fade transitions.
- * Stub — to be implemented by Dev.
+ * AnimationAction — 基于权重的动画播放包装器，支持淡入淡出过渡。
  * @see test/unit/animation/animation-action.test.ts
  */
 
-export const __STUB__ = true;
-
 import type { AnimationClip } from './animation-clip';
 import type { Skeleton } from './skeleton';
+
+type FadeMode = 'none' | 'in' | 'out';
 
 export class AnimationAction {
   readonly clip: AnimationClip;
@@ -19,34 +18,151 @@ export class AnimationAction {
   enabled: boolean = true;
   clampWhenFinished: boolean = false;
 
+  private _time: number = 0;
+  private _isRunning: boolean = false;
+  private _fadeWeight: number = 1;
+  private _fadeMode: FadeMode = 'none';
+  private _fadeDuration: number = 0;
+  private _fadeElapsed: number = 0;
+  private _fadeStartWeight: number = 1;
+
   constructor(clip: AnimationClip, skeleton: Skeleton) {
     this.clip = clip;
     this.skeleton = skeleton;
   }
 
-  get time(): number { throw new Error('Not implemented'); }
-  set time(_v: number) { throw new Error('Not implemented'); }
-  get isRunning(): boolean { throw new Error('Not implemented'); }
-  get effectiveWeight(): number { throw new Error('Not implemented'); }
+  get time(): number { return this._time; }
+  set time(v: number) { this._time = v; }
 
-  play(): this { throw new Error('Not implemented'); }
-  stop(): this { throw new Error('Not implemented'); }
-  reset(): this { throw new Error('Not implemented'); }
+  get isRunning(): boolean { return this._isRunning; }
 
-  fadeIn(_duration: number): this { throw new Error('Not implemented'); }
-  fadeOut(_duration: number): this { throw new Error('Not implemented'); }
-  crossFadeTo(_action: AnimationAction, _duration: number): this { throw new Error('Not implemented'); }
+  get effectiveWeight(): number {
+    return this.weight * this._fadeWeight * (this.enabled ? 1 : 0);
+  }
 
-  /** Advance time and fade state. Called by mixer or manually. */
-  _update(_deltaTime: number): void { throw new Error('Not implemented'); }
+  play(): this {
+    this._isRunning = true;
+    return this;
+  }
+
+  stop(): this {
+    this._isRunning = false;
+    this._time = 0;
+    return this;
+  }
+
+  /** 重置时间和淡入淡出状态，保持运行状态不变 */
+  reset(): this {
+    this._time = 0;
+    this._fadeWeight = 1;
+    this._fadeMode = 'none';
+    this._fadeElapsed = 0;
+    return this;
+  }
+
+  /** 从 0 淡入到 1，持续 duration 秒 */
+  fadeIn(duration: number): this {
+    this._fadeMode = 'in';
+    this._fadeDuration = duration;
+    this._fadeElapsed = 0;
+    this._fadeWeight = 0;
+    return this;
+  }
+
+  /** 从当前权重淡出到 0，完成后停止 */
+  fadeOut(duration: number): this {
+    this._fadeStartWeight = this._fadeWeight;
+    this._fadeMode = 'out';
+    this._fadeDuration = duration;
+    this._fadeElapsed = 0;
+    return this;
+  }
+
+  crossFadeTo(action: AnimationAction, duration: number): this {
+    this.fadeOut(duration);
+    action.reset().fadeIn(duration).play();
+    return this;
+  }
+
+  /** 推进时间和淡入淡出状态 */
+  _update(deltaTime: number): void {
+    // 处理淡入淡出
+    if (this._fadeMode !== 'none') {
+      this._fadeElapsed += deltaTime;
+      const t = this._fadeDuration > 0
+        ? Math.min(this._fadeElapsed / this._fadeDuration, 1)
+        : 1;
+
+      if (this._fadeMode === 'in') {
+        this._fadeWeight = t;
+      } else {
+        this._fadeWeight = this._fadeStartWeight * (1 - t);
+      }
+
+      if (this._fadeElapsed >= this._fadeDuration) {
+        const wasFadeOut = this._fadeMode === 'out';
+        this._fadeMode = 'none';
+        if (wasFadeOut) {
+          this._fadeWeight = 0;
+          this._isRunning = false;
+        } else {
+          this._fadeWeight = 1;
+        }
+      }
+    }
+
+    // 推进时间
+    if (!this._isRunning) return;
+
+    this._time += deltaTime * this.timeScale;
+
+    if (this.loop) {
+      if (this.clip.duration > 0) {
+        this._time = this._time % this.clip.duration;
+      }
+    } else {
+      if (this._time > this.clip.duration) {
+        this._time = this.clip.duration;
+        if (!this.clampWhenFinished) {
+          this._isRunning = false;
+        }
+      }
+    }
+  }
 
   /**
-   * Sample clip tracks at current time. Returns per-bone transforms.
-   * positions: Float32Array(boneCount * 3)
-   * rotations: Float32Array(boneCount * 4)
-   * scales:    Float32Array(boneCount * 3)
+   * 在当前时间采样所有轨道，返回每根骨骼的变换数组。
+   * 无轨道覆盖的骨骼使用 skeleton 当前的局部变换。
    */
   _sample(): { positions: Float32Array; rotations: Float32Array; scales: Float32Array } {
-    throw new Error('Not implemented');
+    const n = this.skeleton.boneCount;
+    const positions = new Float32Array(n * 3);
+    const rotations = new Float32Array(n * 4);
+    const scales = new Float32Array(n * 3);
+
+    // 默认使用骨骼当前变换
+    positions.set(this.skeleton.localPositions);
+    rotations.set(this.skeleton.localRotations);
+    scales.set(this.skeleton.localScales);
+
+    // 按轨道覆盖
+    for (const track of this.clip.tracks) {
+      const { targetPath, jointIndex } = track;
+      if (targetPath === 'translation') {
+        const out = new Float32Array(3);
+        track.sample(this._time, out);
+        positions.set(out, jointIndex * 3);
+      } else if (targetPath === 'rotation') {
+        const out = new Float32Array(4);
+        track.sample(this._time, out);
+        rotations.set(out, jointIndex * 4);
+      } else {
+        const out = new Float32Array(3);
+        track.sample(this._time, out);
+        scales.set(out, jointIndex * 3);
+      }
+    }
+
+    return { positions, rotations, scales };
   }
 }

--- a/src/animation/animation-mixer.ts
+++ b/src/animation/animation-mixer.ts
@@ -1,10 +1,13 @@
 /**
  * AnimationMixer — 动画播放引擎，驱动 Skeleton 按关键帧轨道更新。
+ * 支持单片段播放和多 AnimationAction 权重混合。
  * @see test/unit/animation/animation-mixer.test.ts
+ * @see test/unit/animation/animation-mixer-blending.test.ts
  */
 
 import { Skeleton } from './skeleton';
 import { AnimationClip } from './animation-clip';
+import { AnimationAction } from './animation-action';
 
 export class AnimationMixer {
   readonly skeleton: Skeleton;
@@ -13,9 +16,20 @@ export class AnimationMixer {
   private _time: number = 0;
   private _loop: boolean = false;
   private _speed: number = 1;
+  private _actions: AnimationAction[] = [];
 
   constructor(skeleton: Skeleton) {
     this.skeleton = skeleton;
+  }
+
+  /** 创建或复用与 clip 关联的 AnimationAction */
+  clipAction(clip: AnimationClip): AnimationAction {
+    let action = this._actions.find(a => a.clip === clip);
+    if (!action) {
+      action = new AnimationAction(clip, this.skeleton);
+      this._actions.push(action);
+    }
+    return action;
   }
 
   play(clip: AnimationClip, options?: { loop?: boolean; speed?: number }): void {
@@ -31,6 +45,13 @@ export class AnimationMixer {
   }
 
   update(deltaTime: number): void {
+    // 多 Action 混合模式
+    if (this._actions.length > 0) {
+      this._updateActions(deltaTime);
+      return;
+    }
+
+    // 单片段兼容模式
     if (!this._isPlaying || !this._clip) return;
 
     this._time += deltaTime * this._speed;
@@ -46,7 +67,6 @@ export class AnimationMixer {
       }
     }
 
-    // 对每个轨道采样并写入骨骼
     for (const track of this._clip.tracks) {
       const { targetPath, jointIndex } = track;
       if (targetPath === 'translation') {
@@ -62,6 +82,35 @@ export class AnimationMixer {
         track.sample(this._time, out);
         this.skeleton.localScales.set(out, jointIndex * 3);
       }
+    }
+
+    this.skeleton.update();
+  }
+
+  /** 推进所有 Action 并按权重混合写入骨骼 */
+  private _updateActions(deltaTime: number): void {
+    const n = this.skeleton.boneCount;
+    const blendedPos = new Float32Array(n * 3);
+    const blendedRot = new Float32Array(n * 4);
+    const blendedScl = new Float32Array(n * 3);
+    let totalWeight = 0;
+
+    for (const action of this._actions) {
+      action._update(deltaTime);
+      const ew = action.effectiveWeight;
+      if (ew <= 0) continue;
+
+      const { positions, rotations, scales } = action._sample();
+      for (let i = 0; i < n * 3; i++) blendedPos[i] += ew * positions[i];
+      for (let i = 0; i < n * 4; i++) blendedRot[i] += ew * rotations[i];
+      for (let i = 0; i < n * 3; i++) blendedScl[i] += ew * scales[i];
+      totalWeight += ew;
+    }
+
+    if (totalWeight > 0) {
+      for (let i = 0; i < n * 3; i++) this.skeleton.localPositions[i] = blendedPos[i] / totalWeight;
+      for (let i = 0; i < n * 4; i++) this.skeleton.localRotations[i] = blendedRot[i] / totalWeight;
+      for (let i = 0; i < n * 3; i++) this.skeleton.localScales[i] = blendedScl[i] / totalWeight;
     }
 
     this.skeleton.update();

--- a/test/unit/animation/animation-mixer-blending.test.ts
+++ b/test/unit/animation/animation-mixer-blending.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { AnimationAction } from '../../../src/animation/animation-action';
+import { AnimationClip } from '../../../src/animation/animation-clip';
+import { AnimationMixer } from '../../../src/animation/animation-mixer';
+import { KeyframeTrack } from '../../../src/animation/keyframe-track';
+import { Skeleton } from '../../../src/animation/skeleton';
+
+const EPSILON = 1e-4;
+function near(a: number, b: number) { return Math.abs(a - b) < EPSILON; }
+
+function identityMat4() {
+  const m = new Float32Array(16);
+  m[0] = 1; m[5] = 1; m[10] = 1; m[15] = 1;
+  return m;
+}
+
+function createSkeleton() {
+  const bones = [{ name: 'root', parentIndex: -1 }];
+  const ibm = new Float32Array(16);
+  ibm.set(identityMat4(), 0);
+  return new Skeleton(bones, ibm);
+}
+
+describe('AnimationMixer — action blending', () => {
+  it('clipAction should return an AnimationAction', () => {
+    const sk = createSkeleton();
+    const mixer = new AnimationMixer(sk);
+    const clip = new AnimationClip('walk', [
+      new KeyframeTrack({
+        targetPath: 'translation', jointIndex: 0,
+        times: new Float32Array([0, 1]),
+        values: new Float32Array([0,0,0, 1,0,0]),
+      }),
+    ]);
+    const action = mixer.clipAction(clip);
+    expect(action).toBeInstanceOf(AnimationAction);
+    expect(action.clip).toBe(clip);
+  });
+
+  it('should blend two actions by weight into skeleton', () => {
+    const sk = createSkeleton();
+    const mixer = new AnimationMixer(sk);
+
+    const walkClip = new AnimationClip('walk', [
+      new KeyframeTrack({
+        targetPath: 'translation', jointIndex: 0,
+        times: new Float32Array([0, 1]),
+        values: new Float32Array([0,0,0, 2,0,0]),
+      }),
+    ]);
+    const jumpClip = new AnimationClip('jump', [
+      new KeyframeTrack({
+        targetPath: 'translation', jointIndex: 0,
+        times: new Float32Array([0, 1]),
+        values: new Float32Array([0,0,0, 0,4,0]),
+      }),
+    ]);
+
+    const walkAction = mixer.clipAction(walkClip);
+    const jumpAction = mixer.clipAction(jumpClip);
+
+    walkAction.weight = 0.5;
+    jumpAction.weight = 0.5;
+    walkAction.loop = true;
+    jumpAction.loop = true;
+    walkAction.play();
+    jumpAction.play();
+
+    mixer.update(0.5);
+
+    // At t=0.5: walk=(1,0,0), jump=(0,2,0)
+    // Blended 50/50: (0.5, 1.0, 0)
+    expect(near(sk.localPositions[0], 0.5)).toBe(true);
+    expect(near(sk.localPositions[1], 1.0)).toBe(true);
+    expect(near(sk.localPositions[2], 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- 实现 `AnimationAction` 类，支持权重混合动画播放与平滑过渡
- 增强 `AnimationMixer`，新增 `clipAction()` 工厂方法与多 Action 权重归一化混合
- 新增 `test/unit/animation/animation-mixer-blending.test.ts`（Issue body 中的 B 类测试）

## 关键实现细节

- `effectiveWeight = weight × _fadeWeight × (enabled ? 1 : 0)`
- `fadeIn` 立即将 `_fadeWeight` 设为 0，线性插值至 1
- `fadeOut` 从当前权重线性插值至 0，完成时停止 Action
- `crossFadeTo` = `this.fadeOut(duration)` + `target.reset().fadeIn(duration).play()`
- 时间结束条件使用严格 `>` 比较（恰好等于 duration 不停止，确保 crossFade 边界正确）
- AnimationMixer 多 Action 模式：归一化权重混合位置/旋转/缩放

## 测试结果

- `animation-action.test.ts`: 20/20 通过
- `animation-mixer-blending.test.ts`: 2/2 通过
- 全量单元测试: 1410/1410 通过

close #188