### PR TITLE
feat: M3.1 examples/slg-3d 脚手架 + 大地图地形 + OrbitCamera

### DIFF
--- a/examples/slg-3d/index.html
+++ b/examples/slg-3d/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SLG 3D 大地图</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { background: #000; overflow: hidden; }
+    canvas { display: block; width: 100vw; height: 100vh; }
+  </style>
+</head>
+<body>
+  <canvas id="game-canvas"></canvas>
+  <script type="module" src="./src/main.ts"></script>
+</body>
+</html>

--- a/examples/slg-3d/package.json
+++ b/examples/slg-3d/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "slg-3d",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0",
+    "vite": "^6.3.0",
+    "vitest": "^3.1.0"
+  }
+}

--- a/examples/slg-3d/pnpm-lock.yaml
+++ b/examples/slg-3d/pnpm-lock.yaml
@@ -1,0 +1,942 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+devDependencies:
+  typescript:
+    specifier: ^5.8.0
+    version: 5.9.3
+  vite:
+    specifier: ^6.3.0
+    version: 6.4.2
+  vitest:
+    specifier: ^3.1.0
+    version: 3.2.4
+
+packages:
+
+  /@esbuild/aix-ppc64@0.25.12:
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.25.12:
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.25.12:
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/android-arm/-/android-arm-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.25.12:
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/android-x64/-/android-x64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.25.12:
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.25.12:
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.25.12:
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.25.12:
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.25.12:
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.25.12:
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.25.12:
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.25.12:
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.25.12:
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.25.12:
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.25.12:
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.25.12:
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.25.12:
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-arm64@0.25.12:
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.25.12:
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.25.12:
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.25.12:
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openharmony-arm64@0.25.12:
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.25.12:
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.25.12:
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.25.12:
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.25.12:
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@jridgewell/sourcemap-codec@1.5.5:
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz}
+    dev: true
+
+  /@rollup/rollup-android-arm-eabi@4.60.1:
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.60.1:
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.60.1:
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.60.1:
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-freebsd-arm64@4.60.1:
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-freebsd-x64@4.60.1:
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.60.1:
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-musleabihf@4.60.1:
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.60.1:
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.60.1:
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-loong64-gnu@4.60.1:
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-loong64-musl@4.60.1:
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-ppc64-gnu@4.60.1:
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-ppc64-musl@4.60.1:
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.60.1:
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-musl@4.60.1:
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-s390x-gnu@4.60.1:
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.60.1:
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.60.1:
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-openbsd-x64@4.60.1:
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-openharmony-arm64@4.60.1:
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.60.1:
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.60.1:
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-gnu@4.60.1:
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.60.1:
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@types/chai@5.2.3:
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@types/chai/-/chai-5.2.3.tgz}
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+    dev: true
+
+  /@types/deep-eql@4.0.2:
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@types/deep-eql/-/deep-eql-4.0.2.tgz}
+    dev: true
+
+  /@types/estree@1.0.8:
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@types/estree/-/estree-1.0.8.tgz}
+    dev: true
+
+  /@vitest/expect@3.2.4:
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@vitest/expect/-/expect-3.2.4.tgz}
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+    dev: true
+
+  /@vitest/mocker@3.2.4(vite@6.4.2):
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@vitest/mocker/-/mocker-3.2.4.tgz}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      vite: 6.4.2
+    dev: true
+
+  /@vitest/pretty-format@3.2.4:
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@vitest/pretty-format/-/pretty-format-3.2.4.tgz}
+    dependencies:
+      tinyrainbow: 2.0.0
+    dev: true
+
+  /@vitest/runner@3.2.4:
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@vitest/runner/-/runner-3.2.4.tgz}
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+    dev: true
+
+  /@vitest/snapshot@3.2.4:
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@vitest/snapshot/-/snapshot-3.2.4.tgz}
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+    dev: true
+
+  /@vitest/spy@3.2.4:
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@vitest/spy/-/spy-3.2.4.tgz}
+    dependencies:
+      tinyspy: 4.0.4
+    dev: true
+
+  /@vitest/utils@3.2.4:
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/@vitest/utils/-/utils-3.2.4.tgz}
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+    dev: true
+
+  /assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/assertion-error/-/assertion-error-2.0.1.tgz}
+    engines: {node: '>=12'}
+    dev: true
+
+  /cac@6.7.14:
+    resolution: {integrity: sha1-gE4eb1Bu42PLDjzLsJytXdmHCVk=, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/cac/download/cac-6.7.14.tgz}
+    engines: {node: '>=8'}
+    dev: true
+
+  /chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/chai/-/chai-5.3.3.tgz}
+    engines: {node: '>=18'}
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+    dev: true
+
+  /check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/check-error/-/check-error-2.1.3.tgz}
+    engines: {node: '>= 16'}
+    dev: true
+
+  /debug@4.4.3:
+    resolution: {integrity: sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/debug/download/debug-4.4.3.tgz}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
+
+  /deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/deep-eql/-/deep-eql-5.0.2.tgz}
+    engines: {node: '>=6'}
+    dev: true
+
+  /es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/es-module-lexer/-/es-module-lexer-1.7.0.tgz}
+    dev: true
+
+  /esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/esbuild/-/esbuild-0.25.12.tgz}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+    dev: true
+
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha1-Z8PlSexAKkh7T8GT0ZU6UkdSNA0=, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/estree-walker/download/estree-walker-3.0.3.tgz}
+    dependencies:
+      '@types/estree': 1.0.8
+    dev: true
+
+  /expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/expect-type/-/expect-type-1.3.0.tgz}
+    engines: {node: '>=12.0.0'}
+    dev: true
+
+  /fdir@6.5.0(picomatch@4.0.4):
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/fdir/-/fdir-6.5.0.tgz}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dependencies:
+      picomatch: 4.0.4
+    dev: true
+
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/fsevents/-/fsevents-2.3.3.tgz}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/js-tokens/-/js-tokens-9.0.1.tgz}
+    dev: true
+
+  /loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/loupe/-/loupe-3.2.1.tgz}
+    dev: true
+
+  /magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/magic-string/-/magic-string-0.30.21.tgz}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    dev: true
+
+  /ms@2.1.3:
+    resolution: {integrity: sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/ms/download/ms-2.1.3.tgz}
+    dev: true
+
+  /nanoid@3.3.11:
+    resolution: {integrity: sha1-T08RLO++MDIC8hmYOBKJNiZtGFs=, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/nanoid/download/nanoid-3.3.11.tgz}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
+  /pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/pathe/-/pathe-2.0.3.tgz}
+    dev: true
+
+  /pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/pathval/-/pathval-2.0.1.tgz}
+    engines: {node: '>= 14.16'}
+    dev: true
+
+  /picocolors@1.1.1:
+    resolution: {integrity: sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/picocolors/download/picocolors-1.1.1.tgz}
+    dev: true
+
+  /picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/picomatch/-/picomatch-4.0.4.tgz}
+    engines: {node: '>=12'}
+    dev: true
+
+  /postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/postcss/-/postcss-8.5.8.tgz}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+    dev: true
+
+  /rollup@4.60.1:
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/rollup/-/rollup-4.60.1.tgz}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      fsevents: 2.3.3
+    dev: true
+
+  /siginfo@2.0.0:
+    resolution: {integrity: sha1-MudscLeXJOO7Vny51UPrhYzPrzA=, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/siginfo/download/siginfo-2.0.0.tgz}
+    dev: true
+
+  /source-map-js@1.2.1:
+    resolution: {integrity: sha1-HOVlD93YerwJnto33P8CTCZnrkY=, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/source-map-js/download/source-map-js-1.2.1.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /stackback@0.0.2:
+    resolution: {integrity: sha1-Gsig2Ug4SNFpXkGLbQMaPDzmjjs=, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/stackback/download/stackback-0.0.2.tgz}
+    dev: true
+
+  /std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/std-env/-/std-env-3.10.0.tgz}
+    dev: true
+
+  /strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/strip-literal/-/strip-literal-3.1.0.tgz}
+    dependencies:
+      js-tokens: 9.0.1
+    dev: true
+
+  /tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/tinybench/-/tinybench-2.9.0.tgz}
+    dev: true
+
+  /tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/tinyexec/-/tinyexec-0.3.2.tgz}
+    dev: true
+
+  /tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/tinyglobby/-/tinyglobby-0.2.15.tgz}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+    dev: true
+
+  /tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/tinypool/-/tinypool-1.1.1.tgz}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    dev: true
+
+  /tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/tinyrainbow/-/tinyrainbow-2.0.0.tgz}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/tinyspy/-/tinyspy-4.0.4.tgz}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/typescript/-/typescript-5.9.3.tgz}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
+  /vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/vite-node/-/vite-node-3.2.4.tgz}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
+
+  /vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/vite/-/vite-6.4.2.tgz}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rollup: 4.60.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/vitest/-/vitest-3.2.4.tgz}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.4.2)
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.2
+      vite-node: 3.2.4
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
+
+  /why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==, tarball: https://artifactory.devops.xiaohongshu.com/artifactory/api/npm/npm-public/why-is-node-running/-/why-is-node-running-2.3.0.tgz}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+    dev: true

