### PR TITLE
feat: M1.3 骨骼动画状态机 idle/run/jump 平滑切换

### DIFF
--- a/examples/runner-3d/src/anim-fixtures.ts
+++ b/examples/runner-3d/src/anim-fixtures.ts
@@ -1,0 +1,56 @@
+/**
+ * 程序化生成用于测试的最简骨骼和动画片段。
+ * 不依赖外部 glTF 文件，仅用于集成测试。
+ */
+
+import { Skeleton, type BoneData } from '../../../src/animation/skeleton';
+import { AnimationClip } from '../../../src/animation/animation-clip';
+import { KeyframeTrack } from '../../../src/animation/keyframe-track';
+
+/** 创建 2 骨骼的 stub 骨架：root + spine */
+export function makeStubSkeleton(): Skeleton {
+  const bones: BoneData[] = [
+    { name: 'root', parentIndex: -1 },
+    { name: 'spine', parentIndex: 0 },
+  ];
+  // 单位逆绑定矩阵（2 根骨骼）
+  const ibm = new Float32Array(2 * 16);
+  for (let i = 0; i < 2; i++) {
+    const b = i * 16;
+    ibm[b + 0] = 1; ibm[b + 5] = 1; ibm[b + 10] = 1; ibm[b + 15] = 1;
+  }
+  return new Skeleton(bones, ibm);
+}
+
+/** idle: root 微微上下浮动，0.5s loop */
+export function makeIdleClip(): AnimationClip {
+  const track = new KeyframeTrack({
+    targetPath: 'translation',
+    jointIndex: 0,
+    times: new Float32Array([0, 0.25, 0.5]),
+    values: new Float32Array([0, 0, 0,  0, 0.1, 0,  0, 0, 0]),
+  });
+  return new AnimationClip('idle', [track]);
+}
+
+/** run: spine 来回俯仰，0.4s loop */
+export function makeRunClip(): AnimationClip {
+  const track = new KeyframeTrack({
+    targetPath: 'rotation',
+    jointIndex: 1,
+    times: new Float32Array([0, 0.2, 0.4]),
+    values: new Float32Array([0, 0, 0, 1,  0, 0.1, 0, 0.995,  0, 0, 0, 1]),
+  });
+  return new AnimationClip('run', [track]);
+}
+
+/** jump: root y 跳一下，0.6s 不循环 */
+export function makeJumpClip(): AnimationClip {
+  const track = new KeyframeTrack({
+    targetPath: 'translation',
+    jointIndex: 0,
+    times: new Float32Array([0, 0.3, 0.6]),
+    values: new Float32Array([0, 0, 0,  0, 1, 0,  0, 0, 0]),
+  });
+  return new AnimationClip('jump', [track]);
+}

