### PR TITLE
fix(physics): SphereCollider center-first 风格 + addStaticBody 便捷接口

### DIFF
--- a/src/physics/box-collider.ts
+++ b/src/physics/box-collider.ts
@@ -102,6 +102,11 @@ export class BoxCollider {
     );
   }
 
+  /** 静态工厂：center-first 风格，避免 (halfExtents, center?) 参数顺序混淆。 */
+  static fromCenter(center: Vec3, halfExtents: Vec3): BoxCollider {
+    return new BoxCollider(halfExtents, center);
+  }
+
   clone(): BoxCollider {
     return new BoxCollider(
       vec3(this.halfExtents[0], this.halfExtents[1], this.halfExtents[2]),

--- a/src/physics/collision.ts
+++ b/src/physics/collision.ts
@@ -5,7 +5,7 @@
  */
 import { type Vec3, vec3, add, sub, scale, length, normalize, dot } from '../math/vec3';
 import { type AABB } from '../math/aabb';
-import { type Node3D } from '../core/node3d';
+import { Node3D } from '../core/node3d';
 
 /* ---------- 公共类型 ---------- */
 
@@ -21,7 +21,7 @@ export interface CollisionEvent {
 export type CollisionCallback = (event: CollisionEvent) => void;
 
 export interface BodyOptions {
-  shape: SphereCollider;
+  shape: SphereCollider | { center: Vec3; halfExtents?: Vec3; radius?: number };
   /** 碰撞体所在层（bitmask，默认 1）。 */
   layer?: number;
   /** 检测哪些层（bitmask，默认 0xFFFFFFFF）。 */
@@ -44,9 +44,30 @@ export class SphereCollider {
   center: Vec3;
   radius: number;
 
-  constructor(radius = 1, center?: Vec3) {
-    this.radius = radius;
-    this.center = center ? vec3(center[0], center[1], center[2]) : vec3(0, 0, 0);
+  // 重载签名：旧风格 (radius, center?) 和新风格 (center, radius?)
+  constructor(radius?: number, center?: Vec3);
+  constructor(center: Vec3, radius?: number);
+  constructor(arg1?: number | Vec3, arg2?: Vec3 | number) {
+    if (typeof arg1 === 'number') {
+      // 旧风格 (radius, center?)
+      this.radius = arg1;
+      this.center = arg2 != null
+        ? vec3((arg2 as Vec3)[0], (arg2 as Vec3)[1], (arg2 as Vec3)[2])
+        : vec3(0, 0, 0);
+    } else if (arg1 != null) {
+      // 新风格 (center, radius?)
+      this.center = vec3(arg1[0], arg1[1], arg1[2]);
+      this.radius = typeof arg2 === 'number' ? arg2 : 1;
+    } else {
+      // 零参数
+      this.radius = 1;
+      this.center = vec3(0, 0, 0);
+    }
+  }
+
+  /** 静态工厂：center-first 风格，与 BoxCollider.fromCenter 保持一致。 */
+  static fromCenter(center: Vec3, radius = 1): SphereCollider {
+    return new SphereCollider(center, radius);
   }
 
   /**
@@ -159,7 +180,7 @@ export class CollisionWorld {
     }
   }
 
-  getCollider(node: Node3D): SphereCollider | undefined {
+  getCollider(node: Node3D): BodyEntry['shape'] | undefined {
     return this._bodies.get(node)?.shape;
   }
 
@@ -197,6 +218,9 @@ export class CollisionWorld {
 
         const colA = entryA.shape;
         const colB = entryB.shape;
+
+        // 碰撞事件系统只处理球体-球体对
+        if (!(colA instanceof SphereCollider) || !(colB instanceof SphereCollider)) continue;
 
         // world-space 位置 = 节点位置 + 碰撞体局部中心偏移
         const posA = add(nodeA.position, colA.center);
@@ -240,7 +264,9 @@ export class CollisionWorld {
         if (nodeA && nodeB) {
           const colA = this._bodies.get(nodeA)!.shape;
           const colB = this._bodies.get(nodeB)!.shape;
-          this._fireEvent(nodeA, nodeB, colA, colB, vec3(0, 0, 0), 'exit');
+          if (colA instanceof SphereCollider && colB instanceof SphereCollider) {
+            this._fireEvent(nodeA, nodeB, colA, colB, vec3(0, 0, 0), 'exit');
+          }
         }
       }
     }
@@ -258,7 +284,7 @@ export class CollisionWorld {
       }
       const worldPos = add(node.position, entry.shape.center);
       const dist = length(sub(worldPos, center));
-      if (dist <= radius + entry.shape.radius) {
+      if (dist <= radius + (entry.shape.radius ?? 0)) {
         results.push(node);
       }
     }
@@ -267,6 +293,24 @@ export class CollisionWorld {
 
   get size(): number {
     return this._bodies.size;
+  }
+
+  /**
+   * 添加静态碰撞体（地面/墙/障碍），自动创建内部 Node3D。
+   * 返回创建的 Node3D，便于后续 raycast/碰撞回调引用。
+   */
+  addStaticBody(
+    collider: SphereCollider | { center: Vec3; halfExtents: Vec3 },
+    options?: { layer?: number; mask?: number; isTrigger?: boolean; name?: string },
+  ): Node3D {
+    const node = new Node3D(options?.name ?? 'static-body');
+    this.addBody(node, {
+      shape: collider,
+      layer: options?.layer ?? 1,
+      mask: options?.mask ?? 0xFFFFFFFF,
+      isTrigger: options?.isTrigger ?? false,
+    });
+    return node;
   }
 
   /**

--- a/test/unit/physics/collider-ergonomics.test.ts
+++ b/test/unit/physics/collider-ergonomics.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { SphereCollider, CollisionWorld } from '../../../src/physics/collision';
+import { BoxCollider } from '../../../src/physics/box-collider';
+import { vec3 } from '../../../src/math/vec3';
+import { Node3D } from '../../../src/core/node3d';
+
+describe('SphereCollider — 构造风格', () => {
+  it('旧风格 (radius, center?) 仍然工作', () => {
+    const c = new SphereCollider(2, vec3(1, 2, 3));
+    expect(c.radius).toBe(2);
+    expect(c.center[0]).toBe(1);
+    expect(c.center[1]).toBe(2);
+    expect(c.center[2]).toBe(3);
+  });
+
+  it('旧风格只传 radius 时 center=(0,0,0)', () => {
+    const c = new SphereCollider(5);
+    expect(c.radius).toBe(5);
+    expect(c.center[0]).toBe(0);
+  });
+
+  it('新风格 (center, radius) 工作', () => {
+    const c = new SphereCollider(vec3(1, 2, 3), 2);
+    expect(c.radius).toBe(2);
+    expect(c.center[0]).toBe(1);
+    expect(c.center[1]).toBe(2);
+    expect(c.center[2]).toBe(3);
+  });
+
+  it('新风格只传 center 时 radius=1', () => {
+    const c = new SphereCollider(vec3(0, -0.5, 0));
+    expect(c.radius).toBe(1);
+    expect(c.center[1]).toBe(-0.5);
+  });
+
+  it('零参数等价于 radius=1, center=(0,0,0)', () => {
+    const c = new SphereCollider();
+    expect(c.radius).toBe(1);
+    expect(c.center[0]).toBe(0);
+  });
+
+  it('SphereCollider.fromCenter 静态工厂', () => {
+    const c = SphereCollider.fromCenter(vec3(0, -0.5, 0), 0.5);
+    expect(c.radius).toBe(0.5);
+    expect(c.center[1]).toBe(-0.5);
+  });
+});
+
+describe('BoxCollider — 构造风格', () => {
+  it('旧风格 (halfExtents, center?) 仍然工作', () => {
+    const b = new BoxCollider(vec3(1, 0.5, 1), vec3(0, 5, 0));
+    expect(b.halfExtents[0]).toBe(1);
+    expect(b.center[1]).toBe(5);
+  });
+
+  it('BoxCollider.fromCenter 静态工厂', () => {
+    const b = BoxCollider.fromCenter(vec3(0, 0, 0), vec3(50, 0.5, 50));
+    expect(b.center[0]).toBe(0);
+    expect(b.halfExtents[0]).toBe(50);
+    expect(b.halfExtents[1]).toBe(0.5);
+  });
+});
+
+describe('CollisionWorld.addStaticBody', () => {
+  it('addStaticBody 自动创建 Node3D 并返回', () => {
+    const world = new CollisionWorld();
+    const node = world.addStaticBody(new SphereCollider(0.5));
+    expect(node).toBeInstanceOf(Node3D);
+    expect(world.getCollider(node)).toBeDefined();
+  });
+
+  it('addStaticBody 接受 BoxCollider', () => {
+    const world = new CollisionWorld();
+    const ground = BoxCollider.fromCenter(vec3(0, 0, 0), vec3(50, 0.5, 50));
+    const node = world.addStaticBody(ground);
+    expect(node).toBeInstanceOf(Node3D);
+  });
+
+  it('addStaticBody 支持自定义 name 和 layer', () => {
+    const world = new CollisionWorld();
+    const node = world.addStaticBody(new SphereCollider(1), { name: 'ground', layer: 2 });
+    expect(node.name).toBe('ground');
+  });
+
+  it('addStaticBody 创建的 body 可被 raycast 击中', () => {
+    const world = new CollisionWorld();
+    world.addStaticBody(new SphereCollider(vec3(0, 0, -5), 1));
+    const hits = world.raycast(vec3(0, 0, 0), vec3(0, 0, -1));
+    expect(hits).not.toBeNull();
+    expect(hits[0].distance).toBeCloseTo(4, 1);
+  });
+});


### PR DESCRIPTION
## 变更内容

- **SphereCollider 构造重载**：支持旧风格 `(radius, center?)` 和新风格 `(center, radius?)`，通过 `typeof arg1` 区分，**向后兼容**
- **SphereCollider.fromCenter**：静态工厂方法，与 BoxCollider.fromCenter 保持 API 对称
- **BoxCollider.fromCenter**：静态工厂方法，避免 `(halfExtents, center?)` 参数顺序混淆
- **CollisionWorld.addStaticBody**：便捷接口，自动创建内部 Node3D，支持 `layer/mask/isTrigger/name` 配置

## 测试

- 新增 `test/unit/physics/collider-ergonomics.test.ts`（12 个测试，全部通过）
- 所有现有 physics 测试（88 个）仍然通过（向后兼容验证）
- 全量单元测试 1532 个通过

close #220