### PR TITLE
feat: WebGLRenderer Line & Sprite 渲染集成 (#194)

### DIFF
--- a/src/renderer/line-renderer.ts
+++ b/src/renderer/line-renderer.ts
@@ -41,21 +41,36 @@ export class LineGeometry {
   positions: Float32Array;
   colors: Float32Array;
 
-  constructor(opts: { points: Vec3[]; colors?: Vec3[] }) {
-    this.positions = LineGeometry._toBuffer(opts.points);
-    this.colors = opts.colors
-      ? LineGeometry._toBuffer(opts.colors)
-      : new Float32Array(opts.points.length * 3).fill(1);
+  private _pts: Vec3[];
+  private _cols: Vec3[];
+
+  constructor(opts?: { points?: Vec3[]; colors?: Vec3[] }) {
+    const points = opts?.points ?? [];
+    const colors = opts?.colors;
+    this._pts = [...points];
+    this._cols = colors ? [...colors] : points.map(() => vec3(1, 1, 1));
+    this.positions = LineGeometry._toBuffer(this._pts);
+    this.colors = LineGeometry._toBuffer(this._cols);
+  }
+
+  /** 追加一个顶点及其可选颜色 */
+  addPoint(position: Vec3, color?: Vec3): void {
+    this._pts.push(position);
+    this._cols.push(color ?? vec3(1, 1, 1));
+    this.positions = LineGeometry._toBuffer(this._pts);
+    this.colors = LineGeometry._toBuffer(this._cols);
   }
 
   /** 更新点列表（重新分配缓冲区） */
   setPoints(points: Vec3[]): void {
-    this.positions = LineGeometry._toBuffer(points);
+    this._pts = [...points];
+    this.positions = LineGeometry._toBuffer(this._pts);
   }
 
   /** 更新逐顶点颜色 */
   setColors(colors: Vec3[]): void {
-    this.colors = LineGeometry._toBuffer(colors);
+    this._cols = [...colors];
+    this.colors = LineGeometry._toBuffer(this._cols);
   }
 
   /** 点数量 */

--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -19,6 +19,8 @@ import { TextureMaterial } from './texture-material';
 import { Texture } from './texture';
 import { PhongMaterial } from './phong-material';
 import { BitmapTextMaterial } from './bitmap-text';
+import { Line, LineMaterial } from './line-renderer';
+import { Sprite, SpriteMaterial } from './sprite';
 
 // ── Internal GPU resource cache ──────────────────────────────────
 
@@ -81,6 +83,40 @@ interface UploadedGeometry {
   jointsBuffer: WebGLBuffer | null;
   weightsBuffer: WebGLBuffer | null;
 }
+
+// ── Line program cache ───────────────────────────────────────────
+
+interface LineProgramInfo {
+  program: WebGLProgram;
+  aPosition: number;
+  aColor: number;
+  uMvp: WebGLUniformLocation;
+  uColor: WebGLUniformLocation | null;
+  uOpacity: WebGLUniformLocation | null;
+}
+
+// ── Sprite program cache ─────────────────────────────────────────
+
+interface SpriteProgramInfo {
+  program: WebGLProgram;
+  aPosition: number;
+  aUv: number;
+  uModelView: WebGLUniformLocation | null;
+  uProjection: WebGLUniformLocation | null;
+  uColor: WebGLUniformLocation | null;
+  uOpacity: WebGLUniformLocation | null;
+  uHasTexture: WebGLUniformLocation | null;
+  uTexture: WebGLUniformLocation | null;
+}
+
+interface SpriteQuad {
+  positionBuffer: WebGLBuffer;
+  uvBuffer: WebGLBuffer;
+  indexBuffer: WebGLBuffer;
+}
+
+// WebGL 1.0 LINE_LOOP 常量（mock 中可能未定义）
+const GL_LINE_LOOP = 0x0002;
 
 const MAX_BONES = 32;
 
@@ -205,6 +241,9 @@ export class WebGLRenderer {
   private geometryCache: WeakMap<Geometry, UploadedGeometry> = new WeakMap();
   private textureCache: WeakMap<Texture, WebGLTexture> = new WeakMap();
   private skinningProgram: SkinningProgram | null = null;
+  private lineProgramCache: WeakMap<LineMaterial, LineProgramInfo> = new WeakMap();
+  private spriteProgramCache: WeakMap<SpriteMaterial, SpriteProgramInfo> = new WeakMap();
+  private spriteQuad: SpriteQuad | null = null;
 
   constructor(canvas: HTMLCanvasElement) {
     const gl = canvas.getContext('webgl', {
@@ -299,11 +338,26 @@ export class WebGLRenderer {
 
     const viewProj = camera.viewProjectionMatrix;
 
+    const lines: Line[] = [];
+    const sprites: Sprite[] = [];
+
     scene.traverse((node) => {
       if (node instanceof Mesh) {
         this._drawMesh(node, viewProj, lightCtx);
+      } else if (node instanceof Line) {
+        lines.push(node);
+      } else if (node instanceof Sprite) {
+        sprites.push(node);
       }
     });
+
+    // Line 和 Sprite 在所有 Mesh 之后渲染（叠加行为）
+    for (const line of lines) {
+      this._drawLine(line, viewProj);
+    }
+    for (const sprite of sprites) {
+      this._drawSprite(sprite, camera);
+    }
   }
 
   /** Release all GPU resources. */
@@ -841,5 +895,195 @@ export class WebGLRenderer {
     } else {
       gl.drawArrays(gl.TRIANGLES, 0, uploaded.vertexCount);
     }
+  }
+
+  // ── Line rendering ────────────────────────────────────────────────
+
+  private _getLineProgramInfo(mat: LineMaterial): LineProgramInfo {
+    const cached = this.lineProgramCache.get(mat);
+    if (cached) return cached;
+
+    const gl = this.gl;
+    const vs = compileShader(gl, gl.VERTEX_SHADER, mat.vertexShader);
+    const fs = compileShader(gl, gl.FRAGMENT_SHADER, mat.fragmentShader);
+    const program = createProgram(gl, vs, fs);
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+
+    const uMvpLoc = gl.getUniformLocation(program, 'u_mvp');
+    if (!uMvpLoc) throw new Error('Line shader must define uniform mat4 u_mvp');
+
+    const info: LineProgramInfo = {
+      program,
+      aPosition: gl.getAttribLocation(program, 'a_position'),
+      aColor:    gl.getAttribLocation(program, 'a_color'),
+      uMvp:      uMvpLoc,
+      uColor:    gl.getUniformLocation(program, 'u_color'),
+      uOpacity:  gl.getUniformLocation(program, 'u_opacity'),
+    };
+    this.lineProgramCache.set(mat, info);
+    return info;
+  }
+
+  private _drawLine(line: Line, viewProj: Mat4): void {
+    if (!line.visible) return;
+
+    const gl = this.gl;
+    const geo = line.geometry;
+    const vertexCount = geo.positions.length / 3;
+    if (vertexCount === 0) return;
+
+    const mat = line.material;
+    const prog = this._getLineProgramInfo(mat);
+
+    // 上传顶点缓冲区（Line 几何可能动态变化，每帧创建）
+    const posBuffer = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, posBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, geo.positions, gl.DYNAMIC_DRAW);
+
+    const colBuffer = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, colBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, geo.colors, gl.DYNAMIC_DRAW);
+
+    const mvp = multiply(viewProj, line.worldMatrix);
+
+    gl.useProgram(prog.program);
+    gl.uniformMatrix4fv(prog.uMvp, false, mvp);
+    if (prog.uColor)   gl.uniform3fv(prog.uColor, mat.color);
+    if (prog.uOpacity) gl.uniform1f(prog.uOpacity, mat.opacity);
+
+    if (prog.aPosition >= 0) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, posBuffer);
+      gl.enableVertexAttribArray(prog.aPosition);
+      gl.vertexAttribPointer(prog.aPosition, 3, gl.FLOAT, false, 0, 0);
+    }
+    if (prog.aColor >= 0) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, colBuffer);
+      gl.enableVertexAttribArray(prog.aColor);
+      gl.vertexAttribPointer(prog.aColor, 3, gl.FLOAT, false, 0, 0);
+    }
+
+    const glMode = line.drawMode === 'LINES'      ? gl.LINES
+                 : line.drawMode === 'LINE_STRIP'  ? gl.LINE_STRIP
+                 : GL_LINE_LOOP;
+
+    gl.drawArrays(glMode, 0, vertexCount);
+
+    gl.deleteBuffer(posBuffer);
+    gl.deleteBuffer(colBuffer);
+  }
+
+  // ── Sprite rendering ──────────────────────────────────────────────
+
+  private _getSpriteProgramInfo(mat: SpriteMaterial): SpriteProgramInfo {
+    const cached = this.spriteProgramCache.get(mat);
+    if (cached) return cached;
+
+    const gl = this.gl;
+    const vs = compileShader(gl, gl.VERTEX_SHADER, mat.vertexShader);
+    const fs = compileShader(gl, gl.FRAGMENT_SHADER, mat.fragmentShader);
+    const program = createProgram(gl, vs, fs);
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+
+    const info: SpriteProgramInfo = {
+      program,
+      aPosition:   gl.getAttribLocation(program, 'a_position'),
+      aUv:         gl.getAttribLocation(program, 'a_uv'),
+      uModelView:  gl.getUniformLocation(program, 'u_modelView'),
+      uProjection: gl.getUniformLocation(program, 'u_projection'),
+      uColor:      gl.getUniformLocation(program, 'u_color'),
+      uOpacity:    gl.getUniformLocation(program, 'u_opacity'),
+      uHasTexture: gl.getUniformLocation(program, 'u_hasTexture'),
+      uTexture:    gl.getUniformLocation(program, 'u_texture'),
+    };
+    this.spriteProgramCache.set(mat, info);
+    return info;
+  }
+
+  private _getSpriteQuad(): SpriteQuad {
+    if (this.spriteQuad) return this.spriteQuad;
+
+    const gl = this.gl;
+
+    // 单位四边形：4 顶点，中心在原点
+    const positions = new Float32Array([
+      -0.5, -0.5, 0,
+       0.5, -0.5, 0,
+       0.5,  0.5, 0,
+      -0.5,  0.5, 0,
+    ]);
+    const uvs = new Float32Array([
+      0, 0,
+      1, 0,
+      1, 1,
+      0, 1,
+    ]);
+    const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);
+
+    const positionBuffer = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+
+    const uvBuffer = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, uvs, gl.STATIC_DRAW);
+
+    const indexBuffer = gl.createBuffer()!;
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+
+    this.spriteQuad = { positionBuffer, uvBuffer, indexBuffer };
+    return this.spriteQuad;
+  }
+
+  private _drawSprite(sprite: Sprite, camera: Camera): void {
+    if (!sprite.visible) return;
+
+    const gl = this.gl;
+    const mat = sprite.material;
+
+    const quad = this._getSpriteQuad();
+    const prog = this._getSpriteProgramInfo(mat);
+
+    // 开启 alpha 混合
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+    // modelView = viewMatrix × worldMatrix
+    const modelView = multiply(camera.viewMatrix, sprite.worldMatrix);
+
+    gl.useProgram(prog.program);
+    if (prog.uModelView)  gl.uniformMatrix4fv(prog.uModelView, false, modelView);
+    if (prog.uProjection) gl.uniformMatrix4fv(prog.uProjection, false, camera.projectionMatrix);
+    if (prog.uColor)      gl.uniform3fv(prog.uColor, mat.color);
+    if (prog.uOpacity)    gl.uniform1f(prog.uOpacity, mat.opacity);
+
+    if (mat.texture) {
+      if (prog.uHasTexture) gl.uniform1f(prog.uHasTexture, 1.0);
+      const webglTex = this._getWebGLTexture(mat.texture);
+      gl.activeTexture(gl.TEXTURE0);
+      gl.bindTexture(gl.TEXTURE_2D, webglTex);
+      if (prog.uTexture) gl.uniform1i(prog.uTexture, 0);
+    } else {
+      if (prog.uHasTexture) gl.uniform1f(prog.uHasTexture, 0.0);
+    }
+
+    if (prog.aPosition >= 0) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, quad.positionBuffer);
+      gl.enableVertexAttribArray(prog.aPosition);
+      gl.vertexAttribPointer(prog.aPosition, 3, gl.FLOAT, false, 0, 0);
+    }
+    if (prog.aUv >= 0) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, quad.uvBuffer);
+      gl.enableVertexAttribArray(prog.aUv);
+      gl.vertexAttribPointer(prog.aUv, 2, gl.FLOAT, false, 0, 0);
+    }
+
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, quad.indexBuffer);
+    gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
+
+    // 恢复混合状态
+    gl.disable(gl.BLEND);
   }
 }

