### PR TITLE
feat: M2.3 塔放置系统 — Raycast picking + grid 对齐 + 占位检查

### DIFF
--- a/examples/tower-defense-3d/src/picker.ts
+++ b/examples/tower-defense-3d/src/picker.ts
@@ -1,0 +1,48 @@
+import type { Map } from './map';
+import type { OrbitCamera } from '../../../src/core/orbit-camera';
+import { Raycaster } from '../../../src/core/ray';
+
+export interface PickerHit {
+  gridX: number;
+  gridY: number;
+  world: [number, number, number];
+}
+
+export class Picker {
+  constructor(public camera: OrbitCamera, public map: Map) {}
+
+  /** 根据屏幕 NDC 坐标 (-1..1) 拾取地面 cell（y=0 平面）。 */
+  pickAtNDC(ndcX: number, ndcY: number): PickerHit | null {
+    const raycaster = new Raycaster();
+    raycaster.setFromCamera({ x: ndcX, y: ndcY }, this.camera);
+
+    const ray = raycaster.ray;
+    // 与 y=0 平面求交：origin.y + t * direction.y = 0
+    const dirY = ray.direction[1];
+    if (Math.abs(dirY) < 1e-10) return null; // 射线平行于地面
+
+    const t = -ray.origin[1] / dirY;
+    if (t < 0) return null; // 交点在射线起点后方
+
+    const worldX = ray.origin[0] + t * ray.direction[0];
+    const worldZ = ray.origin[2] + t * ray.direction[2];
+
+    // 世界坐标转 grid 坐标
+    const grid = this.map.grid;
+    const halfW = grid.width / 2;
+    const halfH = grid.height / 2;
+    const cs = this.map.cellSize;
+
+    const gx = Math.floor((worldX + halfW * cs) / cs);
+    const gy = Math.floor((worldZ + halfH * cs) / cs);
+
+    if (!grid.isInBounds(gx, gy)) return null;
+
+    const worldPos = this.map.gridToWorld(gx, gy);
+    return {
+      gridX: gx,
+      gridY: gy,
+      world: worldPos,
+    };
+  }
+}

--- a/examples/tower-defense-3d/src/tower-manager.ts
+++ b/examples/tower-defense-3d/src/tower-manager.ts
@@ -1,0 +1,40 @@
+import type { Map } from './map';
+import { Tower, type TowerType } from './tower';
+
+export class TowerManager {
+  readonly map: Map;
+  readonly towers: Tower[] = [];
+  private occupied = new globalThis.Map<string, Tower>();
+
+  constructor(map: Map) {
+    this.map = map;
+  }
+
+  isOccupied(gx: number, gy: number): boolean {
+    return this.occupied.has(`${gx},${gy}`);
+  }
+
+  /** 在 grid 坐标放置一座塔。返回 Tower 或 null（失败）。 */
+  place(gx: number, gy: number, type: TowerType): Tower | null {
+    if (!this.map.grid.isInBounds(gx, gy)) return null;
+    if (!this.map.grid.isWalkable(gx, gy)) return null;
+    if (this.isOccupied(gx, gy)) return null;
+
+    const worldPos = this.map.gridToWorld(gx, gy);
+    const tower = new Tower({ type, gridX: gx, gridY: gy, worldPosition: worldPos });
+    this.towers.push(tower);
+    this.occupied.set(`${gx},${gy}`, tower);
+    return tower;
+  }
+
+  /** 移除指定 grid 坐标的塔。返回是否成功。 */
+  remove(gx: number, gy: number): boolean {
+    const key = `${gx},${gy}`;
+    const tower = this.occupied.get(key);
+    if (!tower) return false;
+    this.occupied.delete(key);
+    const idx = this.towers.indexOf(tower);
+    if (idx !== -1) this.towers.splice(idx, 1);
+    return true;
+  }
+}