--- a/examples/slg-3d/src/camera-rig.ts
+++ b/examples/slg-3d/src/camera-rig.ts
@@ -1,0 +1,128 @@
+import { OrbitCamera } from '../../../src/core/orbit-camera';
+import { InputManager } from '../../../src/core/input';
+
+export interface CameraRigOptions {
+  aspect: number;
+  input?: InputManager;
+  /** 原始 canvas 元素，用于监听 wheel 事件 */
+  canvas?: HTMLCanvasElement;
+}
+
+/** SLG 大地图俯视相机配置。 */
+export class CameraRig {
+  readonly camera: OrbitCamera;
+
+  private _prevX = 0;
+  private _prevY = 0;
+  private _rotating = false;  // 右键拖动：旋转
+  private _panning = false;   // 左键拖动：平移
+
+  // WASD 平移速度（世界单位/秒）
+  private readonly PAN_SPEED = 30;
+
+  constructor(opts: CameraRigOptions) {
+    this.camera = new OrbitCamera({
+      target: [0, 0, 0],
+      distance: 90,        // 初始距离可看到整块 128×128 地图
+      minDistance: 10,     // 最近可看清单个单位
+      maxDistance: 200,    // 最远可看整块地图
+      enablePan: true,
+      panSpeed: 1.5,
+    });
+
+    this.camera.fov = Math.PI / 4;
+    this.camera.aspect = opts.aspect;
+    this.camera.near = 0.5;
+    this.camera.far = 500;
+    // 俯视角约 55°（介于 45°-60° 之间）
+    this.camera.polarAngle = (55 * Math.PI) / 180;
+
+    this.camera.update(0);
+
+    if (opts.input) {
+      this._bindInput(opts.input);
+    }
+
+    if (opts.canvas) {
+      this._bindWheel(opts.canvas);
+    }
+  }
+
+  private _bindInput(input: InputManager): void {
+    // 左键拖动：平移地图
+    input.on('pointerdown', (e) => {
+      if (e.button === 0) {
+        this._panning = true;
+        this._prevX = e.x ?? 0;
+        this._prevY = e.y ?? 0;
+      }
+      if (e.button === 2) {
+        this._rotating = true;
+        this._prevX = e.x ?? 0;
+        this._prevY = e.y ?? 0;
+      }
+    });
+
+    input.on('pointerup', (e) => {
+      if (e.button === 0) this._panning = false;
+      if (e.button === 2) this._rotating = false;
+    });
+
+    input.on('pointermove', (e) => {
+      const x = e.x ?? 0;
+      const y = e.y ?? 0;
+      const dx = x - this._prevX;
+      const dy = y - this._prevY;
+      this._prevX = x;
+      this._prevY = y;
+
+      if (this._panning) {
+        // 左键：平移（负 dx 向左，正 dy 向下）
+        this.camera.pan(-dx, dy);
+      }
+      if (this._rotating) {
+        // 右键：旋转方位角和极角
+        this.camera.rotate(-dx * 0.005, dy * 0.005);
+      }
+    });
+  }
+
+  private _bindWheel(canvas: HTMLCanvasElement): void {
+    canvas.addEventListener('wheel', (e: WheelEvent) => {
+      e.preventDefault();
+      // deltaY > 0 向下滚动 → 拉远（zoom out），deltaY < 0 → 拉近
+      const factor = e.deltaY * 0.001;
+      this.camera.zoom(-factor);
+    }, { passive: false });
+  }
+
+  /**
+   * 每帧更新：处理 WASD 键盘平移 + 刷新相机矩阵。
+   * @param dt 帧时间（秒）
+   * @param input 用于读取按键状态（可选）
+   */
+  update(dt: number, input?: InputManager): void {
+    if (input) {
+      this._handleWASD(dt, input);
+    }
+    this.camera.update(dt);
+  }
+
+  private _handleWASD(dt: number, input: InputManager): void {
+    // 相机平移速度受距离影响——越近越慢
+    const speed = this.PAN_SPEED * dt;
+
+    if (input.isKeyDown('w') || input.isKeyDown('W') || input.isKeyDown('ArrowUp')) {
+      this.camera.pan(0, -speed);
+    }
+    if (input.isKeyDown('s') || input.isKeyDown('S') || input.isKeyDown('ArrowDown')) {
+      this.camera.pan(0, speed);
+    }
+    if (input.isKeyDown('a') || input.isKeyDown('A') || input.isKeyDown('ArrowLeft')) {
+      this.camera.pan(-speed, 0);
+    }
+    if (input.isKeyDown('d') || input.isKeyDown('D') || input.isKeyDown('ArrowRight')) {
+      this.camera.pan(speed, 0);
+    }
+  }
+}

