### PR TITLE
feat: M3.5 SLG HUD — 小地图+资源计数+单位信息面板+命令反馈

### DIFF
--- a/examples/slg-3d/src/hud/command-feedback.ts
+++ b/examples/slg-3d/src/hud/command-feedback.ts
@@ -1,0 +1,64 @@
+/**
+ * CommandFeedback — 命令反馈标记。
+ * 右键命令（移动/采集）时，在屏幕坐标位置短暂显示一个方块标记（0.5s 淡出）。
+ */
+import { UIRect } from '../../../../src/ui/ui-rect';
+import { vec3 } from '../../../../src/math/vec3';
+
+/** 命令反馈持续时间（秒） */
+const FEEDBACK_DURATION = 0.5;
+/** 标记尺寸（像素） */
+const MARKER_SIZE = 20;
+
+export class CommandFeedback {
+  readonly marker: UIRect;
+
+  private _isActive: boolean = false;
+  private _elapsed: number = 0;
+
+  constructor(_opts?: { canvasWidth?: number; canvasHeight?: number }) {
+    this.marker = new UIRect({
+      x: 0,
+      y: 0,
+      width: MARKER_SIZE,
+      height: MARKER_SIZE,
+      color: vec3(0.2, 1.0, 0.4),
+      opacity: 0,
+    });
+    this.marker.visible = false;
+  }
+
+  /**
+   * 在屏幕坐标处显示命令反馈标记。
+   * @param screenX 屏幕 X 坐标（像素）
+   * @param screenY 屏幕 Y 坐标（像素）
+   */
+  show(screenX: number, screenY: number): void {
+    this.marker.x = screenX - MARKER_SIZE / 2;
+    this.marker.y = screenY - MARKER_SIZE / 2;
+    this.marker.opacity = 1.0;
+    this.marker.visible = true;
+    this._isActive = true;
+    this._elapsed = 0;
+  }
+
+  /**
+   * 逐帧更新，淡出效果。
+   * @param dt 帧时间（秒）
+   */
+  update(dt: number): void {
+    if (!this._isActive) return;
+    this._elapsed += dt;
+    if (this._elapsed >= FEEDBACK_DURATION) {
+      this._isActive = false;
+      this.marker.visible = false;
+      this.marker.opacity = 0;
+    } else {
+      // 线性淡出
+      this.marker.opacity = 1.0 - this._elapsed / FEEDBACK_DURATION;
+    }
+  }
+
+  get isActive(): boolean { return this._isActive; }
+  get elapsed(): number { return this._elapsed; }
+}

