### PR TITLE
feat: M2.4 塔攻击系统 — StateMachine + Projectile + 命中粒子特效

### DIFF
--- a/examples/tower-defense-3d/src/combat.ts
+++ b/examples/tower-defense-3d/src/combat.ts
@@ -1,0 +1,58 @@
+import { Tower } from './tower';
+import { Enemy } from './enemy';
+import { Projectile } from './projectile';
+
+export class CombatSystem {
+  readonly projectiles: Projectile[] = [];
+
+  update(dt: number, towers: Tower[], enemies: Enemy[]): void {
+    for (const tower of towers) {
+      tower.cooldownLeft = Math.max(0, tower.cooldownLeft - dt);
+
+      // 目标失效（死亡或离开射程）→ 重置目标
+      if (tower.target && (tower.target.dead || this._dist(tower, tower.target) > tower.config.range)) {
+        tower.target = null;
+        tower.fsm.transition('idle');
+      }
+
+      // 搜索新目标
+      if (!tower.target) {
+        let nearest: Enemy | null = null;
+        let nearestDist = tower.config.range;
+        for (const e of enemies) {
+          if (e.dead || e.reachedEnd) continue;
+          const d = this._dist(tower, e);
+          if (d <= nearestDist) { nearest = e; nearestDist = d; }
+        }
+        tower.target = nearest;
+        if (tower.target) {
+          tower.fsm.transition('targeting');
+        }
+      }
+
+      // 攻击：目标有效且冷却结束
+      if (tower.target && tower.cooldownLeft <= 0) {
+        tower.fsm.transition('attacking');
+        const projectile = new Projectile({
+          target: tower.target,
+          damage: tower.config.damage,
+          from: [tower.node.position[0], tower.node.position[1] + 1, tower.node.position[2]],
+        });
+        this.projectiles.push(projectile);
+        tower.cooldownLeft = tower.config.cooldown;
+      }
+    }
+
+    // 推进 projectile，清理已完成的
+    for (const p of this.projectiles) p.update(dt);
+    for (let i = this.projectiles.length - 1; i >= 0; i--) {
+      if (this.projectiles[i].done) this.projectiles.splice(i, 1);
+    }
+  }
+
+  private _dist(tower: Tower, enemy: Enemy): number {
+    const dx = tower.node.position[0] - enemy.node.position[0];
+    const dz = tower.node.position[2] - enemy.node.position[2];
+    return Math.sqrt(dx * dx + dz * dz);
+  }
+}

--- a/examples/tower-defense-3d/src/projectile.ts
+++ b/examples/tower-defense-3d/src/projectile.ts
@@ -1,0 +1,62 @@
+import { Node3D } from '../../../src/core/node3d';
+import { ParticleEmitter } from '../../../src/renderer/particle-emitter';
+import { vec3 } from '../../../src/math/vec3';
+import type { Enemy } from './enemy';
+
+export class Projectile {
+  readonly node: Node3D;
+  readonly target: Enemy;
+  readonly damage: number;
+  readonly speed: number;
+  done: boolean = false;
+
+  constructor(opts: { target: Enemy; damage: number; from: [number, number, number]; speed?: number }) {
+    this.node = new Node3D('projectile');
+    this.node.position[0] = opts.from[0];
+    this.node.position[1] = opts.from[1];
+    this.node.position[2] = opts.from[2];
+    this.target = opts.target;
+    this.damage = opts.damage;
+    this.speed = opts.speed ?? 12;
+  }
+
+  update(dt: number): void {
+    if (this.done) return;
+    if (this.target.dead) { this.done = true; return; }
+
+    const dx = this.target.node.position[0] - this.node.position[0];
+    const dy = this.target.node.position[1] - this.node.position[1];
+    const dz = this.target.node.position[2] - this.node.position[2];
+    const distSq = dx * dx + dy * dy + dz * dz;
+
+    if (distSq < 0.25) {
+      this.target.takeDamage(this.damage);
+      this._spawnHitEffect();
+      this.done = true;
+      return;
+    }
+
+    const dist = Math.sqrt(distSq);
+    const move = Math.min(dist, this.speed * dt);
+    this.node.position[0] += (dx / dist) * move;
+    this.node.position[1] += (dy / dist) * move;
+    this.node.position[2] += (dz / dist) * move;
+  }
+
+  private _spawnHitEffect(): void {
+    const emitter = new ParticleEmitter({
+      maxParticles: 10,
+      emissionRate: 0,
+      lifetime: { min: 0.2, max: 0.5 },
+      speed: { min: 2, max: 5 },
+      size: { min: 0.1, max: 0.3 },
+      color: vec3(1, 0.5, 0),
+      colorEnd: vec3(1, 0.1, 0),
+      spread: Math.PI / 4,
+    });
+    emitter.position[0] = this.node.position[0];
+    emitter.position[1] = this.node.position[1];
+    emitter.position[2] = this.node.position[2];
+    emitter.emit(10);
+  }
+}

--- a/examples/tower-defense-3d/src/tower.ts
+++ b/examples/tower-defense-3d/src/tower.ts
@@ -1,4 +1,6 @@
 import { Node3D } from '../../../src/core/node3d';
+import { StateMachine } from '../../../src/gameplay/state-machine';
+import type { Enemy } from './enemy';
 
 export type TowerType = 'arrow' | 'cannon';
 
@@ -9,11 +11,28 @@ export interface TowerOptions {
   worldPosition: [number, number, number];
 }
 
