### PR TITLE
feat: M1.2 跑道地形 + 障碍物 + 收集品碰撞集成

### DIFF
--- a/examples/runner-3d/src/game.ts
+++ b/examples/runner-3d/src/game.ts
@@ -3,7 +3,9 @@ import { PerspectiveCamera } from '../../../src/core/camera';
 import { WebGLRenderer } from '../../../src/renderer/webgl-renderer';
 import { GameLoop } from '../../../src/core/game-loop';
 import { InputManager } from '../../../src/core/input';
+import { CollisionWorld } from '../../../src/physics/collision';
 import { Player } from './player';
+import { Track } from './track';
 import { vec3 } from '../../../src/math/vec3';
 
 export class Game {
@@ -13,6 +15,12 @@ export class Game {
   private loop: GameLoop;
   private player: Player;
   private input: InputManager;
+  private world: CollisionWorld;
+  private track: Track;
+
+  // 游戏状态
+  private hp = 3;
+  private score = 0;
 
   constructor(canvas: HTMLCanvasElement) {
     const gl = canvas.getContext('webgl', {
@@ -31,8 +39,33 @@ export class Game {
     this.renderer = new WebGLRenderer(gl);
     this.input = new InputManager(canvas);
 
-    this.player = new Player({ input: this.input, startPosition: [0, 1, 0] });
+    // 创建碰撞世界和跑道
+    this.world = new CollisionWorld();
+    this.track = new Track(
+      { length: 200, width: 4, obstacleCount: 20, coinCount: 30, seed: 1234 },
+      this.world,
+    );
+    this.scene.addChild(this.track.root);
+
+    // 创建玩家（传入 world 和 track 以启用碰撞回调）
+    this.player = new Player({
+      input: this.input,
+      startPosition: [0, 1, 0],
+      collisionWorld: this.world,
+      track: this.track,
+    });
     this.scene.addChild(this.player.node);
+
+    // 碰撞事件处理
+    this.player.on('hit-obstacle', () => {
+      this.hp = Math.max(0, this.hp - 1);
+    });
+    this.player.on('collect-coin', (coin) => {
+      if (coin) {
+        this.track.collectCoin(coin, this.world);
+        this.score += 10;
+      }
+    });
 
     this.loop = new GameLoop();
     this.loop.onUpdate = (dt) => this.update(dt);
@@ -55,6 +88,8 @@ export class Game {
 
   private update(dt: number): void {
     this.player.update(dt);
+    // 推进碰撞检测（触发 hit-obstacle / collect-coin 回调）
+    this.world.step();
     // 相机跟随玩家
     this.camera.position[0] = this.player.position[0];
     this.camera.position[1] = this.player.position[1] + 3;

--- a/examples/runner-3d/src/player.ts
+++ b/examples/runner-3d/src/player.ts
@@ -1,19 +1,24 @@
 import { Node3D } from '../../../src/core/node3d';
 import { CharacterController } from '../../../src/gameplay/character-controller';
 import { InputManager } from '../../../src/core/input';
-import { CollisionWorld } from '../../../src/physics/collision';
+import { CollisionWorld, SphereCollider } from '../../../src/physics/collision';
 import { vec3 } from '../../../src/math/vec3';
+import { LAYER_PLAYER, LAYER_OBSTACLE, LAYER_COIN, type CoinHandle, type Track } from './track';
+
+type EventType = 'hit-obstacle' | 'collect-coin';
 
 export interface PlayerOptions {
   collisionWorld?: CollisionWorld;
   input?: InputManager;
   startPosition?: [number, number, number];
+  track?: Track;
 }
 
 export class Player {
   readonly node: Node3D;
   readonly controller: CharacterController;
   private input: InputManager | null;
+  private _listeners: Map<EventType, Array<(data?: CoinHandle) => void>> = new Map();
 
   constructor(opts: PlayerOptions = {}) {
     this.node = new Node3D('player');
@@ -29,6 +34,41 @@ export class Player {
       collisionWorld: opts.collisionWorld,
     });
     this.input = opts.input ?? null;
+
+    // 注册玩家碰撞体到 CollisionWorld（LAYER_PLAYER）
+    if (opts.collisionWorld) {
+      opts.collisionWorld.addBody(this.node, {
+        shape: new SphereCollider(0.4, vec3(0, 0.4, 0)),
+        layer: LAYER_PLAYER,
+        mask: LAYER_OBSTACLE | LAYER_COIN,
+      });
+
+      // 碰撞回调：障碍物 → hit-obstacle，金币 → collect-coin
+      opts.collisionWorld.onCollisionEnter(this.node, (event) => {
+        const otherLayer = (event.otherNode as any).__collisionLayer as number | undefined;
+        void otherLayer; // layer 信息通过 CollisionWorld 内部过滤已处理
+
+        // 通过节点名称前缀区分障碍物和金币
+        const name = event.otherNode.name ?? '';
+        if (name.startsWith('obstacle')) {
+          this._emit('hit-obstacle');
+        } else if (name.startsWith('coin') && opts.track) {
+          const coin = opts.track.coins.find(c => c.node === event.otherNode);
+          if (coin && !coin.collected) {
+            this._emit('collect-coin', coin);
+          }
+        }
+      });
+    }
+  }
+
+  on(event: EventType, cb: (data?: CoinHandle) => void): void {
+    if (!this._listeners.has(event)) this._listeners.set(event, []);
+    this._listeners.get(event)!.push(cb);
+  }
+
+  private _emit(event: EventType, data?: CoinHandle): void {
+    for (const cb of this._listeners.get(event) ?? []) cb(data);
   }
 
   /** 每帧调用：读输入 → 驱动 controller → 应用重力/碰撞 */

--- a/examples/runner-3d/src/track.ts
+++ b/examples/runner-3d/src/track.ts
@@ -1,0 +1,166 @@
+/**
+ * Track — 程序化生成跑道 + 障碍物 + 金币。
+ * Issue #212：M1.2 跑道地形 + 障碍物 + 收集品（碰撞集成）
+ */
+import { Node3D } from '../../../src/core/node3d';
+import { CollisionWorld } from '../../../src/physics/collision';
+import { BoxCollider } from '../../../src/physics/box-collider';
+import { vec3 } from '../../../src/math/vec3';
+
+// 碰撞层（bitmask）
+export const LAYER_GROUND = 1 << 0;    // 0b0001 = 1
+export const LAYER_OBSTACLE = 1 << 1;  // 0b0010 = 2
+export const LAYER_COIN = 1 << 2;      // 0b0100 = 4
+export const LAYER_PLAYER = 1 << 3;    // 0b1000 = 8
+
+export interface TrackOptions {
+  /** 跑道长度（米，Z 方向） */
+  length: number;
+  /** 跑道宽度（X 方向） */
+  width: number;
+  obstacleCount: number;
+  coinCount: number;
+  /** 确定性种子（用于测试复现） */
+  seed?: number;
+}
+
+export interface CoinHandle {
+  node: Node3D;
+  collected: boolean;
+  position: [number, number, number];
+}
+
+export interface ObstacleHandle {
+  node: Node3D;
+  position: [number, number, number];
+  size: [number, number, number];
+}
+
+/** 简单线性同余伪随机数生成器，返回 [0, 1) 范围 */
+class SeededRng {
+  private state: number;
+
+  constructor(seed: number) {
+    this.state = seed >>> 0; // 转为 uint32
+  }
+
+  next(): number {
+    // LCG 参数（Numerical Recipes）
+    this.state = (Math.imul(this.state, 1664525) + 1013904223) >>> 0;
+    return this.state / 0x100000000;
+  }
+
+  /** 返回 [min, max) 范围内的随机数 */
+  range(min: number, max: number): number {
+    return min + this.next() * (max - min);
+  }
+}
+
+export class Track {
+  readonly root: Node3D;
+  readonly coins: CoinHandle[] = [];
+  readonly obstacles: ObstacleHandle[] = [];
+
+  constructor(opts: TrackOptions, world: CollisionWorld) {
+    this.root = new Node3D('track');
+    const rng = new SeededRng(opts.seed ?? 0);
+
+    // 1. 生成地面：跑道长度覆盖整个 length，Y 在 0 以下
+    const groundNode = new Node3D('ground');
+    groundNode.position[0] = 0;
+    groundNode.position[1] = -0.1;
+    groundNode.position[2] = opts.length / 2;
+    const groundCollider = new BoxCollider(
+      vec3(opts.width / 2, 0.1, opts.length / 2),
+      vec3(0, 0, 0),
+    );
+    world.addBody(groundNode, {
+      shape: groundCollider,
+      layer: LAYER_GROUND,
+      mask: LAYER_PLAYER,
+    });
+    this.root.addChild(groundNode);
+
+    // 2. 障碍物：随机分布在 Z [5, length-5]，X [-width/2+0.5, width/2-0.5]
+    const obstacleHalfW = 0.5;
+    const obstacleHalfH = 0.75;
+    const obstacleHalfD = 0.5;
+    const marginZ = 5;
+    const marginX = obstacleHalfW + 0.1;
+
+    for (let i = 0; i < opts.obstacleCount; i++) {
+      const x = rng.range(-opts.width / 2 + marginX, opts.width / 2 - marginX);
+      const z = rng.range(marginZ, opts.length - marginZ);
+      const pos: [number, number, number] = [
+        Math.round(x * 100) / 100,
+        obstacleHalfH,        // Y 中心 = 高度一半（放在地面上）
+        Math.round(z * 100) / 100,
+      ];
+      const size: [number, number, number] = [
+        obstacleHalfW * 2,
+        obstacleHalfH * 2,
+        obstacleHalfD * 2,
+      ];
+
+      const node = new Node3D(`obstacle-${i}`);
+      node.position[0] = pos[0];
+      node.position[1] = pos[1];
+      node.position[2] = pos[2];
+
+      const collider = new BoxCollider(
+        vec3(obstacleHalfW, obstacleHalfH, obstacleHalfD),
+        vec3(0, 0, 0),
+      );
+      world.addBody(node, {
+        shape: collider,
+        layer: LAYER_OBSTACLE,
+        mask: LAYER_PLAYER,
+      });
+
+      this.root.addChild(node);
+      this.obstacles.push({ node, position: pos, size });
+    }
+
+    // 3. 金币：随机分布在 Z [5, length-5]，X 跑道内，Y 略高于地面
+    const coinHalfSize = 0.3;
+    const coinY = 0.6; // 悬浮在地面上方
+
+    for (let i = 0; i < opts.coinCount; i++) {
+      const x = rng.range(-opts.width / 2 + coinHalfSize, opts.width / 2 - coinHalfSize);
+      const z = rng.range(marginZ, opts.length - marginZ);
+      const pos: [number, number, number] = [
+        Math.round(x * 100) / 100,
+        coinY,
+        Math.round(z * 100) / 100,
+      ];
+
+      const node = new Node3D(`coin-${i}`);
+      node.position[0] = pos[0];
+      node.position[1] = pos[1];
+      node.position[2] = pos[2];
+
+      const collider = new BoxCollider(
+        vec3(coinHalfSize, coinHalfSize, coinHalfSize),
+        vec3(0, 0, 0),
+      );
+      world.addBody(node, {
+        shape: collider,
+        layer: LAYER_COIN,
+        mask: LAYER_PLAYER,
+        isTrigger: true,
+      });
+
+      this.root.addChild(node);
+      this.coins.push({ node, collected: false, position: pos });
+    }
+  }
+
+  /**
+   * 玩家穿过金币时调用：标记为已收集，从场景和碰撞世界移除。
+   */
+  collectCoin(handle: CoinHandle, world: CollisionWorld): void {
+    handle.collected = true;
+    handle.node.parent?.removeChild(handle.node);
+    world.removeCollider(handle.node);
+  }
+}

--- a/examples/runner-3d/test/integration/track.test.ts
+++ b/examples/runner-3d/test/integration/track.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Track 集成测试 — Issue #212
+ *
+ * 验证跑道生成、障碍物/金币布局确定性、raycast 检测和 collectCoin 逻辑。
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Track, LAYER_OBSTACLE, LAYER_COIN } from '../../src/track';
+import { CollisionWorld } from '../../../../src/physics/collision';
+import { vec3 } from '../../../../src/math/vec3';
+
+describe('Track 集成测试', () => {
+  let world: CollisionWorld;
+  let track: Track;
+
+  beforeEach(() => {
+    world = new CollisionWorld();
+    track = new Track({ length: 100, width: 4, obstacleCount: 5, coinCount: 10, seed: 42 }, world);
+  });
+
+  it('在 +Z 方向生成 length 长度的跑道', () => {
+    expect(track.root.children.length).toBeGreaterThan(0);
+  });
+
+  it('生成 5 个障碍物 + 10 个金币', () => {
+    expect(track.obstacles.length).toBe(5);
+    expect(track.coins.length).toBe(10);
+  });
+
+  it('障碍物 z 坐标都在跑道范围内', () => {
+    for (const o of track.obstacles) {
+      expect(o.position[2]).toBeGreaterThanOrEqual(0);
+      expect(o.position[2]).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('seed 相同则障碍物布局确定', () => {
+    const w2 = new CollisionWorld();
+    const t2 = new Track({ length: 100, width: 4, obstacleCount: 5, coinCount: 10, seed: 42 }, w2);
+    for (let i = 0; i < 5; i++) {
+      expect(t2.obstacles[i].position).toEqual(track.obstacles[i].position);
+    }
+  });
+
+  it('raycast 从玩家位置向前检测到障碍物', () => {
+    // 将玩家放到第一个障碍物前 1 米，向 +Z 射线
+    const obs = track.obstacles[0];
+    const origin = vec3(obs.position[0], obs.position[1], obs.position[2] - 3);
+    const direction = vec3(0, 0, 1);
+
+    // 只检测 LAYER_OBSTACLE 层，向前 10 米内
+    const hits = world.raycast(origin, direction, 10, LAYER_OBSTACLE);
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].distance).toBeLessThan(10);
+  });
+
+  it('collectCoin 移除金币节点和碰撞体', () => {
+    const coin = track.coins[0];
+    expect(coin.collected).toBe(false);
+
+    track.collectCoin(coin, world);
+
+    expect(coin.collected).toBe(true);
+    expect(coin.node.parent).toBe(null);
+    // 移除后 world 中不再有该节点
+    const hits = world.raycast(
+      vec3(coin.position[0], coin.position[1], coin.position[2] - 5),
+      vec3(0, 0, 1),
+      20,
+      LAYER_COIN,
+    );
+    const wasHit = hits.some(h => h.node === coin.node);
+    expect(wasHit).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概述

实现 Issue #212：在 examples/runner-3d/ 中搭建跑酷游戏的"世界"——程序化生成跑道 + 障碍物（BoxCollider）+ 金币（BoxCollider trigger），验证碰撞系统在真实场景中可用。

## 变更内容

### 新增文件

- `examples/runner-3d/src/track.ts` — Track 类
  - `SeededRng`：LCG 确定性伪随机数
  - 四个碰撞层：`LAYER_GROUND` / `LAYER_OBSTACLE` / `LAYER_COIN` / `LAYER_PLAYER`
  - `Track` 构造：地面 + N 障碍物(LAYER_OBSTACLE) + N 金币(LAYER_COIN trigger)，全部注册到 CollisionWorld
  - `collectCoin()`：从场景图 + CollisionWorld 双重移除金币

- `examples/runner-3d/test/integration/track.test.ts` — 6 项集成测试全通过

### 修改文件

- `examples/runner-3d/src/player.ts`：注册 LAYER_PLAYER 碰撞体，碰撞回调 emit 事件
- `examples/runner-3d/src/game.ts`：集成 CollisionWorld + Track，update 调用 world.step()

## 测试

全量 104 文件 / 1532 测试全部通过。

close #212