--- a/examples/slg-3d/src/hud/minimap.ts
+++ b/examples/slg-3d/src/hud/minimap.ts
@@ -1,0 +1,97 @@
+/**
+ * Minimap — SLG 小地图（右上角）。
+ * 简单方案：UIRect 背景 + 逐帧计算单位点位置。
+ * 将世界空间坐标映射到小地图像素坐标。
+ */
+import { UIRect } from '../../../../src/ui/ui-rect';
+import { vec3, type Vec3 } from '../../../../src/math/vec3';
+import type { UnitData } from '../units';
+
+/** 单位在小地图上的点信息 */
+export interface MinimapDot {
+  unitId: number;
+  /** 相对于小地图左上角的像素坐标 */
+  x: number;
+  y: number;
+  /** 阵营颜色 */
+  color: Vec3;
+}
+
+// 阵营颜色
+const DOT_COLOR_ALLY    = vec3(0.2, 0.5, 1.0);   // 蓝色
+const DOT_COLOR_ENEMY   = vec3(1.0, 0.3, 0.2);   // 红色
+const DOT_COLOR_NEUTRAL = vec3(0.8, 0.8, 0.2);   // 黄色
+const DOT_COLOR_SELECTED = vec3(1.0, 1.0, 0.0);  // 高亮黄
+
+export class Minimap {
+  readonly background: UIRect;
+
+  /** 小地图在屏幕上的位置 */
+  readonly x: number;
+  readonly y: number;
+  /** 小地图像素尺寸（正方形） */
+  readonly size: number;
+  /** 世界地图单位尺寸（TERRAIN_SIZE） */
+  readonly worldSize: number;
+
+  /** 所有单位在小地图上的点（update 后刷新） */
+  dots: MinimapDot[] = [];
+
+  constructor(opts: {
+    x: number;
+    y: number;
+    size: number;
+    worldSize: number;
+  }) {
+    this.x = opts.x;
+    this.y = opts.y;
+    this.size = opts.size;
+    this.worldSize = opts.worldSize;
+
+    // 小地图背景：深色半透明
+    this.background = new UIRect({
+      x: opts.x,
+      y: opts.y,
+      width: opts.size,
+      height: opts.size,
+      color: vec3(0.05, 0.08, 0.05),
+      opacity: 0.85,
+    });
+  }
+
+  /**
+   * 将世界空间 XZ 坐标映射到小地图像素坐标（相对于小地图左上角）。
+   * 世界坐标范围：[-worldSize/2, worldSize/2]
+   */
+  worldToMap(worldX: number, worldZ: number): { x: number; y: number } {
+    const half = this.worldSize / 2;
+    const nx = (worldX + half) / this.worldSize; // 0..1
+    const nz = (worldZ + half) / this.worldSize; // 0..1
+    return {
+      x: nx * this.size,
+      y: nz * this.size,
+    };
+  }
+
+  /**
+   * 逐帧更新单位点位置。
+   * @param units UnitData 数组（来自 UnitManager）
+   */
+  update(units: UnitData[]): void {
+    this.dots = units.map((unit) => {
+      const pos = this.worldToMap(unit.x, unit.z);
+      let color: Vec3;
+      if (unit.selected) {
+        color = DOT_COLOR_SELECTED;
+      } else {
+        switch (unit.faction) {
+          case 'ally':    color = DOT_COLOR_ALLY; break;
+          case 'enemy':   color = DOT_COLOR_ENEMY; break;
+          case 'neutral': color = DOT_COLOR_NEUTRAL; break;
+          default:        color = DOT_COLOR_NEUTRAL;
+        }
+      }
+      return { unitId: unit.id, x: pos.x, y: pos.y, color };
+    });
+  }
+}

