### PR TITLE
feat: WebGLRenderer RenderInfo 统计与纹理版本跟踪 (#196)

### DIFF
--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -18,11 +18,12 @@ import { SkinnedMesh } from './skinned-mesh';
 import { Geometry } from './geometry';
 import { Material, Side, BlendMode } from './material';
 import { TextureMaterial } from './texture-material';
-import { Texture } from './texture';
+import { Texture, TextureWrap, TextureFilter } from './texture';
 import { PhongMaterial } from './phong-material';
 import { BitmapTextMaterial } from './bitmap-text';
 import { Line, LineMaterial } from './line-renderer';
 import { Sprite, SpriteMaterial } from './sprite';
+import { type RenderInfo, createRenderInfo, resetRenderInfo } from './render-info';
 
 // ── Internal GPU resource cache ──────────────────────────────────
 
@@ -299,7 +300,8 @@ export class WebGLRenderer {
   // Caches keyed by object identity
   private programCache: WeakMap<Material, CompiledProgram> = new WeakMap();
   private geometryCache: WeakMap<Geometry, UploadedGeometry> = new WeakMap();
-  private textureCache: WeakMap<Texture, WebGLTexture> = new WeakMap();
+  private textureCache: WeakMap<Texture, { glTex: WebGLTexture; version: number }> = new WeakMap();
+  readonly info: RenderInfo = createRenderInfo();
   private skinningProgram: SkinningProgram | null = null;
   private lineProgramCache: WeakMap<LineMaterial, LineProgramInfo> = new WeakMap();
   private spriteProgramCache: WeakMap<SpriteMaterial, SpriteProgramInfo> = new WeakMap();
@@ -323,6 +325,8 @@ export class WebGLRenderer {
    */
   render(scene: Scene, camera: Camera): void {
     const gl = this.gl;
+    const _startTime = performance.now();
+    resetRenderInfo(this.info);
 
     gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
     const bg = scene.background;
@@ -449,6 +453,8 @@ export class WebGLRenderer {
     for (const sprite of sprites) {
       this._drawSprite(sprite, camera);
     }
+
+    this.info.frameTime = performance.now() - _startTime;
   }
 
   /** Release all GPU resources. */
@@ -457,26 +463,87 @@ export class WebGLRenderer {
     // Nothing else to clean up explicitly without iterating all cached entries.
   }
 
-  private _getWebGLTexture(texture: Texture): WebGLTexture {
-    const cached = this.textureCache.get(texture);
-    if (cached) return cached;
-
+  private _applyTextureSamplingParams(texture: Texture): void {
     const gl = this.gl;
-    const webglTex = gl.createTexture();
-    if (!webglTex) throw new Error('Failed to create WebGL texture');
 
-    gl.bindTexture(gl.TEXTURE_2D, webglTex);
+    // wrapS
+    const wrapSMap: Record<TextureWrap, number> = {
+      [TextureWrap.ClampToEdge]:    gl.CLAMP_TO_EDGE,
+      [TextureWrap.Repeat]:         gl.REPEAT,
+      [TextureWrap.MirroredRepeat]: (gl as any).MIRRORED_REPEAT ?? 0x8370,
+    };
+    // wrapT
+    const wrapTMap: Record<TextureWrap, number> = {
+      [TextureWrap.ClampToEdge]:    gl.CLAMP_TO_EDGE,
+      [TextureWrap.Repeat]:         gl.REPEAT,
+      [TextureWrap.MirroredRepeat]: (gl as any).MIRRORED_REPEAT ?? 0x8370,
+    };
+    // minFilter
+    const minFilterMap: Record<TextureFilter, number> = {
+      [TextureFilter.Nearest]:              gl.NEAREST,
+      [TextureFilter.Linear]:               gl.LINEAR,
+      [TextureFilter.NearestMipmapNearest]: (gl as any).NEAREST_MIPMAP_NEAREST ?? 0x2700,
+      [TextureFilter.NearestMipmapLinear]:  (gl as any).NEAREST_MIPMAP_LINEAR  ?? 0x2702,
+      [TextureFilter.LinearMipmapNearest]:  (gl as any).LINEAR_MIPMAP_NEAREST  ?? 0x2701,
+      [TextureFilter.LinearMipmapLinear]:   (gl as any).LINEAR_MIPMAP_LINEAR   ?? 0x2703,
+    };
+    // magFilter（只支持 NEAREST / LINEAR）
+    const magFilterMap: Record<TextureFilter, number> = {
+      [TextureFilter.Nearest]:              gl.NEAREST,
+      [TextureFilter.Linear]:               gl.LINEAR,
+      [TextureFilter.NearestMipmapNearest]: gl.NEAREST,
+      [TextureFilter.NearestMipmapLinear]:  gl.LINEAR,
+      [TextureFilter.LinearMipmapNearest]:  gl.NEAREST,
+      [TextureFilter.LinearMipmapLinear]:   gl.LINEAR,
+    };
+
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrapSMap[texture.wrapS]);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrapTMap[texture.wrapT]);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, minFilterMap[texture.minFilter]);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, magFilterMap[texture.magFilter]);
+  }
+
+  private _uploadTextureData(texture: Texture): void {
+    const gl = this.gl;
+    if (texture.flipY) {
+      gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 1);
+    }
     gl.texImage2D(
       gl.TEXTURE_2D, 0, gl.RGBA,
       texture.width, texture.height, 0,
       gl.RGBA, gl.UNSIGNED_BYTE, texture.data,
     );
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    if (texture.generateMipmaps) {
+      gl.generateMipmap(gl.TEXTURE_2D);
+    }
+    if (texture.flipY) {
+      gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
+    }
+  }
 