+export interface TowerConfig {
+  range: number;
+  damage: number;
+  cooldown: number;
+}
+
+export const TOWER_CONFIGS: Record<TowerType, TowerConfig> = {
+  arrow:  { range: 4, damage: 15, cooldown: 0.6 },
+  cannon: { range: 3, damage: 40, cooldown: 1.5 },
+};
+
+type TowerState = 'idle' | 'targeting' | 'attacking';
+
 export class Tower {
   readonly node: Node3D;
   readonly type: TowerType;
   readonly gridX: number;
   readonly gridY: number;
+  readonly config: TowerConfig;
+  readonly fsm: StateMachine<TowerState>;
+  cooldownLeft: number = 0;
+  target: Enemy | null = null;
 
   constructor(opts: TowerOptions) {
     this.node = new Node3D(`tower-${opts.type}`);
@@ -23,5 +42,16 @@ export class Tower {
     this.type = opts.type;
     this.gridX = opts.gridX;
     this.gridY = opts.gridY;
+    this.config = TOWER_CONFIGS[opts.type];
+
+    this.fsm = new StateMachine<TowerState>(
+      { idle: {}, targeting: {}, attacking: {} },
+      'idle',
+    );
+    this.fsm.addTransition('idle', 'targeting');
+    this.fsm.addTransition('targeting', 'idle');
+    this.fsm.addTransition('targeting', 'attacking');
+    this.fsm.addTransition('attacking', 'targeting');
+    this.fsm.addTransition('attacking', 'idle');
   }
 }

--- a/examples/tower-defense-3d/test/integration/tower-combat.test.ts
+++ b/examples/tower-defense-3d/test/integration/tower-combat.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { Map } from '../../src/map';
+import { Enemy } from '../../src/enemy';
+import { Tower } from '../../src/tower';
+import { TowerManager } from '../../src/tower-manager';
+import { CombatSystem } from '../../src/combat';
+
+describe('CombatSystem — 塔攻击集成', () => {
+  it('射程内有敌人时发射 projectile', () => {
+    const map = new Map();
+    const mgr = new TowerManager(map);
+    const tower = mgr.place(3, 6, 'arrow')!;
+    // 把敌人放在塔旁
+    const enemy = new Enemy({ map });
+    enemy.node.position[0] = tower.node.position[0] + 1;
+    enemy.node.position[2] = tower.node.position[2];
+
+    const combat = new CombatSystem();
+    combat.update(1 / 60, [tower], [enemy]);
+    expect(combat.projectiles.length).toBeGreaterThan(0);
+  });
+
+  it('射程外的敌人不会被攻击', () => {
+    const map = new Map();
+    const mgr = new TowerManager(map);
+    const tower = mgr.place(3, 6, 'arrow')!;
+    const enemy = new Enemy({ map });
+    enemy.node.position[0] = tower.node.position[0] + 100;
+
+    const combat = new CombatSystem();
+    combat.update(1 / 60, [tower], [enemy]);
+    expect(combat.projectiles.length).toBe(0);
+  });
+
+  it('cooldown 内不会重复攻击', () => {
+    const map = new Map();
+    const mgr = new TowerManager(map);
+    const tower = mgr.place(3, 6, 'arrow')!;
+    const enemy = new Enemy({ map });
+    enemy.node.position[0] = tower.node.position[0] + 1;
+
+    const combat = new CombatSystem();
+    combat.update(1 / 60, [tower], [enemy]);
+    const after1 = combat.projectiles.length;
+    combat.update(1 / 60, [tower], [enemy]); // 立刻再 update
+    const after2 = combat.projectiles.length;
+    // 第二次 update 不应该新增 projectile（因为 cooldown）
+    expect(after2 - after1).toBeLessThanOrEqual(1);
+  });
+
+  it('projectile 命中后敌人扣血', () => {
+    const map = new Map();
+    const mgr = new TowerManager(map);
+    const tower = mgr.place(3, 6, 'arrow')!;
+    const enemy = new Enemy({ map, maxHealth: 200 });
+    enemy.node.position[0] = tower.node.position[0] + 1;
+
+    const combat = new CombatSystem();
+    // 多 step 让 projectile 命中
+    for (let i = 0; i < 60; i++) combat.update(1 / 60, [tower], [enemy]);
+    expect(enemy.health).toBeLessThan(200);
+  });
+
+  it('攻击致死的敌人正确进入 dead 状态', () => {
+    const map = new Map();
+    const mgr = new TowerManager(map);
+    const tower = mgr.place(3, 6, 'cannon')!; // 高伤害
+    const enemy = new Enemy({ map, maxHealth: 30 });
+    enemy.node.position[0] = tower.node.position[0] + 1;
+
+    const combat = new CombatSystem();
+    for (let i = 0; i < 120; i++) combat.update(1 / 60, [tower], [enemy]);
+    expect(enemy.dead).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **tower.ts** 扩展：加入 `TowerConfig`/`TOWER_CONFIGS`、`StateMachine<TowerState>`（idle/targeting/attacking）、`cooldownLeft`/`target` 字段
- **projectile.ts**（新增）：`Projectile` 类，追踪目标飞行，命中后调用 `takeDamage`，并通过 `ParticleEmitter` 触发命中爆炸特效
- **combat.ts**（新增）：`CombatSystem.update`，每帧协调塔搜索目标 → 发射抛射体 → 推进/清理完成的抛射体
- **tower-combat.test.ts**（新增）：5 项集成测试全部通过（射程内发射、射程外不攻击、cooldown 限制、命中扣血、致死状态）

## Test plan

- [x] `pnpm test`（examples/tower-defense-3d）：24 tests passed (含新增 5 项)
- [x] `pnpm run test`（根目录全量）：1535 tests passed, 0 failures

close #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)