--- a/examples/slg-3d/src/hud/pause-menu.ts
+++ b/examples/slg-3d/src/hud/pause-menu.ts
@@ -1,0 +1,126 @@
+/**
+ * PauseMenu — 暂停菜单覆盖层。
+ * ESC 键弹出/关闭，包含 Resume / Restart / Back to Menu 三个按钮。
+ */
+import { UICanvas } from '../../../../src/ui/ui-canvas';
+import { UIRect } from '../../../../src/ui/ui-rect';
+import { UIText } from '../../../../src/ui/ui-text';
+import { UIButton } from '../../../../src/ui/ui-button';
+import { UIFlexContainer } from '../../../../src/ui/ui-flex-container';
+import { vec3 } from '../../../../src/math/vec3';
+import type { BitmapFontData } from '../../../../src/renderer/bitmap-font';
+
+const STUB_FONT: BitmapFontData = {
+  lineHeight: 16,
+  base: 12,
+  scaleW: 256,
+  scaleH: 256,
+  chars: new Map(),
+};
+
+const BTN_WIDTH  = 180;
+const BTN_HEIGHT = 44;
+
+export class PauseMenu {
+  readonly canvas: UICanvas;
+  readonly overlay: UIRect;
+  readonly title: UIText;
+  readonly buttonContainer: UIFlexContainer;
+  readonly resumeBtn: UIButton;
+  readonly restartBtn: UIButton;
+  readonly backToMenuBtn: UIButton;
+
+  visible: boolean = false;
+
+  onResume:     (() => void) | null = null;
+  onRestart:    (() => void) | null = null;
+  onBackToMenu: (() => void) | null = null;
+
+  constructor(opts: { width: number; height: number }) {
+    this.canvas = new UICanvas(opts.width, opts.height);
+
+    // 全屏半透明遮罩
+    this.overlay = new UIRect({
+      x: 0,
+      y: 0,
+      width: opts.width,
+      height: opts.height,
+      color: vec3(0, 0, 0),
+      opacity: 0.65,
+    });
+
+    // 标题
+    this.title = new UIText({
+      font: STUB_FONT,
+      text: '暂停',
+      x: opts.width / 2 - 30,
+      y: opts.height / 2 - 100,
+      color: vec3(1, 1, 1),
+    });
+
+    // 按钮列（垂直布局）
+    this.buttonContainer = new UIFlexContainer({
+      x: opts.width / 2 - BTN_WIDTH / 2,
+      y: opts.height / 2 - 60,
+      width: BTN_WIDTH,
+      height: BTN_HEIGHT * 3 + 12 * 2,
+      direction: 'vertical',
+      gap: 12,
+      padding: 0,
+    });
+
+    this.resumeBtn = new UIButton({
+      width: BTN_WIDTH,
+      height: BTN_HEIGHT,
+      label: 'Resume',
+      normalColor: vec3(0.2, 0.5, 0.2),
+    });
+    this.resumeBtn.onClick = () => this.onResume?.();
+
+    this.restartBtn = new UIButton({
+      width: BTN_WIDTH,
+      height: BTN_HEIGHT,
+      label: 'Restart',
+      normalColor: vec3(0.4, 0.4, 0.4),
+    });
+    this.restartBtn.onClick = () => this.onRestart?.();
+
+    this.backToMenuBtn = new UIButton({
+      width: BTN_WIDTH,
+      height: BTN_HEIGHT,
+      label: 'Back to Menu',
+      normalColor: vec3(0.5, 0.2, 0.2),
+    });
+    this.backToMenuBtn.onClick = () => this.onBackToMenu?.();
+
+    this.buttonContainer.add(this.resumeBtn);
+    this.buttonContainer.add(this.restartBtn);
+    this.buttonContainer.add(this.backToMenuBtn);
+
+    this.canvas.add(this.overlay);
+    this.canvas.add(this.title);
+    this.canvas.add(this.buttonContainer);
+
+    // 默认隐藏
+    this.canvas.children.forEach(c => { c.visible = false; });
+  }
+
+  show(): void {
+    this.visible = true;
+    this.canvas.children.forEach(c => { c.visible = true; });
+  }
+
+  hide(): void {
+    this.visible = false;
+    this.canvas.children.forEach(c => { c.visible = false; });
+  }
+
+  /** 切换可见性（ESC 键调用） */
+  toggle(): void {
+    if (this.visible) {
+      this.hide();
+    } else {
+      this.show();
+    }
+  }
+}

--- a/examples/slg-3d/src/hud/resource-bar.ts
+++ b/examples/slg-3d/src/hud/resource-bar.ts
@@ -1,0 +1,77 @@
+/**
+ * ResourceBar — SLG 顶部资源计数栏。
+ * 显示金/木资源图标 + 数字，支持实时更新。
+ */
+import { UICanvas } from '../../../../src/ui/ui-canvas';
+import { UIText } from '../../../../src/ui/ui-text';
+import { UIRect } from '../../../../src/ui/ui-rect';
+import { vec3 } from '../../../../src/math/vec3';
+import type { BitmapFontData } from '../../../../src/renderer/bitmap-font';
+
+// 占位字体 — 仅满足类型约束，测试环境不进行实际渲染
+const STUB_FONT: BitmapFontData = {
+  lineHeight: 16,
+  base: 12,
+  scaleW: 256,
+  scaleH: 256,
+  chars: new Map(),
+};
+
+export class ResourceBar {
+  readonly canvas: UICanvas;
+  readonly background: UIRect;
+  readonly goldText: UIText;
+  readonly woodText: UIText;
+
+  private _gold: number = 0;
+  private _wood: number = 0;
+
+  constructor(opts: { width: number; height: number }) {
+    this.canvas = new UICanvas(opts.width, opts.height);
+
+    // 顶部资源栏背景
+    this.background = new UIRect({
+      x: 0,
+      y: 0,
+      width: opts.width,
+      height: 40,
+      color: vec3(0.1, 0.1, 0.15),
+      opacity: 0.8,
+    });
+
+    // 金资源文本（左侧）
+    this.goldText = new UIText({
+      font: STUB_FONT,
+      text: '金: 0',
+      x: 16,
+      y: 12,
+      color: vec3(1.0, 0.85, 0.2),
+    });
+
+    // 木资源文本（右侧）
+    this.woodText = new UIText({
+      font: STUB_FONT,
+      text: '木: 0',
+      x: 160,
+      y: 12,
+      color: vec3(0.4, 0.9, 0.3),
+    });
+
+    this.canvas.add(this.background);
+    this.canvas.add(this.goldText);
+    this.canvas.add(this.woodText);
+  }
+
+  setGold(value: number): void {
+    this._gold = value;
+    this.goldText.text = `金: ${value}`;
+  }
+
+  setWood(value: number): void {
+    this._wood = value;
+    this.woodText.text = `木: ${value}`;
+  }
+
+  get gold(): number { return this._gold; }
+  get wood(): number { return this._wood; }
+}