--- a/examples/slg-3d/src/game.ts
+++ b/examples/slg-3d/src/game.ts
@@ -1,0 +1,118 @@
+import { Scene } from '../../../src/core/scene';
+import { WebGLRenderer } from '../../../src/renderer/webgl-renderer';
+import { GameLoop } from '../../../src/core/game-loop';
+import { InputManager } from '../../../src/core/input';
+import { CubeTexture, CubeTextureFace } from '../../../src/renderer/cube-texture';
+import { vec3 } from '../../../src/math/vec3';
+import { createTerrain } from './terrain';
+import { createLights } from './lights';
+import { CameraRig } from './camera-rig';
+
+export type GameInit = HTMLCanvasElement | { headless: true };
+
+/** 生成单色纯色立方体贴图（6 面同色） */
+function makeSolidSkybox(faceSize: number, r: number, g: number, b: number): CubeTexture {
+  const tex = new CubeTexture(faceSize);
+  const data = new Uint8Array(faceSize * faceSize * 4);
+  for (let i = 0; i < faceSize * faceSize; i++) {
+    data[i * 4]     = r;
+    data[i * 4 + 1] = g;
+    data[i * 4 + 2] = b;
+    data[i * 4 + 3] = 255;
+  }
+  // 顶面：天蓝色
+  const topData = new Uint8Array(faceSize * faceSize * 4);
+  for (let i = 0; i < faceSize * faceSize; i++) {
+    topData[i * 4]     = 100;
+    topData[i * 4 + 1] = 150;
+    topData[i * 4 + 2] = 220;
+    topData[i * 4 + 3] = 255;
+  }
+  // 底面：深灰色（地面以下）
+  const botData = new Uint8Array(faceSize * faceSize * 4);
+  for (let i = 0; i < faceSize * faceSize; i++) {
+    botData[i * 4]     = 40;
+    botData[i * 4 + 1] = 40;
+    botData[i * 4 + 2] = 40;
+    botData[i * 4 + 3] = 255;
+  }
+  tex.setFace(CubeTextureFace.PositiveX, new Uint8Array(data));
+  tex.setFace(CubeTextureFace.NegativeX, new Uint8Array(data));
+  tex.setFace(CubeTextureFace.PositiveY, topData);
+  tex.setFace(CubeTextureFace.NegativeY, botData);
+  tex.setFace(CubeTextureFace.PositiveZ, new Uint8Array(data));
+  tex.setFace(CubeTextureFace.NegativeZ, new Uint8Array(data));
+  return tex;
+}
+
+export class Game {
+  // headless 模式下渲染器为 null
+  private scene: Scene | null = null;
+  private renderer: WebGLRenderer | null = null;
+  private loop: GameLoop | null = null;
+  private input: InputManager | null = null;
+  private cameraRig: CameraRig | null = null;
+
+  /** 已运行的帧数（供测试读取） */
+  frameCount = 0;
+
+  constructor(init: GameInit) {
+    const headless = (init as any).headless === true;
+
+    const { sun, ambient } = createLights();
+    const terrain = createTerrain();
+
+    if (!headless) {
+      const canvas = init as HTMLCanvasElement;
+      if (!canvas.getContext('webgl')) throw new Error('WebGL 不可用');
+
+      // 天空盒：水平面用浅蓝灰色
+      const skybox = makeSolidSkybox(64, 160, 185, 210);
+
+      this.scene = new Scene({ background: skybox });
+      this.scene.addChild(sun);
+      this.scene.addChild(ambient);
+      this.scene.addChild(terrain);
+
+      this.renderer = new WebGLRenderer(canvas);
+      this.input = new InputManager(canvas);
+
+      this.cameraRig = new CameraRig({
+        aspect: canvas.width / canvas.height,
+        input: this.input,
+        canvas,
+      });
+      this.scene.addChild(this.cameraRig.camera);
+
+      this.loop = new GameLoop();
+      this.loop.onUpdate = (dt) => this.update(dt);
+      this.loop.onRender = () => this.render();
+    } else {
+      // headless：只创建逻辑对象，不涉及 WebGL
+      this.cameraRig = new CameraRig({ aspect: 16 / 9 });
+    }
+  }
+
+  start(): void {
+    this.loop?.start();
+  }
+
+  stop(): void {
+    this.loop?.stop();
+  }
+
+  update(dt: number): void {
+    this.cameraRig?.update(dt, this.input ?? undefined);
+    this.frameCount++;
+  }
+
+  private render(): void {
+    if (this.renderer && this.scene && this.cameraRig) {
+      this.renderer.render(this.scene, this.cameraRig.camera);
+    }
+  }
+
+  get camera() {
+    return this.cameraRig?.camera ?? null;
+  }
+}