--- a/examples/runner-3d/src/animator.ts
+++ b/examples/runner-3d/src/animator.ts
@@ -1,0 +1,70 @@
+/**
+ * PlayerAnimator — 骨骼动画状态机，包装 AnimationMixer 实现 idle/run/jump 平滑切换。
+ */
+
+import { AnimationMixer } from '../../../src/animation/animation-mixer';
+import type { AnimationAction } from '../../../src/animation/animation-action';
+import type { AnimationClip } from '../../../src/animation/animation-clip';
+import type { Skeleton } from '../../../src/animation/skeleton';
+
+export type PlayerAnimState = 'idle' | 'run' | 'jump';
+
+export class PlayerAnimator {
+  readonly mixer: AnimationMixer;
+  private actions: Record<PlayerAnimState, AnimationAction>;
+  private current: PlayerAnimState = 'idle';
+
+  constructor(
+    skeleton: Skeleton,
+    clips: { idle: AnimationClip; run: AnimationClip; jump: AnimationClip },
+  ) {
+    this.mixer = new AnimationMixer(skeleton);
+    this.actions = {
+      idle: this.mixer.clipAction(clips.idle),
+      run: this.mixer.clipAction(clips.run),
+      jump: this.mixer.clipAction(clips.jump),
+    };
+
+    this.actions.idle.loop = true;
+    this.actions.run.loop = true;
+    this.actions.jump.loop = false;
+
+    // idle 为初始激活状态
+    this.actions.idle.weight = 1;
+    this.actions.idle.play();
+
+    // run / jump 初始不激活（weight=0 使 effectiveWeight=0）
+    this.actions.run.weight = 0;
+    this.actions.jump.weight = 0;
+  }
+
+  /**
+   * 切换到目标状态，使用 crossFadeTo 平滑过渡。
+   * 必须先激活目标 action 的 weight，否则 fadeIn 无效。
+   */
+  setState(state: PlayerAnimState, fadeDuration = 0.2): void {
+    if (state === this.current) return;
+
+    const from = this.actions[this.current];
+    const to = this.actions[state];
+
+    // 激活目标权重，使 crossFade 的 fadeIn 能产生 effectiveWeight > 0
+    to.weight = 1;
+    from.crossFadeTo(to, fadeDuration);
+
+    this.current = state;
+  }
+
+  update(dt: number): void {
+    this.mixer.update(dt);
+  }
+
+  /** 获取指定状态的有效权重（用于测试验证 crossFade 过渡过程） */
+  getEffectiveWeight(state: PlayerAnimState): number {
+    return this.actions[state].effectiveWeight;
+  }
+
+  get state(): PlayerAnimState {
+    return this.current;
+  }
+}

--- a/examples/runner-3d/src/player.ts
+++ b/examples/runner-3d/src/player.ts
@@ -4,6 +4,8 @@ import { InputManager } from '../../../src/core/input';
 import { CollisionWorld, SphereCollider } from '../../../src/physics/collision';
 import { vec3 } from '../../../src/math/vec3';
 import { LAYER_PLAYER, LAYER_OBSTACLE, LAYER_COIN, type CoinHandle, type Track } from './track';
+import { PlayerAnimator } from './animator';
+import { makeStubSkeleton, makeIdleClip, makeRunClip, makeJumpClip } from './anim-fixtures';
 
 type EventType = 'hit-obstacle' | 'collect-coin';
 
@@ -17,6 +19,7 @@ export interface PlayerOptions {
 export class Player {
   readonly node: Node3D;
   readonly controller: CharacterController;
+  readonly animator: PlayerAnimator;
   private input: InputManager | null;
   private _listeners: Map<EventType, Array<(data?: CoinHandle) => void>> = new Map();
 
@@ -60,6 +63,14 @@ export class Player {
         }
       });
     }