--- a/examples/slg-3d/src/hud/unit-panel.ts
+++ b/examples/slg-3d/src/hud/unit-panel.ts
@@ -1,0 +1,131 @@
+/**
+ * UnitPanel — 选中单位信息面板（底部）。
+ * 显示选中单位数量和阵营分布，使用 UIFlexContainer 自动布局。
+ */
+import { UICanvas } from '../../../../src/ui/ui-canvas';
+import { UIRect } from '../../../../src/ui/ui-rect';
+import { UIText } from '../../../../src/ui/ui-text';
+import { UIFlexContainer } from '../../../../src/ui/ui-flex-container';
+import { vec3 } from '../../../../src/math/vec3';
+import type { BitmapFontData } from '../../../../src/renderer/bitmap-font';
+import type { UnitData } from '../units';
+
+const STUB_FONT: BitmapFontData = {
+  lineHeight: 16,
+  base: 12,
+  scaleW: 256,
+  scaleH: 256,
+  chars: new Map(),
+};
+
+export class UnitPanel {
+  readonly canvas: UICanvas;
+  readonly background: UIRect;
+  readonly container: UIFlexContainer;
+  readonly countText: UIText;
+  readonly allyText: UIText;
+  readonly enemyText: UIText;
+  readonly neutralText: UIText;
+
+  private _selectedCount: number = 0;
+
+  constructor(opts: { width: number; height: number }) {
+    this.canvas = new UICanvas(opts.width, opts.height);
+
+    const panelWidth = 400;
+    const panelHeight = 60;
+    const panelX = (opts.width - panelWidth) / 2;
+    const panelY = opts.height - panelHeight - 8;
+
+    // 底部面板背景
+    this.background = new UIRect({
+      x: panelX,
+      y: panelY,
+      width: panelWidth,
+      height: panelHeight,
+      color: vec3(0.1, 0.1, 0.15),
+      opacity: 0.85,
+    });
+
+    // 使用 FlexContainer 水平排列文本
+    this.container = new UIFlexContainer({
+      x: panelX + 8,
+      y: panelY + 8,
+      width: panelWidth - 16,
+      height: panelHeight - 16,
+      direction: 'horizontal',
+      gap: 16,
+      padding: 0,
+    });
+
+    this.countText = new UIText({
+      font: STUB_FONT,
+      text: '选中: 0',
+      width: 90,
+      height: 20,
+      color: vec3(1, 1, 1),
+    });
+
+    this.allyText = new UIText({
+      font: STUB_FONT,
+      text: '我方: 0',
+      width: 80,
+      height: 20,
+      color: vec3(0.2, 0.5, 1.0),
+    });
+
+    this.enemyText = new UIText({
+      font: STUB_FONT,
+      text: '敌方: 0',
+      width: 80,
+      height: 20,
+      color: vec3(1.0, 0.3, 0.2),
+    });
+
+    this.neutralText = new UIText({
+      font: STUB_FONT,
+      text: '中立: 0',
+      width: 80,
+      height: 20,
+      color: vec3(0.8, 0.8, 0.2),
+    });
+
+    this.container.add(this.countText);
+    this.container.add(this.allyText);
+    this.container.add(this.enemyText);
+    this.container.add(this.neutralText);
+
+    this.canvas.add(this.background);
+    this.canvas.add(this.container);
+  }
+
+  /**
+   * 更新选中单位信息面板。
+   * @param selectedIds 选中单位 ID 集合
+   * @param units 所有单位数据
+   */
+  update(selectedIds: ReadonlySet<number>, units: UnitData[]): void {
+    this._selectedCount = selectedIds.size;
+
+    let ally = 0;
+    let enemy = 0;
+    let neutral = 0;
+
+    for (const id of selectedIds) {
+      const unit = units[id];
+      if (!unit) continue;
+      switch (unit.faction) {
+        case 'ally':    ally++;    break;
+        case 'enemy':   enemy++;   break;
+        case 'neutral': neutral++; break;
+      }
+    }
+
+    this.countText.text  = `选中: ${this._selectedCount}`;
+    this.allyText.text   = `我方: ${ally}`;
+    this.enemyText.text  = `敌方: ${enemy}`;
+    this.neutralText.text = `中立: ${neutral}`;
+  }
+
+  get selectedCount(): number { return this._selectedCount; }
+}