-    this.textureCache.set(texture, webglTex);
+  private _getWebGLTexture(texture: Texture): WebGLTexture {
+    const gl = this.gl;
+    const cached = this.textureCache.get(texture);
+
+    if (cached) {
+      if (cached.version !== texture.version) {
+        // 版本变更，重新上传数据并更新采样参数
+        gl.bindTexture(gl.TEXTURE_2D, cached.glTex);
+        this._uploadTextureData(texture);
+        this._applyTextureSamplingParams(texture);
+        cached.version = texture.version;
+      }
+      return cached.glTex;
+    }
+
+    const webglTex = gl.createTexture();
+    if (!webglTex) throw new Error('Failed to create WebGL texture');
+
+    gl.bindTexture(gl.TEXTURE_2D, webglTex);
+    this._uploadTextureData(texture);
+    this._applyTextureSamplingParams(texture);
+
+    this.textureCache.set(texture, { glTex: webglTex, version: texture.version });
     return webglTex;
   }
 
@@ -928,8 +995,12 @@ export class WebGLRenderer {
     if (uploaded.indexBuffer !== null) {
       gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, uploaded.indexBuffer);
       gl.drawElements(gl.TRIANGLES, uploaded.indexCount, gl.UNSIGNED_SHORT, 0);
+      this.info.drawCalls++;
+      this.info.triangles += uploaded.indexCount / 3;
     } else {
       gl.drawArrays(gl.TRIANGLES, 0, uploaded.vertexCount);
+      this.info.drawCalls++;
+      this.info.triangles += uploaded.vertexCount / 3;
     }
 
     // 恢复默认 GL 状态，避免状态泄漏

