### PR TITLE
feat: M2.2 敌人波次系统 — Enemy/NavAgent/WaveSpawner

### DIFF
--- a/examples/tower-defense-3d/src/enemy.ts
+++ b/examples/tower-defense-3d/src/enemy.ts
@@ -1,0 +1,57 @@
+import { Node3D } from '../../../src/core/node3d';
+import { NavAgent } from '../../../src/navigation/nav-agent';
+import type { Map } from './map';
+
+export interface EnemyOptions {
+  map: Map;
+  speed?: number;
+  maxHealth?: number;
+}
+
+export class Enemy {
+  readonly node: Node3D;
+  readonly agent: NavAgent;
+  readonly maxHealth: number;
+  health: number;
+  reachedEnd: boolean = false;
+  dead: boolean = false;
+
+  constructor(opts: EnemyOptions) {
+    this.node = new Node3D('enemy');
+    this.maxHealth = opts.maxHealth ?? 100;
+    this.health = this.maxHealth;
+
+    // 起点世界坐标
+    const [sx, sy, sz] = opts.map.gridToWorld(opts.map.start.x, opts.map.start.y);
+    this.node.position[0] = sx;
+    this.node.position[1] = sy;
+    this.node.position[2] = sz;
+
+    // 把 grid path 转成世界 [x, z] waypoints（NavAgent 只用 x/z）
+    const waypoints = opts.map.path.map(
+      (p): [number, number] => {
+        const [wx, , wz] = opts.map.gridToWorld(p.x, p.y);
+        return [wx, wz];
+      }
+    );
+
+    this.agent = new NavAgent(this.node, opts.speed ?? 2);
+    this.agent.onArrived(() => {
+      this.reachedEnd = true;
+    });
+    this.agent.followPath(waypoints);
+  }
+
+  update(dt: number): void {
+    if (this.dead || this.reachedEnd) return;
+    this.agent.update(dt);
+  }
+
+  takeDamage(amount: number): void {
+    this.health -= amount;
+    if (this.health <= 0) {
+      this.health = 0;
+      this.dead = true;
+    }
+  }
+}

--- a/examples/tower-defense-3d/src/game.ts
+++ b/examples/tower-defense-3d/src/game.ts
@@ -5,6 +5,7 @@ import { InputManager } from '../../../src/core/input';
 import { vec3 } from '../../../src/math/vec3';
 import { Map } from './map';
 import { CameraRig } from './camera-rig';
