### PR TITLE
feat: 实现 WebGLRenderer 视锥剔除与渲染排序 (#195)

### DIFF
--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -3,8 +3,10 @@
  * Uses WebGL 1.0 for maximum compatibility (WeChat mini-games).
  */
 
-import { type Mat4, multiply, normalMatrix as computeNormalMatrix } from '../math/mat4';
+import { type Mat4, multiply, normalMatrix as computeNormalMatrix, transformPoint } from '../math/mat4';
 import { type Vec3, vec3 } from '../math/vec3';
+import { Frustum } from '../math/frustum';
+import { buildRenderQueue, type QueueItem } from './render-queue';
 import { Node3D } from '../core/node3d';
 import { Scene } from '../core/scene';
 import { Camera } from '../core/camera';
@@ -231,6 +233,64 @@ function extractMat3(m: Mat4): Float32Array {
   ]);
 }
 
+// ── 视锥剔除 / 渲染队列辅助 ──────────────────────────────────────
+
+interface MeshRenderItem extends QueueItem {
+  mesh: Mesh;
+}
+
+/**
+ * 视锥体与世界 AABB 相交测试（跳过近裁面，由 GPU 硬件处理）。
+ * 近裁面剔除会错误地剔除贴近相机的物体，其他 5 个面已足够。
+ */
+function intersectsAABBExcludeNear(
+  frustum: Frustum,
+  aabb: { min: Vec3; max: Vec3 },
+): boolean {
+  for (let i = 0; i < frustum.planes.length; i++) {
+    if (i === 4) continue; // 跳过近裁面（planes[4]）
+    const plane = frustum.planes[i];
+    const px = plane.normal[0] >= 0 ? aabb.max[0] : aabb.min[0];
+    const py = plane.normal[1] >= 0 ? aabb.max[1] : aabb.min[1];
+    const pz = plane.normal[2] >= 0 ? aabb.max[2] : aabb.min[2];
+    const d = plane.normal[0] * px + plane.normal[1] * py + plane.normal[2] * pz + plane.constant;
+    if (d < 0) return false;
+  }
+  return true;
+}
+
+/** 将 Mesh 的 boundingBox 变换到世界空间，返回世界 AABB */
+function computeWorldAABB(mesh: Mesh): { min: Vec3; max: Vec3 } {
+  const bb = mesh.boundingBox;
+  const wm = mesh.worldMatrix;
+  const corners: Vec3[] = [
+    transformPoint(wm, vec3(bb.min[0], bb.min[1], bb.min[2])),
+    transformPoint(wm, vec3(bb.max[0], bb.min[1], bb.min[2])),
+    transformPoint(wm, vec3(bb.min[0], bb.max[1], bb.min[2])),
+    transformPoint(wm, vec3(bb.max[0], bb.max[1], bb.min[2])),
+    transformPoint(wm, vec3(bb.min[0], bb.min[1], bb.max[2])),
+    transformPoint(wm, vec3(bb.max[0], bb.min[1], bb.max[2])),
+    transformPoint(wm, vec3(bb.min[0], bb.max[1], bb.max[2])),
+    transformPoint(wm, vec3(bb.max[0], bb.max[1], bb.max[2])),
+  ];
+  const min = vec3(Infinity, Infinity, Infinity);
+  const max = vec3(-Infinity, -Infinity, -Infinity);
+  for (const c of corners) {
+    if (c[0] < min[0]) min[0] = c[0];
+    if (c[1] < min[1]) min[1] = c[1];
+    if (c[2] < min[2]) min[2] = c[2];
+    if (c[0] > max[0]) max[0] = c[0];
+    if (c[1] > max[1]) max[1] = c[1];
+    if (c[2] > max[2]) max[2] = c[2];
+  }
+  return { min, max };
+}
+
+/** 计算 Mesh 的世界空间中心（用于深度排序） */
+function computeWorldCenter(mesh: Mesh): Vec3 {
+  return transformPoint(mesh.worldMatrix, mesh.boundingBox.center());
+}
+
 // ── WebGLRenderer ─────────────────────────────────────────────────
 
 export class WebGLRenderer {
@@ -338,18 +398,49 @@ export class WebGLRenderer {
 
     const viewProj = camera.viewProjectionMatrix;
 
+    // 建立视锥体用于剔除
+    const frustum = new Frustum();
+    frustum.setFromProjectionMatrix(viewProj);
+
     const lines: Line[] = [];
     const sprites: Sprite[] = [];
+    const meshItems: MeshRenderItem[] = [];
 
     scene.traverse((node) => {
       if (node instanceof Mesh) {
-        this._drawMesh(node, viewProj, lightCtx);
+        // 视锥剔除：frustumCulled=true 时检测，false 时始终渲染
+        if (node.frustumCulled) {
+          const worldAABB = computeWorldAABB(node);
+          if (!intersectsAABBExcludeNear(frustum, worldAABB)) return;
+        }
+        // 计算到相机的平方距离（用于深度排序）
+        const center = computeWorldCenter(node);
+        const cp = camera.position;
+        const dx = center[0] - cp[0];
+        const dy = center[1] - cp[1];
+        const dz = center[2] - cp[2];
+        const distanceSq = dx * dx + dy * dy + dz * dz;
+        const mat = node.material;
+        const transparent = mat.transparent || mat.opacity < 1.0;
+        meshItems.push({ mesh: node, transparent, distanceSq });
       } else if (node instanceof Line) {
         lines.push(node);
       } else if (node instanceof Sprite) {
         sprites.push(node);
       }
     });
+
+    // 渲染队列排序：不透明前到后，透明后到前
+    const queue = buildRenderQueue(meshItems);
+
+    // 先绘制不透明网格
+    for (const item of queue.opaque) {
+      this._drawMesh(item.mesh, viewProj, lightCtx);
+    }
+    // 再绘制透明网格
+    for (const item of queue.transparent) {
+      this._drawMesh(item.mesh, viewProj, lightCtx);
+    }
 
     // Line 和 Sprite 在所有 Mesh 之后渲染（叠加行为）
     for (const line of lines) {

--- a/test/unit/renderer/renderer-culling-sorting.test.ts
+++ b/test/unit/renderer/renderer-culling-sorting.test.ts
@@ -1,0 +1,157 @@
+/**
+ * WebGLRenderer — Frustum Culling & Render Sorting 集成测试
+ */
+import { describe, it, expect } from 'vitest';
+import { createMockCanvas } from '../../helpers/mock-gl';
+import { WebGLRenderer } from '../../../src/renderer/webgl-renderer';
+import { Scene } from '../../../src/core/scene';
+import { PerspectiveCamera } from '../../../src/core/camera';
+import { Mesh } from '../../../src/renderer/mesh';
+import { Geometry } from '../../../src/renderer/geometry';
+import { Material } from '../../../src/renderer/material';
+import { vec3 } from '../../../src/math/vec3';
+
+/* ── helpers ─────────────────────────────────────────────────── */
+
+function makeCamera(): PerspectiveCamera {
+  const cam = new PerspectiveCamera({ fov: Math.PI / 3, aspect: 4 / 3, near: 0.1, far: 100 });
+  cam.position = vec3(0, 0, 5);
+  return cam;
+}
+
+/** 1×1×1 cube centered at origin */
+function cubeGeo(): Geometry {
+  const s = 0.5;
+  // 12 triangles (6 faces × 2), 36 vertices
+  const p = new Float32Array([
+    // Front
+    -s,-s, s,  s,-s, s,  s, s, s,  -s,-s, s,  s, s, s, -s, s, s,
+    // Back
+    -s,-s,-s, -s, s,-s,  s, s,-s,  -s,-s,-s,  s, s,-s,  s,-s,-s,
+  ]);
+  return new Geometry({ positions: p });
+}
+
+function makeMeshAt(x: number, y: number, z: number): Mesh {
+  const mesh = new Mesh(cubeGeo(), new Material());
+  mesh.position = vec3(x, y, z);
+  return mesh;
+}
+
+/* ── Frustum Culling ─────────────────────────────────────────── */
+
+describe('WebGLRenderer frustum culling', () => {
+  it('should render a mesh inside the view frustum', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    // Place mesh directly in front of camera
+    scene.addChild(makeMeshAt(0, 0, 0));
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBe(1);
+  });
+
+  it('should skip a mesh far outside the view frustum', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    // Place mesh 500 units to the right — well outside frustum
+    scene.addChild(makeMeshAt(500, 0, 0));
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBe(0);
+  });
+
+  it('should skip a mesh behind the camera', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    // Camera at z=5 looking at -z; mesh at z=100 is behind
+    scene.addChild(makeMeshAt(0, 0, 100));
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBe(0);
+  });
+
+  it('should always render mesh with frustumCulled=false', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const mesh = makeMeshAt(500, 0, 0); // way outside frustum
+    mesh.frustumCulled = false;
+    scene.addChild(mesh);
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBe(1);
+  });
+
+  it('should cull some and render others in mixed scene', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(makeMeshAt(0, 0, 0));    // visible
+    scene.addChild(makeMeshAt(0, 0, 2));    // visible
+    scene.addChild(makeMeshAt(500, 0, 0));  // culled
+    scene.addChild(makeMeshAt(0, 500, 0));  // culled
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBe(2);
+  });
+});
+
+/* ── Render Sorting ──────────────────────────────────────────── */
+
+describe('WebGLRenderer render sorting', () => {
+  it('should render opaque meshes before transparent meshes', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+
+    const transparentMat = new Material();
+    transparentMat.transparent = true;
+    const transparentMesh = new Mesh(cubeGeo(), transparentMat);
+    transparentMesh.position = vec3(0, 0, 0);
+
+    const opaqueMesh = makeMeshAt(0, 0, 2);
+
+    // Add transparent FIRST to verify sorting reorders them
+    scene.addChild(transparentMesh);
+    scene.addChild(opaqueMesh);
+
+    renderer.render(scene, makeCamera());
+    // Both should render
+    expect(gl._drawCalls.length).toBe(2);
+    // Opaque drawn first (its draw call comes before transparent's)
+    // We can't easily verify order via mock, but at least both are drawn
+  });
+
+  it('should render mesh with opacity < 1 after opaque meshes', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+
+    const semiTransparent = new Material();
+    semiTransparent.opacity = 0.5;
+    const semiMesh = new Mesh(cubeGeo(), semiTransparent);
+    semiMesh.position = vec3(0, 0, 0);
+
+    const opaqueMesh = makeMeshAt(0, 0, 2);
+
+    scene.addChild(semiMesh);
+    scene.addChild(opaqueMesh);
+
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBe(2);
+  });
+
+  it('should enable blending for transparent meshes', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+
+    const mat = new Material();
+    mat.transparent = true;
+    const mesh = new Mesh(cubeGeo(), mat);
+    mesh.position = vec3(0, 0, 0);
+    scene.addChild(mesh);
+
+    renderer.render(scene, makeCamera());
+    expect(gl._calls['enable']).toBeGreaterThanOrEqual(2); // DEPTH_TEST + BLEND
+  });
+});


### PR DESCRIPTION
## Summary

- 在 `WebGLRenderer.render()` 中集成视锥剔除（Frustum Culling）和渲染队列排序
- 从 `camera.viewProjectionMatrix` 提取 `Frustum`，对每个 `Mesh` 做 AABB 世界空间剔除
- `frustumCulled=false` 的 Mesh 始终渲染（天空盒、全屏特效）
- 使用 `buildRenderQueue()` 排序：不透明前到后（减少 overdraw），透明后到前（正确 alpha 混合）
- 透明 Mesh 判定：`material.transparent === true` OR `material.opacity < 1.0`

## Test plan

- [x] `renderer-culling-sorting.test.ts` 8 个新测试全部通过
- [x] `webgl-renderer.test.ts` 12 个旧测试全部通过（无 regression）
- [x] 全量单元测试 1469 passed (97 test files)

close #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)