+
+    // 初始化骨骼动画（使用程序化 stub 骨架）
+    const skeleton = makeStubSkeleton();
+    this.animator = new PlayerAnimator(skeleton, {
+      idle: makeIdleClip(),
+      run: makeRunClip(),
+      jump: makeJumpClip(),
+    });
   }
 
   on(event: EventType, cb: (data?: CoinHandle) => void): void {
@@ -71,7 +82,7 @@ export class Player {
     for (const cb of this._listeners.get(event) ?? []) cb(data);
   }
 
-  /** 每帧调用：读输入 → 驱动 controller → 应用重力/碰撞 */
+  /** 每帧调用：读输入 → 驱动 controller → 更新动画状态 */
   update(dt: number): void {
     if (this.input) {
       const left = this.input.isKeyDown('ArrowLeft') || this.input.isKeyDown('a');
@@ -86,6 +97,18 @@ export class Player {
       if (jump) this.controller.jump();
     }
     this.controller.update(dt);
+
+    // 根据 controller 状态切换动画
+    const vel = this.controller.velocity;
+    const horizSpeed = Math.sqrt(vel[0] * vel[0] + vel[2] * vel[2]);
+    if (!this.controller.isGrounded) {
+      this.animator.setState('jump');
+    } else if (horizSpeed > 0.1) {
+      this.animator.setState('run');
+    } else {
+      this.animator.setState('idle');
+    }
+    this.animator.update(dt);
   }
 
   get position() { return this.node.position; }

--- a/examples/runner-3d/test/integration/animation.test.ts
+++ b/examples/runner-3d/test/integration/animation.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { PlayerAnimator } from '../../src/animator';
+import { makeStubSkeleton, makeIdleClip, makeRunClip, makeJumpClip } from '../../src/anim-fixtures';
+
+describe('PlayerAnimator 状态切换', () => {
+  it('初始状态为 idle，weight=1', () => {
+    const skel = makeStubSkeleton();
+    const animator = new PlayerAnimator(skel, {
+      idle: makeIdleClip(), run: makeRunClip(), jump: makeJumpClip(),
+    });
+    expect(animator.state).toBe('idle');
+  });
+
+  it('切换到 run 后状态更新', () => {
+    const skel = makeStubSkeleton();
+    const animator = new PlayerAnimator(skel, {
+      idle: makeIdleClip(), run: makeRunClip(), jump: makeJumpClip(),
+    });
+    animator.setState('run');
+    expect(animator.state).toBe('run');
+  });
+
+  it('crossFade 过程中两个 action 权重都 > 0', () => {
+    const skel = makeStubSkeleton();
+    const animator = new PlayerAnimator(skel, {
+      idle: makeIdleClip(), run: makeRunClip(), jump: makeJumpClip(),
+    });
+    animator.setState('run', 0.5); // 0.5s 过渡
+    animator.update(0.25); // 走过渡一半
+    // 两个 action 的 effectiveWeight 都应该在 (0, 1) 之间
+    expect(animator.getEffectiveWeight('idle')).toBeGreaterThan(0);
+    expect(animator.getEffectiveWeight('run')).toBeGreaterThan(0);
+  });
+
+  it('mixer.update 真的驱动骨骼变换', () => {
+    const skel = makeStubSkeleton();
+    const animator = new PlayerAnimator(skel, {
+      idle: makeIdleClip(), run: makeRunClip(), jump: makeJumpClip(),
+    });
+    // bone 0 的 Y 分量初始为 0（localPositions 全零初始化）
+    const initialBoneY = skel.localPositions[1];
+    animator.update(0.25); // idle clip 在 0.25s 处 y=0.1
+    // 骨骼 position 应该被动画驱动而改变
+    expect(skel.localPositions[1]).not.toBe(initialBoneY);
+  });
+
+  it('jump 不 loop，结束后保持终态', () => {
+    const skel = makeStubSkeleton();
+    const animator = new PlayerAnimator(skel, {
+      idle: makeIdleClip(), run: makeRunClip(), jump: makeJumpClip(),
+    });
+    animator.setState('jump');
+    animator.update(2); // 远超 jump 时长（0.6s）
+    // jump action 应该已经停止或保持终态，不报错
+    expect(animator.state).toBe('jump');
+  });
+});


### PR DESCRIPTION
## 概述

实现 Issue #213 要求的骨骼动画状态机，为 `examples/runner-3d/` 玩家添加 idle/run/jump 动画平滑切换。

## 变更内容

- **`anim-fixtures.ts`**：程序化构造 2 骨骼 Skeleton（root + spine）+ 三段 AnimationClip，无需外部 glTF 文件
- **`animator.ts`**：`PlayerAnimator` 状态机，封装 `AnimationMixer`，通过 `crossFadeTo` 实现 0.2s 默认淡入淡出
- **`player.ts`**：集成 `PlayerAnimator`，根据 `controller.isGrounded` 和水平速度自动切换动画状态
- **`animation.test.ts`**：5 个集成测试，覆盖初始状态、状态切换、crossFade 权重共存、骨骼变换驱动、jump 非循环终态

## API 关键发现

- `KeyframeTrack.targetPath` 为 `'translation'`（不是 `'position'`）
- `weight=0` 的 action 在 crossFade 中 `effectiveWeight` 永远为 0，因此 `setState` 时先激活目标 `weight=1`
- `AnimationAction` 有 `crossFadeTo(action, duration)` 内置方法

## 测试结果

- examples/runner-3d 集成测试：9 passed（含新增 5 个）
- 根目录全量单元测试：1532 passed，0 failed

close #213