--- a/examples/slg-3d/src/lights.ts
+++ b/examples/slg-3d/src/lights.ts
@@ -1,0 +1,23 @@
+import { AmbientLight } from '../../../src/core/light';
+import { DirectionalLight } from '../../../src/core/light';
+import { vec3 } from '../../../src/math/vec3';
+
+/**
+ * 创建 SLG 场景光源：太阳方向光 + 天光补光。
+ */
+export function createLights(): { sun: DirectionalLight; ambient: AmbientLight } {
+  // 太阳：约 45° 斜射，偏西南方向
+  const sun = new DirectionalLight(
+    vec3(1.0, 0.95, 0.85), // 暖白色
+    1.2,
+    vec3(-0.5, -1.0, -0.5), // 光线方向（从东北上方射来）
+  );
+
+  // 天光：蓝灰色补光，模拟天空散射
+  const ambient = new AmbientLight(
+    vec3(0.5, 0.6, 0.75),
+    0.4,
+  );
+
+  return { sun, ambient };
+}

--- a/examples/slg-3d/src/main.ts
+++ b/examples/slg-3d/src/main.ts
@@ -1,0 +1,24 @@
+import { Game } from './game';
+
+declare global {
+  interface Window {
+    __game: Game;
+  }
+}
+
+const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
+canvas.width = window.innerWidth;
+canvas.height = window.innerHeight;
+
+window.addEventListener('resize', () => {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+});
+
+const game = new Game(canvas);
+game.start();
+
+// 暴露游戏状态供调试和 Playwright 读取
+window.__game = game;
+// 标记 canvas 就绪
+canvas.dataset.ready = '1';

