### PR TITLE
feat: 实现 Node3D 世界空间变换辅助方法

### DIFF
--- a/src/core/node3d.ts
+++ b/src/core/node3d.ts
@@ -96,6 +96,77 @@ export class Node3D {
     return null;
   }
 
+  /** 提取世界空间位置（worldMatrix 第 3 列的 tx, ty, tz）。 */
+  getWorldPosition(): Vec3 {
+    const m = this.worldMatrix;
+    return vec3(m[12], m[13], m[14]);
+  }
+
+  /**
+   * 将局部方向向量通过 worldMatrix 的左上 3×3 旋转部分变换到世界空间，并归一化。
+   * 默认局部前向为 (0, 0, -1)。
+   */
+  getWorldDirection(localDir?: Vec3): Vec3 {
+    const dir = localDir ?? vec3(0, 0, -1);
+    const m = this.worldMatrix;
+    const x = dir[0], y = dir[1], z = dir[2];
+    const wx = m[0] * x + m[4] * y + m[8] * z;
+    const wy = m[1] * x + m[5] * y + m[9] * z;
+    const wz = m[2] * x + m[6] * y + m[10] * z;
+    const len = Math.sqrt(wx * wx + wy * wy + wz * wz);
+    if (len === 0) return vec3(0, 0, -1);
+    return vec3(wx / len, wy / len, wz / len);
+  }
+
+  /**
+   * 设置节点旋转使其 -Z 轴朝向目标世界坐标。
+   * 仅修改 this.rotation（欧拉角），不改变 this.position。
+   * up 默认 (0, 1, 0)。
+   */
+  lookAt(target: Vec3, up?: Vec3): void {
+    const worldPos = this.getWorldPosition();
+    const dx = target[0] - worldPos[0];
+    const dy = target[1] - worldPos[1];
+    const dz = target[2] - worldPos[2];
+    const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (dist < 1e-10) return;
+
+    // 前向向量（指向目标）
+    const fx = dx / dist, fy = dy / dist, fz = dz / dist;
+
+    // 确定 up 向量，避免与 forward 平行
+    let upx = up ? up[0] : 0;
+    let upy = up ? up[1] : 1;
+    let upz = up ? up[2] : 0;
+    const dotFU = fx * upx + fy * upy + fz * upz;
+    if (Math.abs(dotFU) > 0.999) {
+      // forward 与 up 几乎平行，换备用 up
+      upx = 0; upy = 0; upz = 1;
+    }
+
+    // right = forward × up，归一化
+    let rx = fy * upz - fz * upy;
+    let ry = fz * upx - fx * upz;
+    let rz = fx * upy - fy * upx;
+    const rlen = Math.sqrt(rx * rx + ry * ry + rz * rz);
+    rx /= rlen; ry /= rlen; rz /= rlen;
+
+    // 重新计算 up = right × forward
+    const ux = ry * fz - rz * fy;
+    const uy = rz * fx - rx * fz;
+    // uz not needed for euler extraction
+
+    // 从旋转矩阵提取 YXZ 欧拉角
+    // col 2 = [-fx, -fy, -fz]（局部 +Z 轴方向），即 [sy*cx, -sx, cy*cx]
+    // col 0 = [rx, ry, rz]（局部 +X 轴），即 [*, cx*sz, *]
+    // col 1 = [ux, uy, *]（局部 +Y 轴），即 [*, cx*cz, *]
+    const eulerX = Math.asin(Math.max(-1, Math.min(1, fy)));
+    const eulerY = Math.atan2(-fx, -fz);
+    const eulerZ = Math.atan2(ry, uy);
+
+    this.rotation = vec3(eulerX, eulerY, eulerZ);
+  }
+
   /**
    * 克隆节点。克隆出的节点 parent 为 null（脱离原场景图）。
    * @param recursive 默认 false — 不克隆子节点；true — 递归深克隆整棵子树

--- a/test/unit/core/node3d-helpers.test.ts
+++ b/test/unit/core/node3d-helpers.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { Node3D } from '../../../src/core/node3d';
+import { vec3, length, sub, normalize } from '../../../src/math/vec3';
+
+const EPSILON = 1e-4;
+function near(a: number, b: number) { return Math.abs(a - b) < EPSILON; }
+
+describe('Node3D — getWorldPosition', () => {
+  it('should return position for root node', () => {
+    const node = new Node3D('a');
+    node.position = vec3(3, 4, 5);
+    const wp = node.getWorldPosition();
+    expect(near(wp[0], 3)).toBe(true);
+    expect(near(wp[1], 4)).toBe(true);
+    expect(near(wp[2], 5)).toBe(true);
+  });
+
+  it('should include parent transform', () => {
+    const parent = new Node3D('p');
+    parent.position = vec3(10, 0, 0);
+    const child = new Node3D('c');
+    child.position = vec3(0, 5, 0);
+    parent.addChild(child);
+    const wp = child.getWorldPosition();
+    expect(near(wp[0], 10)).toBe(true);
+    expect(near(wp[1], 5)).toBe(true);
+    expect(near(wp[2], 0)).toBe(true);
+  });
+
+  it('should include parent scale', () => {
+    const parent = new Node3D('p');
+    parent.scale = vec3(2, 2, 2);
+    const child = new Node3D('c');
+    child.position = vec3(1, 0, 0);
+    parent.addChild(child);
+    const wp = child.getWorldPosition();
+    expect(near(wp[0], 2)).toBe(true);
+  });
+});
+
+describe('Node3D — getWorldDirection', () => {
+  it('should return default forward (0,0,-1) for identity node', () => {
+    const node = new Node3D('a');
+    const dir = node.getWorldDirection();
+    expect(near(dir[0], 0)).toBe(true);
+    expect(near(dir[1], 0)).toBe(true);
+    expect(near(dir[2], -1)).toBe(true);
+  });
+
+  it('should reflect rotation', () => {
+    const node = new Node3D('a');
+    node.rotation = vec3(0, Math.PI / 2, 0); // 90° around Y
+    const dir = node.getWorldDirection();
+    // Forward (0,0,-1) rotated 90° around Y → (-1, 0, 0)
+    expect(near(dir[0], -1)).toBe(true);
+    expect(near(dir[1], 0)).toBe(true);
+    expect(near(dir[2], 0, 0.01)).toBe(true);
+  });
+
+  it('should accept custom local direction', () => {
+    const node = new Node3D('a');
+    const right = node.getWorldDirection(vec3(1, 0, 0));
+    expect(near(right[0], 1)).toBe(true);
+    expect(near(right[1], 0)).toBe(true);
+    expect(near(right[2], 0)).toBe(true);
+  });
+});
+
+describe('Node3D — lookAt', () => {
+  it('should face target on same Y plane', () => {
+    const node = new Node3D('a');
+    node.position = vec3(0, 0, 0);
+    node.lookAt(vec3(0, 0, -10));
+    // After lookAt forward, getWorldDirection should point toward target
+    const dir = node.getWorldDirection();
+    expect(near(dir[2], -1)).toBe(true);
+  });
+
+  it('should face target at 90° right', () => {
+    const node = new Node3D('a');
+    node.position = vec3(0, 0, 0);
+    node.lookAt(vec3(10, 0, 0));
+    const dir = node.getWorldDirection();
+    // Should point roughly toward +X
+    expect(dir[0]).toBeGreaterThan(0.9);
+  });
+
+  it('should handle target above', () => {
+    const node = new Node3D('a');
+    node.position = vec3(0, 0, 0);
+    node.lookAt(vec3(0, 10, 0));
+    const dir = node.getWorldDirection();
+    // Should point roughly toward +Y
+    expect(dir[1]).toBeGreaterThan(0.9);
+  });
+
+  it('should not change position', () => {
+    const node = new Node3D('a');
+    node.position = vec3(5, 3, 1);
+    node.lookAt(vec3(10, 0, 0));
+    expect(near(node.position[0], 5)).toBe(true);
+    expect(near(node.position[1], 3)).toBe(true);
+    expect(near(node.position[2], 1)).toBe(true);
+  });
+
+  it('should accept custom up vector', () => {
+    const node = new Node3D('a');
+    node.position = vec3(0, 0, 0);
+    // lookAt with default up (0,1,0) should work
+    node.lookAt(vec3(1, 0, 0), vec3(0, 1, 0));
+    const dir = node.getWorldDirection();
+    expect(dir[0]).toBeGreaterThan(0.9);
+  });
+});


### PR DESCRIPTION
## Summary

- 新增 `getWorldPosition()`: 从 worldMatrix 列 12-14 提取世界坐标
- 新增 `getWorldDirection(localDir?)`: 将局部方向（默认 `(0,0,-1)`）通过旋转矩阵变换并归一化
- 新增 `lookAt(target, up?)`: 构建 forward/right/up 正交基，提取 YXZ 欧拉角设置旋转

## Test plan

- [x] 11 个单元测试全部通过 (`test/unit/core/node3d-helpers.test.ts`)
- [x] 全量回归 92 个测试文件 1409 个测试通过，0 失败

close #189