--- a/test/unit/renderer/renderer-line-sprite.test.ts
+++ b/test/unit/renderer/renderer-line-sprite.test.ts
@@ -1,0 +1,159 @@
+/**
+ * WebGLRenderer — Line & Sprite 渲染集成测试
+ * 验证 render() 自动渲染 Line 和 Sprite 节点。
+ */
+import { describe, it, expect } from 'vitest';
+import { createMockCanvas } from '../../helpers/mock-gl';
+import { WebGLRenderer } from '../../../src/renderer/webgl-renderer';
+import { Scene } from '../../../src/core/scene';
+import { PerspectiveCamera } from '../../../src/core/camera';
+import { Mesh } from '../../../src/renderer/mesh';
+import { Geometry } from '../../../src/renderer/geometry';
+import { Material } from '../../../src/renderer/material';
+import { Line, LineGeometry, LineMaterial } from '../../../src/renderer/line-renderer';
+import { Sprite, SpriteMaterial } from '../../../src/renderer/sprite';
+import { vec3 } from '../../../src/math/vec3';
+import { Texture } from '../../../src/renderer/texture';
+
+/* ── helpers ─────────────────────────────────────────────────── */
+
+function makeCamera(): PerspectiveCamera {
+  return new PerspectiveCamera({ fov: Math.PI / 3, aspect: 4 / 3, near: 0.1, far: 100 });
+}
+
+function makeTriGeo(): Geometry {
+  return new Geometry({ positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]) });
+}
+
+function makeLine(mode: 'LINES' | 'LINE_STRIP' | 'LINE_LOOP' = 'LINES'): Line {
+  const geo = new LineGeometry();
+  geo.addPoint(vec3(0, 0, 0), vec3(1, 0, 0));
+  geo.addPoint(vec3(1, 0, 0), vec3(0, 1, 0));
+  geo.addPoint(vec3(1, 1, 0), vec3(0, 0, 1));
+  geo.addPoint(vec3(0, 1, 0), vec3(1, 1, 0));
+  return new Line(geo, new LineMaterial({ color: vec3(1, 0, 0) }), mode);
+}
+
+function makeSprite(): Sprite {
+  return new Sprite(new SpriteMaterial({ color: vec3(0, 1, 0), opacity: 0.8 }));
+}
+
+/* ── Line rendering ──────────────────────────────────────────── */
+
+describe('WebGLRenderer Line rendering', () => {
+  it('should render a Line node in the scene', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(makeLine());
+    renderer.render(scene, makeCamera());
+    // At least one draw call for the line
+    expect(gl._drawCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should issue drawArrays (not drawElements) for Lines', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(makeLine());
+    renderer.render(scene, makeCamera());
+    const lineDraws = gl._drawCalls.filter(d => d.type === 'drawArrays');
+    expect(lineDraws.length).toBe(1);
+    expect(lineDraws[0].count).toBe(4); // 4 vertices
+  });
+
+  it('should not render a Line with visible=false', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const line = makeLine();
+    line.visible = false;
+    scene.addChild(line);
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBe(0);
+  });
+
+  it('should handle LINE_STRIP mode', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(makeLine('LINE_STRIP'));
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+/* ── Sprite rendering ────────────────────────────────────────── */
+
+describe('WebGLRenderer Sprite rendering', () => {
+  it('should render a Sprite node in the scene', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(makeSprite());
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should enable blending for Sprites', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(makeSprite());
+    renderer.render(scene, makeCamera());
+    expect(gl._calls['enable']).toBeGreaterThanOrEqual(2); // DEPTH_TEST + BLEND
+    expect(gl._calls['blendFunc'] || gl._calls['blendFuncSeparate']).toBeTruthy();
+  });
+
+  it('should not render a Sprite with visible=false', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const sprite = makeSprite();
+    sprite.visible = false;
+    scene.addChild(sprite);
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBe(0);
+  });
+
+  it('should render Sprite with texture', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const tex = Texture.checkerboard(2, 2);
+    const sprite = new Sprite(new SpriteMaterial({ texture: tex }));
+    scene.addChild(sprite);
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBeGreaterThanOrEqual(1);
+    expect(gl._calls['bindTexture']).toBeGreaterThanOrEqual(1);
+  });
+});
+
+/* ── Mixed scene ─────────────────────────────────────────────── */
+
+describe('WebGLRenderer mixed scene (Mesh + Line + Sprite)', () => {
+  it('should render all three types in one frame', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeTriGeo(), new Material()));
+    scene.addChild(makeLine());
+    scene.addChild(makeSprite());
+    renderer.render(scene, makeCamera());
+    // 3 draw calls minimum: 1 mesh + 1 line + 1 sprite
+    expect(gl._drawCalls.length).toBe(3);
+  });
+
+  it('should render Lines and Sprites that are children of Mesh nodes', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const parent = new Mesh(makeTriGeo(), new Material());
+    parent.addChild(makeLine());
+    parent.addChild(makeSprite());
+    scene.addChild(parent);
+    renderer.render(scene, makeCamera());
+    // 3 draw calls: 1 mesh parent + 1 child line + 1 child sprite
+    expect(gl._drawCalls.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- `LineGeometry` 支持无参构造器 + `addPoint(position, color?)` 方法动态添加顶点
- `WebGLRenderer.render()` 扩展场景图遍历，在 Mesh 渲染完后批量渲染 Line 和 Sprite 节点
- **Line 渲染**：独立 shader 程序缓存，`drawArrays` 支持 LINES / LINE_STRIP / LINE_LOOP 三种模式
- **Sprite 渲染**：共享单位四边形 quad，开启 alpha 混合（SRC_ALPHA / ONE_MINUS_SRC_ALPHA），支持可选纹理
- 两者均遵守 `node.visible = false` 跳过规则，draw call 顺序：Mesh → Line → Sprite

## Test plan

- [x] `pnpm run test` 全量通过（1445 passed / 16 skipped）
- [x] `pnpm build` 编译通过
- [x] 目标测试 `renderer-line-sprite.test.ts` 10/10 通过
  - Line 渲染：drawArrays、visible=false、LINE_STRIP 模式
  - Sprite 渲染：blending 开启、visible=false、纹理绑定
  - 混合场景：Mesh+Line+Sprite 3 次 draw call、子节点场景图

close #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)