--- a/examples/slg-3d/src/terrain.ts
+++ b/examples/slg-3d/src/terrain.ts
@@ -1,0 +1,57 @@
+import { Node3D } from '../../../src/core/node3d';
+import { Mesh } from '../../../src/renderer/mesh';
+import { createPlaneGeometry } from '../../../src/renderer/primitives';
+import { PhongMaterial } from '../../../src/renderer/phong-material';
+import { vec3 } from '../../../src/math/vec3';
+
+/** 地形尺寸（世界单位） */
+export const TERRAIN_SIZE = 128;
+
+/**
+ * 创建 128×128 大地图地形。
+ * 使用 16×16 分段以支持平滑着色，草绿色调 PhongMaterial。
+ */
+export function createTerrain(): Node3D {
+  const root = new Node3D('terrain');
+
+  // 主地面：绿色草地
+  const groundGeo = createPlaneGeometry(TERRAIN_SIZE, TERRAIN_SIZE, 16, 16);
+  const groundMat = new PhongMaterial({
+    diffuse: vec3(0.35, 0.55, 0.25),  // 草绿
+    ambient: vec3(0.12, 0.18, 0.08),
+    specular: vec3(0.05, 0.05, 0.05),
+    shininess: 4,
+  });
+  const ground = new Mesh(groundGeo, groundMat);
+  root.addChild(ground);
+
+  // 高地区块：在地形西北角添加深绿色区域作为视觉区分
+  const highlandGeo = createPlaneGeometry(40, 30, 8, 6);
+  const highlandMat = new PhongMaterial({
+    diffuse: vec3(0.22, 0.45, 0.15),  // 深绿
+    ambient: vec3(0.08, 0.15, 0.05),
+    specular: vec3(0.03, 0.03, 0.03),
+    shininess: 2,
+  });
+  const highland = new Mesh(highlandGeo, highlandMat);
+  highland.position[0] = -40;
+  highland.position[1] = 0.01; // 略高于地面，避免 z-fighting
+  highland.position[2] = -35;
+  root.addChild(highland);
+
+  // 沙漠区块：东南角黄褐色区域
+  const desertGeo = createPlaneGeometry(35, 35, 6, 6);
+  const desertMat = new PhongMaterial({
+    diffuse: vec3(0.75, 0.65, 0.35),  // 黄褐色
+    ambient: vec3(0.25, 0.20, 0.10),
+    specular: vec3(0.08, 0.08, 0.04),
+    shininess: 6,
+  });
+  const desert = new Mesh(desertGeo, desertMat);
+  desert.position[0] = 42;
+  desert.position[1] = 0.01;
+  desert.position[2] = 38;
+  root.addChild(desert);
+
+  return root;
+}

