### PR TITLE
feat: 实现 WebGLRenderer ParticleEmitter 自动渲染集成 (#199)

### DIFF
--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -26,6 +26,8 @@ import { Sprite, SpriteMaterial } from './sprite';
 import { type RenderInfo, createRenderInfo, resetRenderInfo } from './render-info';
 import { CubeTexture } from './cube-texture';
 import { SkyboxRenderer } from './skybox';
+import { ParticleEmitter } from './particle-emitter';
+import { ParticleRenderer } from './particle-renderer';
 
 // ── Internal GPU resource cache ──────────────────────────────────
 
@@ -309,6 +311,7 @@ export class WebGLRenderer {
   private spriteProgramCache: WeakMap<SpriteMaterial, SpriteProgramInfo> = new WeakMap();
   private spriteQuad: SpriteQuad | null = null;
   private skyboxRenderer: SkyboxRenderer | null = null;
+  private particleCache: WeakMap<ParticleEmitter, ParticleRenderer> = new WeakMap();
 
   constructor(canvas: HTMLCanvasElement) {
     const gl = canvas.getContext('webgl', {
@@ -423,6 +426,7 @@ export class WebGLRenderer {
 
     const lines: Line[] = [];
     const sprites: Sprite[] = [];
+    const emitters: ParticleEmitter[] = [];
     const meshItems: MeshRenderItem[] = [];
 
     scene.traverse((node) => {
@@ -446,6 +450,8 @@ export class WebGLRenderer {
         lines.push(node);
       } else if (node instanceof Sprite) {
         sprites.push(node);
+      } else if (node instanceof ParticleEmitter) {
+        emitters.push(node);
       }
     });
 
@@ -467,6 +473,18 @@ export class WebGLRenderer {
     }
     for (const sprite of sprites) {
       this._drawSprite(sprite, camera);
+    }
+
+    // 粒子最后渲染（在所有不透明、透明、线条、精灵之后）
+    for (const emitter of emitters) {
+      if (!emitter.visible || emitter.activeCount === 0) continue;
+      let particleRenderer = this.particleCache.get(emitter);
+      if (!particleRenderer) {
+        particleRenderer = new ParticleRenderer(gl, emitter.options.maxParticles);
+        this.particleCache.set(emitter, particleRenderer);
+      }
+      particleRenderer.update(emitter);
+      particleRenderer.render(viewProj);
     }
 
     this.info.frameTime = performance.now() - _startTime;

--- a/test/unit/renderer/renderer-particles.test.ts
+++ b/test/unit/renderer/renderer-particles.test.ts
@@ -1,0 +1,117 @@
+/**
+ * WebGLRenderer — ParticleEmitter 自动渲染集成测试
+ */
+import { describe, it, expect } from 'vitest';
+import { createMockCanvas } from '../../helpers/mock-gl';
+import { WebGLRenderer } from '../../../src/renderer/webgl-renderer';
+import { Scene } from '../../../src/core/scene';
+import { PerspectiveCamera } from '../../../src/core/camera';
+import { ParticleEmitter } from '../../../src/renderer/particle-emitter';
+import { Mesh } from '../../../src/renderer/mesh';
+import { Geometry } from '../../../src/renderer/geometry';
+import { Material } from '../../../src/renderer/material';
+import { vec3 } from '../../../src/math/vec3';
+
+function makeCamera(): PerspectiveCamera {
+  return new PerspectiveCamera({ fov: Math.PI / 3, aspect: 4 / 3, near: 0.1, far: 100 });
+}
+
+function makeTriGeo(): Geometry {
+  return new Geometry({
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    indices: new Uint16Array([0, 1, 2]),
+  });
+}
+
+function makeEmitter(seed = 42): ParticleEmitter {
+  const emitter = new ParticleEmitter({
+    maxParticles: 10,
+    emissionRate: 100,
+    lifetime: { min: 1, max: 2 },
+    speed: { min: 1, max: 2 },
+    size: { min: 5, max: 10 },
+    color: vec3(1, 1, 1),
+    seed,
+  });
+  // Emit some particles so activeCount > 0
+  emitter.update(0.1);
+  return emitter;
+}
+
+describe('WebGLRenderer — particle auto-rendering', () => {
+  it('should render particles when scene has ParticleEmitter', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(makeEmitter());
+    renderer.render(scene, makeCamera());
+    // At least one draw call for particles (gl.POINTS)
+    expect(gl._drawCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should skip emitter with activeCount=0', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    // Create emitter but don't update (no particles emitted)
+    const emitter = new ParticleEmitter({
+      maxParticles: 10,
+      emissionRate: 0,
+      lifetime: { min: 1, max: 2 },
+      speed: { min: 1, max: 2 },
+      size: { min: 5, max: 10 },
+      color: vec3(1, 1, 1),
+    });
+    scene.addChild(emitter);
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBe(0);
+  });
+
+  it('should skip emitter with visible=false', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const emitter = makeEmitter();
+    emitter.visible = false;
+    scene.addChild(emitter);
+    renderer.render(scene, makeCamera());
+    expect(gl._drawCalls.length).toBe(0);
+  });
+
+  it('should handle multiple emitters in one scene', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(makeEmitter(1));
+    scene.addChild(makeEmitter(2));
+    renderer.render(scene, makeCamera());
+    // 2 draw calls, one per emitter
+    expect(gl._drawCalls.length).toBe(2);
+  });
+
+  it('should render particles AFTER meshes', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeTriGeo(), new Material()));
+    scene.addChild(makeEmitter());
+    renderer.render(scene, makeCamera());
+    // Mesh draw first, particle draw second
+    expect(gl._drawCalls.length).toBe(2);
+    // Mesh uses drawElements (indexed), particles use drawArrays (POINTS)
+    expect(gl._drawCalls[0].type).toBe('drawElements');
+    expect(gl._drawCalls[1].type).toBe('drawArrays');
+  });
+
+  it('should render ParticleEmitter nested as child of Mesh', () => {
+    const { canvas, gl } = createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    const mesh = new Mesh(makeTriGeo(), new Material());
+    mesh.addChild(makeEmitter());
+    scene.addChild(mesh);
+    renderer.render(scene, makeCamera());
+    // 1 mesh + 1 particle
+    expect(gl._drawCalls.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- `WebGLRenderer.render()` 场景遍历时自动检测 `ParticleEmitter` 节点并收集
- 粒子在所有 Mesh/Line/Sprite 之后最后渲染（正确的叠加/混合顺序）
- 使用 `WeakMap<ParticleEmitter, ParticleRenderer>` 懒加载缓存 GPU 资源
- 跳过 `activeCount === 0` 或 `visible === false` 的发射器

## Test plan

- [x] `should render particles when scene has ParticleEmitter` — 有活跃粒子时产生 draw call
- [x] `should skip emitter with activeCount=0` — 无粒子时不绘制
- [x] `should skip emitter with visible=false` — 隐藏时不绘制
- [x] `should handle multiple emitters in one scene` — 多个发射器各自绘制
- [x] `should render particles AFTER meshes` — 粒子在网格之后渲染
- [x] `should render ParticleEmitter nested as child of Mesh` — 嵌套节点正常遍历
- [x] `pnpm run test` — 1499 tests passed (0 failures)

close #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)