--- a/test/helpers/mock-gl.ts
+++ b/test/helpers/mock-gl.ts
@@ -91,6 +91,7 @@ export function createMockGL(): MockGL & WebGLRenderingContext {
   const LINEAR              = 0x2601;
   const CLAMP_TO_EDGE       = 0x812F;
   const REPEAT              = 0x2901;
+  const MIRRORED_REPEAT     = 0x8370;
   const SRC_ALPHA           = 0x0302;
   const ONE_MINUS_SRC_ALPHA = 0x0303;
   const ONE                 = 0x0001;
@@ -146,7 +147,7 @@ export function createMockGL(): MockGL & WebGLRenderingContext {
     TEXTURE_2D, TEXTURE0,
     RGBA, RGB, LUMINANCE, ALPHA,
     TEXTURE_MIN_FILTER, TEXTURE_MAG_FILTER, TEXTURE_WRAP_S, TEXTURE_WRAP_T,
-    NEAREST, LINEAR, CLAMP_TO_EDGE, REPEAT,
+    NEAREST, LINEAR, CLAMP_TO_EDGE, REPEAT, MIRRORED_REPEAT,
     SRC_ALPHA, ONE_MINUS_SRC_ALPHA, ONE, ZERO, SRC_COLOR, DST_COLOR,
     DST_ALPHA, ONE_MINUS_DST_ALPHA, FUNC_ADD,
     LESS, LEQUAL, GREATER, GEQUAL, EQUAL, NOTEQUAL, ALWAYS, NEVER,

--- a/test/unit/renderer/renderer-info-texture.test.ts
+++ b/test/unit/renderer/renderer-info-texture.test.ts
@@ -1,0 +1,196 @@
+/**
+ * WebGLRenderer — RenderInfo 统计 & Texture 版本/采样集成测试
+ */
+import { describe, it, expect } from 'vitest';
+import { createMockCanvas } from '../../helpers/mock-gl';
+import { WebGLRenderer } from '../../../src/renderer/webgl-renderer';
+import { Scene } from '../../../src/core/scene';
+import { PerspectiveCamera } from '../../../src/core/camera';
+import { Mesh } from '../../../src/renderer/mesh';
+import { Geometry } from '../../../src/renderer/geometry';
+import { Material } from '../../../src/renderer/material';
+import { TextureMaterial } from '../../../src/renderer/texture-material';
+import { Texture, TextureWrap, TextureFilter } from '../../../src/renderer/texture';
+import { vec3 } from '../../../src/math/vec3';
+import type { RenderInfo } from '../../../src/renderer/render-info';
+
+/* ── helpers ─────────────────────────────────────────────────── */
+
+function makeCamera(): PerspectiveCamera {
+  const cam = new PerspectiveCamera({ fov: Math.PI / 3, aspect: 4 / 3, near: 0.1, far: 100 });
+  cam.position = vec3(0, 0, 5);
+  return cam;
+}
+
+function makeTriGeo(): Geometry {
+  return new Geometry({ positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]) });
+}
+
+function makeQuadGeo(): Geometry {
+  return new Geometry({
+    positions: new Float32Array([
+      -1,-1,0, 1,-1,0, 1,1,0,
+      -1,-1,0, 1,1,0, -1,1,0,
+    ]),
+    uvs: new Float32Array([0,0, 1,0, 1,1, 0,0, 1,1, 0,1]),
+  });
+}
+
+/* ── RenderInfo ──────────────────────────────────────────────── */
+
+describe('WebGLRenderer RenderInfo', () => {
+  it('should expose info property as RenderInfo', () => {
+    const { canvas } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    expect(renderer.info).toBeDefined();
+    expect(renderer.info.drawCalls).toBe(0);
+    expect(renderer.info.triangles).toBe(0);
+  });
+
+  it('should count draw calls after render', () => {
+    const { canvas } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeTriGeo(), new Material()));
+    scene.addChild(new Mesh(makeTriGeo(), new Material()));
+    renderer.render(scene, makeCamera());
+    expect(renderer.info.drawCalls).toBe(2);
+  });
+
+  it('should count triangles from vertex count', () => {
+    const { canvas } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeQuadGeo(), new Material())); // 6 verts = 2 triangles
+    renderer.render(scene, makeCamera());
+    expect(renderer.info.triangles).toBe(2);
+  });
+
+  it('should reset info each render call', () => {
+    const { canvas } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeTriGeo(), new Material()));
+    renderer.render(scene, makeCamera());
+    expect(renderer.info.drawCalls).toBe(1);
+    // Render again — info should be reset then re-accumulated
+    renderer.render(scene, makeCamera());
+    expect(renderer.info.drawCalls).toBe(1); // not 2
+  });
+
+  it('should track frameTime > 0', () => {
+    const { canvas } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeTriGeo(), new Material()));
+    renderer.render(scene, makeCamera());
+    expect(renderer.info.frameTime).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should count zero draw calls for empty scene', () => {
+    const { canvas } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    renderer.render(new Scene(), makeCamera());
+    expect(renderer.info.drawCalls).toBe(0);
+    expect(renderer.info.triangles).toBe(0);
+  });
+});
+
+/* ── Texture Version Tracking ────────────────────────────────── */
+
+describe('WebGLRenderer texture version tracking', () => {
+  it('should upload texture data on first use', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const tex = Texture.checkerboard(2, 2);
+    const mat = new TextureMaterial(tex);
+    scene.addChild(new Mesh(makeQuadGeo(), mat));
+    renderer.render(scene, makeCamera());
+    expect(gl._calls['texImage2D']).toBe(1);
+  });
+
+  it('should not re-upload texture if version unchanged', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const tex = Texture.checkerboard(2, 2);
+    const mat = new TextureMaterial(tex);
+    scene.addChild(new Mesh(makeQuadGeo(), mat));
+    renderer.render(scene, makeCamera());
+    const uploadsAfterFirst = gl._calls['texImage2D'];
+    renderer.render(scene, makeCamera());
+    expect(gl._calls['texImage2D']).toBe(uploadsAfterFirst); // no re-upload
+  });
+
+  it('should re-upload texture after needsUpdate()', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const tex = Texture.checkerboard(2, 2);
+    const mat = new TextureMaterial(tex);
+    scene.addChild(new Mesh(makeQuadGeo(), mat));
+    renderer.render(scene, makeCamera());
+    const uploadsFirst = gl._calls['texImage2D'];
+
+    tex.needsUpdate(); // bump version
+    renderer.render(scene, makeCamera());
+    expect(gl._calls['texImage2D']).toBe(uploadsFirst + 1);
+  });
+});
+
+/* ── Texture Sampling Parameters ─────────────────────────────── */
+
+describe('WebGLRenderer texture sampling', () => {
+  it('should apply wrapS=Repeat when set', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const tex = Texture.checkerboard(2, 2);
+    tex.wrapS = TextureWrap.Repeat;
+    tex.wrapT = TextureWrap.Repeat;
+    const mat = new TextureMaterial(tex);
+    scene.addChild(new Mesh(makeQuadGeo(), mat));
+    renderer.render(scene, makeCamera());
+    // texParameteri called at least 4 times (wrapS, wrapT, minFilter, magFilter)
+    expect(gl._calls['texParameteri']).toBeGreaterThanOrEqual(4);
+  });
+
+  it('should apply linear filter when set', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const tex = Texture.checkerboard(4, 4);
+    tex.minFilter = TextureFilter.Linear;
+    tex.magFilter = TextureFilter.Linear;
+    const mat = new TextureMaterial(tex);
+    scene.addChild(new Mesh(makeQuadGeo(), mat));
+    renderer.render(scene, makeCamera());
+    expect(gl._calls['texParameteri']).toBeGreaterThanOrEqual(4);
+  });
+
+  it('should generate mipmaps when texture.generateMipmaps=true', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const tex = Texture.checkerboard(4, 4);
+    tex.generateMipmaps = true;
+    tex.minFilter = TextureFilter.LinearMipmapLinear;
+    const mat = new TextureMaterial(tex);
+    scene.addChild(new Mesh(makeQuadGeo(), mat));
+    renderer.render(scene, makeCamera());
+    expect(gl._calls['generateMipmap']).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should apply flipY when texture.flipY=true', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const tex = Texture.checkerboard(2, 2);
+    tex.flipY = true;
+    const mat = new TextureMaterial(tex);
+    scene.addChild(new Mesh(makeQuadGeo(), mat));
+    renderer.render(scene, makeCamera());
+    expect(gl._calls['pixelStorei']).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary

- `renderer.info` 公开属性（`RenderInfo`），每帧追踪 `drawCalls`、`triangles`、`frameTime`
- `render()` 开始时自动 reset，结束时记录帧耗时
- `textureCache` 改为 `WeakMap<Texture, { glTex, version }>`，版本变更时自动重传纹理数据
- 新增 `_applyTextureSamplingParams()`：完整映射 `wrapS/wrapT/minFilter/magFilter`
- 新增 `_uploadTextureData()`：处理 `flipY` 和 `generateMipmaps`
- `mock-gl` 添加 `MIRRORED_REPEAT` 常量

## Test plan

- [ ] 13 个新测试全部通过（`renderer-info-texture.test.ts`）
- [ ] 全量单元测试 99 文件 / 1493 测试通过

close #196