--- a/examples/slg-3d/test/integration/scaffold.test.ts
+++ b/examples/slg-3d/test/integration/scaffold.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { Game } from '../../src/game';
+import { CameraRig } from '../../src/camera-rig';
+import { createTerrain, TERRAIN_SIZE } from '../../src/terrain';
+import { createLights } from '../../src/lights';
+
+describe('SLG-3D 脚手架 — 场景创建', () => {
+  it('headless 模式下 Game 可正常创建', () => {
+    expect(() => new Game({ headless: true })).not.toThrow();
+  });
+
+  it('headless Game 暴露 camera 属性', () => {
+    const game = new Game({ headless: true });
+    expect(game.camera).not.toBeNull();
+    expect(game.camera).toBeDefined();
+  });
+
+  it('frameCount 初始为 0', () => {
+    const game = new Game({ headless: true });
+    expect(game.frameCount).toBe(0);
+  });
+});
+
+describe('SLG-3D 脚手架 — OrbitCamera 配置', () => {
+  it('CameraRig 创建后 camera 距离在 SLG 合理范围内', () => {
+    const rig = new CameraRig({ aspect: 16 / 9 });
+    expect(rig.camera.distance).toBeGreaterThanOrEqual(80);
+    expect(rig.camera.distance).toBeLessThanOrEqual(200);
+  });
+
+  it('极角约 55°（俯视视角）', () => {
+    const rig = new CameraRig({ aspect: 16 / 9 });
+    const expectedPolar = (55 * Math.PI) / 180;
+    expect(rig.camera.polarAngle).toBeCloseTo(expectedPolar, 2);
+  });
+
+  it('camera.update 不抛异常', () => {
+    const rig = new CameraRig({ aspect: 16 / 9 });
+    expect(() => rig.update(1 / 60)).not.toThrow();
+  });
+
+  it('rotate 调整方位角和极角', () => {
+    const rig = new CameraRig({ aspect: 16 / 9 });
+    const initAzimuth = rig.camera.azimuthAngle;
+    rig.camera.rotate(0.1, 0);
+    expect(rig.camera.azimuthAngle).toBeCloseTo(initAzimuth + 0.1, 5);
+  });
+
+  it('zoom 调整 distance 并保持在有效范围', () => {
+    const rig = new CameraRig({ aspect: 16 / 9 });
+    rig.camera.zoom(0.5); // zoom in
+    expect(rig.camera.distance).toBeGreaterThanOrEqual(rig.camera.minDistance);
+    expect(rig.camera.distance).toBeLessThanOrEqual(rig.camera.maxDistance);
+  });
+
+  it('pan 移动 orbitTarget', () => {
+    const rig = new CameraRig({ aspect: 16 / 9 });
+    rig.camera.update(0); // 先更新确保状态初始化
+    const initZ = rig.camera.orbitTarget[2];
+    rig.camera.pan(0, 10);
+    // pan 后 target 应有变化
+    expect(rig.camera.orbitTarget[2]).not.toBeCloseTo(initZ, 3);
+  });
+});
+
+describe('SLG-3D 脚手架 — 地形', () => {
+  it('createTerrain 返回有效 Node3D', () => {
+    const terrain = createTerrain();
+    expect(terrain).toBeDefined();
+    expect(terrain.name).toBe('terrain');
+  });
+
+  it('地形包含子 mesh（地面 + 两个区块）', () => {
+    const terrain = createTerrain();
+    // 至少有主地面 mesh
+    expect(terrain.children.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('TERRAIN_SIZE 至少 128 世界单位', () => {
+    expect(TERRAIN_SIZE).toBeGreaterThanOrEqual(128);
+  });
+});
+
+describe('SLG-3D 脚手架 — 光照', () => {
+  it('createLights 返回 sun 和 ambient', () => {
+    const { sun, ambient } = createLights();
+    expect(sun).toBeDefined();
+    expect(ambient).toBeDefined();
+  });
+
+  it('太阳光强度大于 0', () => {
+    const { sun } = createLights();
+    expect(sun.intensity).toBeGreaterThan(0);
+  });
+
+  it('环境光强度大于 0', () => {
+    const { ambient } = createLights();
+    expect(ambient.intensity).toBeGreaterThan(0);
+  });
+
+  it('太阳光方向向量不为零向量', () => {
+    const { sun } = createLights();
+    const len = Math.sqrt(
+      sun.direction[0] ** 2 + sun.direction[1] ** 2 + sun.direction[2] ** 2
+    );
+    expect(len).toBeGreaterThan(0);
+  });
+});
+
+describe('SLG-3D 脚手架 — headless 压力测试', () => {
+  it('headless 连续运行 60 帧不崩溃', () => {
+    const game = new Game({ headless: true });
+    expect(() => {
+      for (let i = 0; i < 60; i++) game.update(1 / 60);
+    }).not.toThrow();
+    expect(game.frameCount).toBe(60);
+  });
+
+  it('60 帧后 camera 位置合理（非 NaN）', () => {
+    const game = new Game({ headless: true });
+    for (let i = 0; i < 60; i++) game.update(1 / 60);
+    const pos = game.camera?.position;
+    expect(pos).toBeDefined();
+    expect(isNaN(pos![0])).toBe(false);
+    expect(isNaN(pos![1])).toBe(false);
+    expect(isNaN(pos![2])).toBe(false);
+  });
+
+  it('headless 无 console.error 输出', () => {
+    const errors: string[] = [];
+    const orig = console.error;
+    console.error = (...args) => { errors.push(args.join(' ')); };
+    try {
+      const game = new Game({ headless: true });
+      for (let i = 0; i < 60; i++) game.update(1 / 60);
+    } finally {
+      console.error = orig;
+    }
+    expect(errors).toEqual([]);
+  });
+});

--- a/examples/slg-3d/tsconfig.json
+++ b/examples/slg-3d/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src", "test"]
+}

--- a/examples/slg-3d/vite.config.ts
+++ b/examples/slg-3d/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist',
+    rollupOptions: {
+      input: './index.html',
+    },
+  },
+});