--- a/examples/tower-defense-3d/src/tower.ts
+++ b/examples/tower-defense-3d/src/tower.ts
@@ -1,0 +1,27 @@
+import { Node3D } from '../../../src/core/node3d';
+
+export type TowerType = 'arrow' | 'cannon';
+
+export interface TowerOptions {
+  type: TowerType;
+  gridX: number;
+  gridY: number;
+  worldPosition: [number, number, number];
+}
+
+export class Tower {
+  readonly node: Node3D;
+  readonly type: TowerType;
+  readonly gridX: number;
+  readonly gridY: number;
+
+  constructor(opts: TowerOptions) {
+    this.node = new Node3D(`tower-${opts.type}`);
+    this.node.position[0] = opts.worldPosition[0];
+    this.node.position[1] = opts.worldPosition[1];
+    this.node.position[2] = opts.worldPosition[2];
+    this.type = opts.type;
+    this.gridX = opts.gridX;
+    this.gridY = opts.gridY;
+  }
+}

--- a/examples/tower-defense-3d/test/integration/tower-placement.test.ts
+++ b/examples/tower-defense-3d/test/integration/tower-placement.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { Map } from '../../src/map';
+import { TowerManager } from '../../src/tower-manager';
+
+describe('TowerManager — 塔放置系统', () => {
+  it('在空闲 walkable cell 上放置成功', () => {
+    const map = new Map();
+    const mgr = new TowerManager(map);
+    const tower = mgr.place(1, 1, 'arrow');
+    expect(tower).not.toBeNull();
+    expect(mgr.towers.length).toBe(1);
+    expect(mgr.isOccupied(1, 1)).toBe(true);
+  });
+
+  it('已占用 cell 不能重复放置', () => {
+    const map = new Map();
+    const mgr = new TowerManager(map);
+    mgr.place(1, 1, 'arrow');
+    const second = mgr.place(1, 1, 'cannon');
+    expect(second).toBeNull();
+    expect(mgr.towers.length).toBe(1);
+  });
+
+  it('障碍 cell 不能放置（路径已被预设阻塞）', () => {
+    const map = new Map();
+    const mgr = new TowerManager(map);
+    // M2.1 中障碍在 x=4, y=2..h-2
+    const tower = mgr.place(4, 5, 'arrow');
+    expect(tower).toBeNull();
+  });
+
+  it('越界 cell 不能放置', () => {
+    const map = new Map();
+    const mgr = new TowerManager(map);
+    expect(mgr.place(-1, 0, 'arrow')).toBeNull();
+    expect(mgr.place(0, 999, 'arrow')).toBeNull();
+  });
+
+  it('remove 移除塔后 cell 重新空闲', () => {
+    const map = new Map();
+    const mgr = new TowerManager(map);
+    mgr.place(1, 1, 'arrow');
+    expect(mgr.remove(1, 1)).toBe(true);
+    expect(mgr.isOccupied(1, 1)).toBe(false);
+    expect(mgr.towers.length).toBe(0);
+  });
+
+  it('Tower 世界坐标位于对应 grid cell 上', () => {
+    const map = new Map();
+    const mgr = new TowerManager(map);
+    const tower = mgr.place(2, 3, 'arrow')!;
+    const expected = map.gridToWorld(2, 3);
+    expect(tower.node.position[0]).toBeCloseTo(expected[0]);
+    expect(tower.node.position[2]).toBeCloseTo(expected[2]);
+  });
+});


### PR DESCRIPTION
## 概要

实现 Issue #230 — M2.3 塔放置系统。

- `tower.ts` — Tower 类：gridX/gridY/type + Node3D 位置
- `tower-manager.ts` — TowerManager：放置/移除/占用检测，用 `globalThis.Map` 避免与游戏 Map 类命名冲突
- `picker.ts` — Picker：NDC 坐标 → Raycaster → y=0 平面求交 → grid 坐标
- `test/integration/tower-placement.test.ts` — 6 个集成测试全部通过

## 测试结果

```
✓ test/integration/tower-placement.test.ts (6 tests)
✓ test/integration/map.test.ts (6 tests)
根目录: 105 passed | 2 skipped (107 files), 1535 tests
```

## Picker 实现说明

`OrbitCamera` 已通过 `Raycaster.setFromCamera()` 支持 NDC → 世界射线转换，无需新增 `unproject` API，未开 api-friction issue。

close #230