--- a/examples/slg-3d/test/integration/hud.test.ts
+++ b/examples/slg-3d/test/integration/hud.test.ts
@@ -1,0 +1,332 @@
+/**
+ * 集成测试：M3.5 SLG HUD
+ *
+ * 验收标准：
+ * - 资源栏响应资源变更（从 0 → 500 可见递增）
+ * - 小地图点位置与世界空间单位位置一致
+ * - 选中单位后信息面板显示正确数量
+ * - 暂停菜单按钮可点击并响应
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ResourceBar } from '../../src/hud/resource-bar';
+import { Minimap } from '../../src/hud/minimap';
+import { UnitPanel } from '../../src/hud/unit-panel';
+import { CommandFeedback } from '../../src/hud/command-feedback';
+import { PauseMenu } from '../../src/hud/pause-menu';
+import { UnitManager, TOTAL_UNITS } from '../../src/units';
+import { TERRAIN_SIZE } from '../../src/terrain';
+
+// ────────────────────────────────────────────────────────────
+// ResourceBar — 资源计数栏
+// ────────────────────────────────────────────────────────────
+describe('ResourceBar — 资源计数栏', () => {
+  it('初始化后 gold=0, wood=0', () => {
+    const bar = new ResourceBar({ width: 800, height: 600 });
+    expect(bar.canvas).toBeDefined();
+    expect(bar.gold).toBe(0);
+    expect(bar.wood).toBe(0);
+  });
+
+  it('setGold 正确更新内部值', () => {
+    const bar = new ResourceBar({ width: 800, height: 600 });
+    bar.setGold(150);
+    expect(bar.gold).toBe(150);
+  });
+
+  it('setWood 正确更新内部值', () => {
+    const bar = new ResourceBar({ width: 800, height: 600 });
+    bar.setWood(300);
+    expect(bar.wood).toBe(300);
+  });
+
+  it('资源栏从 0 → 500 递增更新金资源', () => {
+    const bar = new ResourceBar({ width: 800, height: 600 });
+    const steps = [0, 100, 200, 300, 400, 500];
+    for (const v of steps) {
+      bar.setGold(v);
+      expect(bar.gold).toBe(v);
+    }
+    expect(bar.gold).toBe(500);
+  });
+
+  it('goldText 文本随 setGold 更新', () => {
+    const bar = new ResourceBar({ width: 800, height: 600 });
+    bar.setGold(250);
+    expect(bar.goldText.text).toContain('250');
+  });
+
+  it('woodText 文本随 setWood 更新', () => {
+    const bar = new ResourceBar({ width: 800, height: 600 });
+    bar.setWood(75);
+    expect(bar.woodText.text).toContain('75');
+  });
+
+  it('canvas 包含 background + goldText + woodText 共 3 个子元素', () => {
+    const bar = new ResourceBar({ width: 800, height: 600 });
+    expect(bar.canvas.children.length).toBe(3);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Minimap — 小地图
+// ────────────────────────────────────────────────────────────
+describe('Minimap — 小地图', () => {
+  it('创建 Minimap 后有 background，尺寸正确', () => {
+    const minimap = new Minimap({ x: 600, y: 16, size: 200, worldSize: TERRAIN_SIZE });
+    expect(minimap.background).toBeDefined();
+    expect(minimap.background.width).toBe(200);
+    expect(minimap.background.height).toBe(200);
+  });
+
+  it('世界坐标 (0, 0) 映射到小地图中心 (100, 100)', () => {
+    const minimap = new Minimap({ x: 0, y: 0, size: 200, worldSize: 128 });
+    const pos = minimap.worldToMap(0, 0);
+    expect(pos.x).toBeCloseTo(100, 1);
+    expect(pos.y).toBeCloseTo(100, 1);
+  });
+
+  it('世界坐标左上角 (-64, -64) 映射到小地图 (0, 0)', () => {
+    const minimap = new Minimap({ x: 0, y: 0, size: 200, worldSize: 128 });
+    const pos = minimap.worldToMap(-64, -64);
+    expect(pos.x).toBeCloseTo(0, 1);
+    expect(pos.y).toBeCloseTo(0, 1);
+  });
+
+  it('世界坐标右下角 (64, 64) 映射到小地图 (200, 200)', () => {
+    const minimap = new Minimap({ x: 0, y: 0, size: 200, worldSize: 128 });
+    const pos = minimap.worldToMap(64, 64);
+    expect(pos.x).toBeCloseTo(200, 1);
+    expect(pos.y).toBeCloseTo(200, 1);
+  });
+
+  it('update 后 dots 数组长度等于单位总数', () => {
+    const um = new UnitManager();
+    const minimap = new Minimap({ x: 0, y: 0, size: 200, worldSize: TERRAIN_SIZE });
+    minimap.update(um.units);
+    expect(minimap.dots.length).toBe(TOTAL_UNITS);
+  });
+
+  it('单位点位置与世界坐标一致（通过 worldToMap 验证）', () => {
+    const um = new UnitManager();
+    const minimap = new Minimap({ x: 0, y: 0, size: 200, worldSize: TERRAIN_SIZE });
+    minimap.update(um.units);
+
+    // 取前 5 个单位验证坐标一致性
+    for (let i = 0; i < 5; i++) {
+      const unit = um.units[i];
+      const expected = minimap.worldToMap(unit.x, unit.z);
+      const dot = minimap.dots.find(d => d.unitId === unit.id)!;
+      expect(dot).toBeDefined();
+      expect(dot.x).toBeCloseTo(expected.x, 4);
+      expect(dot.y).toBeCloseTo(expected.y, 4);
+    }
+  });
+
+  it('我方单位点颜色为蓝色（B > 0.5）', () => {
+    const um = new UnitManager();
+    const minimap = new Minimap({ x: 0, y: 0, size: 200, worldSize: TERRAIN_SIZE });
+    minimap.update(um.units);
+    const allyUnit = um.units.find(u => u.faction === 'ally')!;
+    const allyDot = minimap.dots.find(d => d.unitId === allyUnit.id)!;
+    expect(allyDot.color[2]).toBeGreaterThan(0.5);
+  });
+
+  it('敌方单位点颜色为红色（R > 0.5）', () => {
+    const um = new UnitManager();
+    const minimap = new Minimap({ x: 0, y: 0, size: 200, worldSize: TERRAIN_SIZE });
+    minimap.update(um.units);
+    const enemyUnit = um.units.find(u => u.faction === 'enemy')!;
+    const enemyDot = minimap.dots.find(d => d.unitId === enemyUnit.id)!;
+    expect(enemyDot.color[0]).toBeGreaterThan(0.5);
+    expect(enemyDot.color[2]).toBeLessThan(0.5);
+  });
+
+  it('选中单位点颜色变为高亮黄（R≈1, G≈1）', () => {
+    const um = new UnitManager();
+    const minimap = new Minimap({ x: 0, y: 0, size: 200, worldSize: TERRAIN_SIZE });
+    const allyUnit = um.units.find(u => u.faction === 'ally')!;
+    // 模拟选中
+    um.setSelected(allyUnit.id, true);
+    minimap.update(um.units);
+    const dot = minimap.dots.find(d => d.unitId === allyUnit.id)!;
+    expect(dot.color[0]).toBeGreaterThan(0.9); // R
+    expect(dot.color[1]).toBeGreaterThan(0.9); // G
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// UnitPanel — 选中单位信息面板
+// ────────────────────────────────────────────────────────────
+describe('UnitPanel — 选中单位信息面板', () => {
+  let um: UnitManager;
+
+  beforeEach(() => {
+    um = new UnitManager();
+  });
+
+  it('初始化后 selectedCount 为 0', () => {
+    const panel = new UnitPanel({ width: 800, height: 600 });
+    expect(panel.selectedCount).toBe(0);
+  });
+
+  it('update 空选中后 selectedCount=0', () => {
+    const panel = new UnitPanel({ width: 800, height: 600 });
+    panel.update(new Set(), um.units);
+    expect(panel.selectedCount).toBe(0);
+  });
+
+  it('update 选中 5 个单位后 selectedCount=5', () => {
+    const panel = new UnitPanel({ width: 800, height: 600 });
+    const allyIds = um.units.filter(u => u.faction === 'ally').slice(0, 5).map(u => u.id);
+    panel.update(new Set(allyIds), um.units);
+    expect(panel.selectedCount).toBe(5);
+  });
+
+  it('countText 文本包含选中数量', () => {
+    const panel = new UnitPanel({ width: 800, height: 600 });
+    const ids = um.units.slice(0, 3).map(u => u.id);
+    panel.update(new Set(ids), um.units);
+    expect(panel.countText.text).toContain('3');
+  });
+
+  it('阵营分布文本正确（全选我方 3 个）', () => {
+    const panel = new UnitPanel({ width: 800, height: 600 });
+    const allyIds = um.units.filter(u => u.faction === 'ally').slice(0, 3).map(u => u.id);
+    panel.update(new Set(allyIds), um.units);
+    expect(panel.allyText.text).toContain('3');
+    expect(panel.enemyText.text).toContain('0');
+    expect(panel.neutralText.text).toContain('0');
+  });
+
+  it('UIFlexContainer 包含 4 个文本子元素', () => {
+    const panel = new UnitPanel({ width: 800, height: 600 });
+    expect(panel.container.children.length).toBe(4);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// CommandFeedback — 命令反馈
+// ────────────────────────────────────────────────────────────
+describe('CommandFeedback — 命令反馈', () => {
+  it('初始 isActive 为 false', () => {
+    const cf = new CommandFeedback();
+    expect(cf.isActive).toBe(false);
+  });
+
+  it('初始 marker 不可见', () => {
+    const cf = new CommandFeedback();
+    expect(cf.marker.visible).toBe(false);
+  });
+
+  it('show 后 isActive 为 true', () => {
+    const cf = new CommandFeedback();
+    cf.show(100, 100);
+    expect(cf.isActive).toBe(true);
+  });
+
+  it('show 后 marker 可见且位置正确', () => {
+    const cf = new CommandFeedback();
+    cf.show(200, 150);
+    expect(cf.marker.visible).toBe(true);
+    // 标记居中在点击位置（marker x = 200 - size/2）
+    expect(cf.marker.x).toBeCloseTo(200 - 10, 0);
+    expect(cf.marker.y).toBeCloseTo(150 - 10, 0);
+  });
+
+  it('show 后 opacity 为 1', () => {
+    const cf = new CommandFeedback();
+    cf.show(100, 100);
+    expect(cf.marker.opacity).toBeCloseTo(1.0, 4);
+  });
+
+  it('update(0.25) 后 opacity 约为 0.5（淡出一半）', () => {
+    const cf = new CommandFeedback();
+    cf.show(100, 100);
+    cf.update(0.25);
+    expect(cf.marker.opacity).toBeCloseTo(0.5, 1);
+  });
+
+  it('update 超过 0.5s 后 isActive 变 false', () => {
+    const cf = new CommandFeedback();
+    cf.show(100, 100);
+    cf.update(0.6);
+    expect(cf.isActive).toBe(false);
+  });
+
+  it('update 超过 0.5s 后 marker 不可见', () => {
+    const cf = new CommandFeedback();
+    cf.show(100, 100);
+    cf.update(0.6);
+    expect(cf.marker.visible).toBe(false);
+  });
+
+  it('未激活时 update 不报错', () => {
+    const cf = new CommandFeedback();
+    expect(() => cf.update(1.0)).not.toThrow();
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// PauseMenu — 暂停菜单
+// ────────────────────────────────────────────────────────────
+describe('PauseMenu — 暂停菜单', () => {
+  it('默认 hidden（visible=false）', () => {
+    const menu = new PauseMenu({ width: 800, height: 600 });
+    expect(menu.visible).toBe(false);
+  });
+
+  it('show() 后 visible=true', () => {
+    const menu = new PauseMenu({ width: 800, height: 600 });
+    menu.show();
+    expect(menu.visible).toBe(true);
+  });
+
+  it('hide() 后 visible=false', () => {
+    const menu = new PauseMenu({ width: 800, height: 600 });
+    menu.show();
+    menu.hide();
+    expect(menu.visible).toBe(false);
+  });
+
+  it('toggle() 切换可见性', () => {
+    const menu = new PauseMenu({ width: 800, height: 600 });
+    menu.toggle();
+    expect(menu.visible).toBe(true);
+    menu.toggle();
+    expect(menu.visible).toBe(false);
+  });
+
+  it('Resume 按钮 onClick 触发 onResume 回调', () => {
+    const menu = new PauseMenu({ width: 800, height: 600 });
+    let resumed = false;
+    menu.onResume = () => { resumed = true; };
+    menu.resumeBtn.onClick?.();
+    expect(resumed).toBe(true);
+  });
+
+  it('Restart 按钮 onClick 触发 onRestart 回调', () => {
+    const menu = new PauseMenu({ width: 800, height: 600 });
+    let restarted = false;
+    menu.onRestart = () => { restarted = true; };
+    menu.restartBtn.onClick?.();
+    expect(restarted).toBe(true);
+  });
+
+  it('Back to Menu 按钮 onClick 触发 onBackToMenu 回调', () => {
+    const menu = new PauseMenu({ width: 800, height: 600 });
+    let backedOut = false;
+    menu.onBackToMenu = () => { backedOut = true; };
+    menu.backToMenuBtn.onClick?.();
+    expect(backedOut).toBe(true);
+  });
+
+  it('canvas 包含 overlay + title + buttonContainer 共 3 个子元素', () => {
+    const menu = new PauseMenu({ width: 800, height: 600 });
+    expect(menu.canvas.children.length).toBe(3);
+  });
+
+  it('buttonContainer 包含 3 个按钮', () => {
+    const menu = new PauseMenu({ width: 800, height: 600 });
+    expect(menu.buttonContainer.children.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- **ResourceBar**: 顶部资源计数栏，金/木资源文本实时更新，从 0→500 递增可见
- **Minimap**: 200×200px 小地图，`worldToMap()` 坐标映射，单位点按阵营颜色区分
- **UnitPanel**: 底部选中单位信息面板，`UIFlexContainer` 自动布局，显示数量+阵营分布
- **CommandFeedback**: 屏幕坐标命令反馈标记，0.5s 线性淡出效果
- **PauseMenu**: 暂停菜单覆盖层，Resume/Restart/Back to Menu 三按钮，ESC 切换

## 验收标准

- [x] 资源栏响应资源变更（从 0 → 500 可见递增）
- [x] 小地图点位置与世界空间单位位置一致（通过 worldToMap 验证）
- [x] 选中单位后信息面板显示正确数量
- [x] 暂停菜单按钮可点击并响应
- [x] 集成测试 hud.test.ts 40 个用例全通过
- [x] 全量回归 1535 tests passed（0 失败）
- [x] 不修改 src/ 任何文件

## Test plan

- [x] cd examples/slg-3d && npx vitest run — 83 tests passed
- [x] pnpm run test 全量 — 1535 tests passed

close #245