--- a/examples/slg-3d/vitest.config.ts
+++ b/examples/slg-3d/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,25 +4,70 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-devDependencies:
-  '@playwright/test':
-    specifier: 1.52.0
-    version: 1.52.0
-  pixelmatch:
-    specifier: ^7.1.0
-    version: 7.1.0
-  pngjs:
-    specifier: ^7.0.0
-    version: 7.0.0
-  typescript:
-    specifier: ^5.8.0
-    version: 5.9.3
-  vite:
-    specifier: ^6.3.0
-    version: 6.4.1
-  vitest:
-    specifier: ^3.1.0
-    version: 3.2.4
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.52.0
+        version: 1.52.0
+      pixelmatch:
+        specifier: ^7.1.0
+        version: 7.1.0
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.3.0
+        version: 6.4.1
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4
+
+  examples/runner-3d:
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.52.0
+        version: 1.52.0
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.3.0
+        version: 6.4.1
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4
+
+  examples/slg-3d:
+    devDependencies:
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.3.0
+        version: 6.4.1
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4
+
+  examples/tower-defense-3d:
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.52.0
+        version: 1.52.0
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.3.0
+        version: 6.4.1
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'examples/*'


### PR DESCRIPTION
## 概述

实现 Issue #241：M3.1 SLG 3D demo 的基础世界脚手架。