+import { WaveSpawner, Wave } from './wave-spawner';
 
 export class Game {
   private scene: Scene;
@@ -13,6 +14,8 @@ export class Game {
   private loop: GameLoop;
   private input: InputManager;
   private map: Map;
+  private waveSpawner: WaveSpawner;
+  lives: number = 20;
 
   constructor(canvas: HTMLCanvasElement) {
     const gl = canvas.getContext('webgl', {
@@ -27,6 +30,13 @@ export class Game {
 
     this.map = new Map({ width: 12, height: 12, cellSize: 1 });
     this.scene.addChild(this.map.node);
+
+    const waves: Wave[] = [
+      { count: 5, interval: 1.0, enemyHealth: 100 },
+      { count: 8, interval: 0.8, enemyHealth: 150 },
+      { count: 10, interval: 0.5, enemyHealth: 200 },
+    ];
+    this.waveSpawner = new WaveSpawner(this.map, waves);
 
     this.cameraRig = new CameraRig({
       aspect: canvas.width / canvas.height,
@@ -55,6 +65,16 @@ export class Game {
 
   private update(dt: number): void {
     this.cameraRig.update(dt);
+    this.waveSpawner.update(dt);
+
+    // 到达终点的敌人扣血
+    for (const enemy of this.waveSpawner.enemies) {
+      if (enemy.reachedEnd && this.lives > 0) {
+        this.lives--;
+        // 标记为 dead 防止重复扣血
+        enemy.dead = true;
+      }
+    }
   }
 
   private render(): void {

--- a/examples/tower-defense-3d/src/wave-spawner.ts
+++ b/examples/tower-defense-3d/src/wave-spawner.ts
@@ -1,0 +1,51 @@
+import { Enemy } from './enemy';
+import type { Map } from './map';
+
+export interface Wave {
+  count: number;       // 本波敌人数
+  interval: number;    // 出怪间隔（秒）
+  enemyHealth: number; // 本波敌人血量
+}
+
+export class WaveSpawner {
+  private waves: Wave[];
+  private currentWave: number = 0;
+  private spawnedInWave: number = 0;
+  private timeSinceLastSpawn: number = 0;
+  private map: Map;
+  readonly enemies: Enemy[] = [];
+
+  constructor(map: Map, waves: Wave[]) {
+    this.map = map;
+    this.waves = waves;
+  }
+
+  update(dt: number): void {
+    if (this.currentWave >= this.waves.length) return;
+    const wave = this.waves[this.currentWave];
+    this.timeSinceLastSpawn += dt;
+    while (
+      this.spawnedInWave < wave.count &&
+      this.timeSinceLastSpawn >= wave.interval
+    ) {
+      const enemy = new Enemy({ map: this.map, maxHealth: wave.enemyHealth });
+      this.enemies.push(enemy);
+      this.spawnedInWave++;
+      this.timeSinceLastSpawn -= wave.interval;
+    }
+    if (this.spawnedInWave >= wave.count) {
+      this.currentWave++;
+      this.spawnedInWave = 0;
+      // 重置计时器，等待下一波
+      this.timeSinceLastSpawn = 0;
+    }
+
+    // 推进所有活敌人
+    for (const e of this.enemies) e.update(dt);
+  }
+
+  /** 当前活敌人数（未死亡且未到达终点） */
+  get activeEnemies(): number {
+    return this.enemies.filter(e => !e.dead && !e.reachedEnd).length;
+  }
+}

--- a/examples/tower-defense-3d/test/integration/wave.test.ts
+++ b/examples/tower-defense-3d/test/integration/wave.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { Map } from '../../src/map';
+import { Enemy } from '../../src/enemy';
+import { WaveSpawner } from '../../src/wave-spawner';
+
+describe('Enemy — NavAgent 路径跟随', () => {
+  it('生成在路径起点', () => {
+    const map = new Map();
+    const enemy = new Enemy({ map });
+    const [sx, , sz] = map.gridToWorld(map.start.x, map.start.y);
+    expect(enemy.node.position[0]).toBeCloseTo(sx);
+    expect(enemy.node.position[2]).toBeCloseTo(sz);
+  });
+
+  it('update 后向终点移动', () => {
+    const map = new Map();
+    const enemy = new Enemy({ map, speed: 5 });
+    const x0 = enemy.node.position[0];
+    for (let i = 0; i < 60; i++) enemy.update(1 / 60);
+    expect(enemy.node.position[0]).toBeGreaterThan(x0);
+  });
+
+  it('受伤至 0 进入 dead 状态', () => {
+    const map = new Map();
+    const enemy = new Enemy({ map, maxHealth: 50 });
+    enemy.takeDamage(20);
+    expect(enemy.dead).toBe(false);
+    expect(enemy.health).toBe(30);
+    enemy.takeDamage(50);
+    expect(enemy.dead).toBe(true);
+    expect(enemy.health).toBe(0);
+  });
+
+  it('沿足够长时间最终到达终点', () => {
+    const map = new Map();
+    const enemy = new Enemy({ map, speed: 10 });
+    for (let i = 0; i < 600; i++) enemy.update(1 / 60); // 10 秒
+    expect(enemy.reachedEnd).toBe(true);
+  });
+});
+
+describe('WaveSpawner — 波次出怪', () => {
+  it('按 interval 生成正确数量的敌人', () => {
+    const map = new Map();
+    const spawner = new WaveSpawner(map, [
+      { count: 5, interval: 0.5, enemyHealth: 100 },
+    ]);
+    // 模拟 3 秒：应该生成 5 个敌人
+    for (let i = 0; i < 180; i++) spawner.update(1 / 60);
+    expect(spawner.enemies.length).toBe(5);
+  });
+
+  it('多波次依次执行', () => {
+    const map = new Map();
+    const spawner = new WaveSpawner(map, [
+      { count: 2, interval: 0.5, enemyHealth: 50 },
+      { count: 3, interval: 0.5, enemyHealth: 80 },
+    ]);
+    for (let i = 0; i < 600; i++) spawner.update(1 / 60); // 10 秒
+    expect(spawner.enemies.length).toBe(5);
+  });
+
+  it('activeEnemies 反映当前活敌人数', () => {
+    const map = new Map();
+    const spawner = new WaveSpawner(map, [
+      { count: 3, interval: 0.5, enemyHealth: 100 },
+    ]);
+    for (let i = 0; i < 180; i++) spawner.update(1 / 60);
+    expect(spawner.activeEnemies).toBeLessThanOrEqual(3);
+    spawner.enemies[0].takeDamage(999);
+    expect(spawner.activeEnemies).toBeLessThan(3);
+  });
+});


### PR DESCRIPTION
## Summary

- 实现 `enemy.ts`：Enemy 类封装 Node3D + NavAgent，沿 A\* 路径移动，支持血量/死亡/到达终点状态
- 实现 `wave-spawner.ts`：WaveSpawner 按时间间隔逐个生成 Enemy，支持多波次依次执行
- 更新 `game.ts`：集成 WaveSpawner 到 update 循环，到达终点的敌人扣 `game.lives`
- 新增 `test/integration/wave.test.ts`：7 项验收测试全部通过

## 实现说明

NavAgent 的真实构造签名为 `constructor(node, speed)`，通过 `followPath([x,z][])` 设置路径，`onArrived()` 注册回调，与 issue 描述略有差异，已按现有 API 调整（未修改 `src/`）。

## Test plan

- [x] `examples/tower-defense-3d/` 下 `pnpm test` 通过：13 tests passed（含 map + wave）
- [x] 根目录单元测试全部通过：1535 passed
- [x] 未修改 `src/` 目录

close #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)