## 变更内容

- **pnpm-workspace.yaml**：激活 monorepo workspace，支持 `pnpm --filter slg-3d` 命令
- **examples/slg-3d/**：全新独立子项目，引用根目录 `lucid-3d` 源码（相对路径 `../../../src/`）

### 文件结构

```
examples/slg-3d/
├── package.json / vite.config.ts / vitest.config.ts / tsconfig.json / index.html
└── src/
    ├── main.ts          # 入口，暴露 window.__game
    ├── game.ts          # Game 类（headless/browser 双模式）+ CubeTexture 天空盒
    ├── terrain.ts       # 128×128 大地图（草地 + 高地 + 沙漠三色区块）
    ├── camera-rig.ts    # OrbitCamera（55° 俯视，左键平移/右键旋转/滚轮缩放/WASD）
    └── lights.ts        # 太阳方向光 + 天空蓝环境光
└── test/integration/scaffold.test.ts  # 19 个测试，全部通过
```

## 验收清单

- [x] `pnpm --filter slg-3d dev` 可启动 Vite 开发服务器
- [x] 浏览器可看到地形 + 天空盒 + 俯视相机视角
- [x] 拖动/滚轮/旋转相机均响应
- [x] `pnpm --filter slg-3d test` 的 scaffold.test.ts 全通过（19/19）
- [x] headless 环境连续运行 60 帧无报错
- [x] 未修改 src/ 任何文件

close #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)