### PR TITLE
feat: M3.4 资源采集循环 — 建筑 + Timer + EventEmitter + 资源计数

### DIFF
--- a/examples/slg-3d/src/buildings.ts
+++ b/examples/slg-3d/src/buildings.ts
@@ -1,0 +1,56 @@
+/**
+ * Buildings — 基地与资源点定义。
+ *
+ * 基地（BaseBuilding）：我方大本营，单位前来存入采集物资。
+ * 资源点（ResourceNode）：金矿 / 木材采集点，有储量上限。
+ *
+ * 世界坐标范围：X/Z ∈ [-64, 64)（与地形一致）。
+ */
+
+export type ResourceType = 'gold' | 'wood';
+
+export interface ResourceNode {
+  id: number;
+  x: number;
+  z: number;
+  type: ResourceType;
+  /** 当前剩余储量 */
+  amount: number;
+  /** 最大储量 */
+  maxAmount: number;
+}
+
+export interface BaseBuilding {
+  x: number;
+  z: number;
+  /** 到达半径（单位进入此范围视为抵达基地） */
+  radius: number;
+}
+
+/**
+ * 创建我方基地，位于地图左下角（与障碍物无重叠区）。
+ */
+export function createBase(): BaseBuilding {
+  return { x: -50, z: -50, radius: 5 };
+}
+
+/**
+ * 创建 5 个资源点，分散在地图各区域（均在可通行区域内）。
+ *
+ * 位置刻意避开 nav.ts 中的障碍物：
+ *   西北森林  (-20,-30, 8×8)
+ *   北部岩石  (10,-20,  6×10)
+ *   西部山丘  (-30,10,  10×6)
+ *   东部丘陵  (20,20,   8×8)
+ *   南部森林  (-10,40,  12×6)
+ *   东北岩石  (40,-10,  6×6)
+ */
+export function createResourceNodes(): ResourceNode[] {
+  return [
+    { id: 0, x:  30, z: -40, type: 'gold', amount: 1000, maxAmount: 1000 },
+    { id: 1, x: -40, z:  30, type: 'gold', amount: 1000, maxAmount: 1000 },
+    { id: 2, x:  50, z:  30, type: 'wood', amount: 1000, maxAmount: 1000 },
+    { id: 3, x:  -5, z: -55, type: 'wood', amount: 1000, maxAmount: 1000 },
+    { id: 4, x:  55, z: -40, type: 'gold', amount: 1000, maxAmount: 1000 },
+  ];
+}

--- a/examples/slg-3d/src/harvest.ts
+++ b/examples/slg-3d/src/harvest.ts
@@ -1,0 +1,416 @@
+/**
+ * HarvestSystem — 采集循环逻辑。
+ *
+ * 每个参与采集的单位持有：
+ *   - Node3D（位置追踪，不加入场景）
+ *   - NavAgent（路径跟随）
+ *   - StateMachine<HarvestState>（4 状态：idle/moving/gathering/depositing）
+ *   - Timer（驱动采集间隔）
+ *
+ * 采集循环：
+ *   idle → moving（前往资源点）
+ *     → gathering（到达资源点，Timer 驱动采集，每秒 GATHER_RATE 金/木）
+ *       → moving（背包满/资源耗尽 → 前往基地）
+ *         → depositing（到达基地，存入资源）
+ *           → moving（返回资源点，继续采集）
+ *             → ...
+ *
+ * 状态变化通过 ResourceState.events 发出 unit.state.changed 事件。
+ */
+import { Node3D } from '../../../src/core/node3d';
+import { NavAgent } from '../../../src/navigation/nav-agent';
+import { StateMachine } from '../../../src/gameplay/state-machine';
+import { Timer } from '../../../src/gameplay/timer';
+import { type NavMap } from './nav';
+import { UnitManager } from './units';
+import { ResourceState } from './resource-state';
+import { type ResourceNode, type BaseBuilding } from './buildings';
+
+/** 采集状态类型 */
+export type HarvestState = 'idle' | 'moving' | 'gathering' | 'depositing';
+
+/** 单位背包容量（金/木合计） */
+const BACKPACK_CAPACITY = 50;
+
+/** 每秒采集量（资源单位） */
+const GATHER_RATE = 10;
+
+/** 采集 tick 间隔（秒） */
+const GATHER_INTERVAL = 1.0;
+
+/** 存入动作停留时间（秒），让 depositing 状态可被外部观察到 */
+const DEPOSIT_LINGER = 0.3;
+
+/** 单个采集单位的内部状态 */
+interface HarvestUnit {
+  id: number;
+  node: Node3D;
+  agent: NavAgent;
+  sm: StateMachine<HarvestState>;
+  timer: Timer;
+  /** 背包中的金矿数量 */
+  carriedGold: number;
+  /** 背包中的木材数量 */
+  carriedWood: number;
+  /** 当前负责的资源点 */
+  targetNode: ResourceNode | null;
+  /** 是否正在前往基地（区分 onArrived 回调的意图） */
+  headingToBase: boolean;
+  /** depositing 状态已停留时间（秒） */
+  depositElapsed: number;
+  /** 采集 timer 句柄（-1 表示未激活） */
+  gatherHandle: number;
+}
+
+/**
+ * 管理采集单位集合，驱动 idle/moving/gathering/depositing 完整循环。
+ */
+export class HarvestSystem {
+  private readonly _units = new Map<number, HarvestUnit>();
+
+  constructor(
+    private readonly _unitManager: UnitManager,
+    private readonly _navMap: NavMap,
+    private readonly _resourceState: ResourceState,
+    private readonly _base: BaseBuilding,
+    private readonly _resourceNodes: ResourceNode[],
+  ) {}
+
+  /**
+   * 命令指定单位前往指定资源点采集。
+   * 若单位已在 HarvestSystem 中注册则直接重新分配目标；否则先注册。
+   */
+  commandGather(unitIds: number[], node: ResourceNode): void {
+    for (const id of unitIds) {
+      let hu = this._units.get(id);
+      if (!hu) {
+        hu = this._createHarvestUnit(id);
+        this._units.set(id, hu);
+      }
+      this._assignTarget(hu, node);
+    }
+  }
+
+  /**
+   * 每帧驱动：更新 Timer、NavAgent、存入计时。
+   * @param dt 帧间隔（秒）
+   */
+  update(dt: number): void {
+    for (const hu of this._units.values()) {
+      // 先驱动 Timer（触发采集 tick 回调）
+      hu.timer.update(dt);
+
+      if (hu.sm.isIn('moving')) {
+        hu.agent.update(dt);
+        // 同步 node 位置 → UnitManager（更新 InstancedMesh）
+        const unit = this._unitManager.units[hu.id];
+        if (unit) {
+          this._unitManager.updateUnitPosition(
+            hu.id,
+            hu.node.position[0],
+            hu.node.position[2],
+          );
+        }
+      }
+
+      if (hu.sm.isIn('depositing')) {
+        hu.depositElapsed += dt;
+        if (hu.depositElapsed >= DEPOSIT_LINGER) {
+          this._finishDeposit(hu);
+        }
+      }
+    }
+  }
+
+  /** 读取单位当前采集状态（不在系统中返回 null）。 */
+  getState(unitId: number): HarvestState | null {
+    return this._units.get(unitId)?.sm.current ?? null;
+  }
+
+  /** 读取单位背包内容（不在系统中返回 null）。 */
+  getCarried(unitId: number): { gold: number; wood: number } | null {
+    const hu = this._units.get(unitId);
+    if (!hu) return null;
+    return { gold: hu.carriedGold, wood: hu.carriedWood };
+  }
+
+  // ─────────────────────────────────────────────────────────
+  // 私有：初始化
+  // ─────────────────────────────────────────────────────────
+
+  private _createHarvestUnit(id: number): HarvestUnit {
+    const unit = this._unitManager.units[id];
+
+    const node = new Node3D(`harv-${id}`);
+    node.position[0] = unit.x;
+    node.position[1] = unit.y;
+    node.position[2] = unit.z;
+
+    const agent = new NavAgent(node, 15);
+    const sm    = this._buildStateMachine();
+    const timer = new Timer();
+
+    const hu: HarvestUnit = {
+      id,
+      node,
+      agent,
+      sm,
+      timer,
+      carriedGold: 0,
+      carriedWood: 0,
+      targetNode: null,
+      headingToBase: false,
+      depositElapsed: 0,
+      gatherHandle: -1,
+    };
+
+    // NavAgent 到达终点回调（捕获 hu 引用）
+    agent.onArrived(() => this._onArrived(hu));
+
+    return hu;
+  }
+
+  /** 构建 4 状态采集状态机并注册所有转换规则。 */
+  private _buildStateMachine(): StateMachine<HarvestState> {
+    const sm = new StateMachine<HarvestState>(
+      { idle: {}, moving: {}, gathering: {}, depositing: {} },
+      'idle',
+    );
+    sm.addTransition('idle',       'moving');
+    sm.addTransition('moving',     'gathering');
+    sm.addTransition('moving',     'depositing');
+    sm.addTransition('gathering',  'moving');
+    sm.addTransition('gathering',  'idle');
+    sm.addTransition('depositing', 'moving');
+    sm.addTransition('depositing', 'idle');
+    // 外部可强制打断：moving/gathering/depositing → idle
+    sm.addTransition('moving',     'idle');
+    return sm;
+  }
+
+  // ─────────────────────────────────────────────────────────
+  // 私有：采集循环
+  // ─────────────────────────────────────────────────────────
+
+  /** 分配资源点并启动前往移动。 */
+  private _assignTarget(hu: HarvestUnit, node: ResourceNode): void {
+    this._stopGathering(hu);
+    hu.targetNode    = node;
+    hu.headingToBase = false;
+    this._moveTo(hu, node.x, node.z);
+  }
+
+  /**
+   * 导航至目标世界坐标。
+   * 若状态不是 moving，则先转换；若路径找不到，回退 idle。
+   */
+  private _moveTo(hu: HarvestUnit, tx: number, tz: number): void {
+    // 同步 node 当前位置（可能已被上次移动改变）
+    const unit = this._unitManager.units[hu.id];
+    if (!unit) return;
+    hu.node.position[0] = unit.x;
+    hu.node.position[2] = unit.z;
+
+    const result = this._navMap.findPathWorld(unit.x, unit.z, tx, tz);
+    if (!result.found || result.path.length === 0) {
+      // 路径不通：回 idle
+      if (!hu.sm.isIn('idle')) {
+        this._safeTransition(hu, 'idle');
+      }
+      return;
+    }
+
+    const waypoints: Array<[number, number]> = result.path.map(
+      ([gx, gz]) => this._navMap.gridToWorld(gx, gz),
+    );
+    hu.agent.followPath(waypoints);
+
+    // 确保处于 moving 状态，并发射事件
+    if (!hu.sm.isIn('moving')) {
+      this._safeTransition(hu, 'moving');
+      this._emitStateChange(hu, 'moving');
+    }
+  }
+
+  /** NavAgent onArrived 回调：根据 headingToBase 分发到资源点到达 or 基地到达。 */
+  private _onArrived(hu: HarvestUnit): void {
+    if (!hu.sm.isIn('moving')) return;
+
+    if (hu.headingToBase) {
+      this._onArrivedBase(hu);
+    } else {
+      this._onArrivedNode(hu);
+    }
+  }
+
+  /** 到达资源点：进入 gathering 状态，启动采集 Timer。 */
+  private _onArrivedNode(hu: HarvestUnit): void {
+    if (!hu.sm.transition('gathering')) return;
+    this._emitStateChange(hu, 'gathering');
+    this._startGatherTimer(hu);
+  }
+
+  /** 到达基地：进入 depositing 状态，等待 DEPOSIT_LINGER 后存入。 */
+  private _onArrivedBase(hu: HarvestUnit): void {
+    if (!hu.sm.transition('depositing')) return;
+    hu.depositElapsed = 0;
+    this._emitStateChange(hu, 'depositing');
+  }
+
+  /** 启动 Timer 驱动的采集 tick。 */
+  private _startGatherTimer(hu: HarvestUnit): void {
+    this._stopGathering(hu);
+    hu.gatherHandle = hu.timer.setInterval(() => {
+      if (!hu.sm.isIn('gathering')) return;
+
+      const node = hu.targetNode;
+      if (!node || node.amount <= 0) {
+        // 资源耗尽：若有存货就回基地，否则找下一个资源点
+        if (this._carriedTotal(hu) > 0) {
+          this._headToBase(hu);
+        } else {
+          const nearest = this._findNearestNode(hu);
+          if (nearest) {
+            this._stopGathering(hu);
+            hu.targetNode    = nearest;
+            hu.headingToBase = false;
+            this._safeTransition(hu, 'moving');
+            this._emitStateChange(hu, 'moving');
+            this._moveTo(hu, nearest.x, nearest.z);
+          } else {
+            this._stopGathering(hu);
+            this._safeTransition(hu, 'idle');
+            this._emitStateChange(hu, 'idle');
+          }
+        }
+        return;
+      }
+
+      // 本次可采集量
+      const space    = BACKPACK_CAPACITY - this._carriedTotal(hu);
+      const canTake  = Math.min(GATHER_RATE, node.amount, space);
+      if (canTake <= 0) {
+        this._headToBase(hu);
+        return;
+      }
+
+      node.amount -= canTake;
+      if (node.type === 'gold') hu.carriedGold += canTake;
+      else                      hu.carriedWood += canTake;
+
+      // 背包满：立即回基地
+      if (this._carriedTotal(hu) >= BACKPACK_CAPACITY) {
+        this._headToBase(hu);
+      }
+    }, GATHER_INTERVAL);
+  }
+
+  /** 停止采集 Timer。 */
+  private _stopGathering(hu: HarvestUnit): void {
+    if (hu.gatherHandle !== -1) {
+      hu.timer.cancel(hu.gatherHandle);
+      hu.gatherHandle = -1;
+    }
+  }
+
+  /** 背包满或资源耗尽时前往基地。 */
+  private _headToBase(hu: HarvestUnit): void {
+    this._stopGathering(hu);
+    hu.headingToBase = true;
+    if (!hu.sm.isIn('moving')) {
+      this._safeTransition(hu, 'moving');
+    }
+    this._emitStateChange(hu, 'moving');
+    this._moveToBase(hu);
+  }
+
+  /** 导航至基地。 */
+  private _moveToBase(hu: HarvestUnit): void {
+    const unit = this._unitManager.units[hu.id];
+    if (!unit) return;
+    hu.node.position[0] = unit.x;
+    hu.node.position[2] = unit.z;
+
+    const result = this._navMap.findPathWorld(unit.x, unit.z, this._base.x, this._base.z);
+    if (!result.found || result.path.length === 0) {
+      // 无法到达基地：直接模拟到达（紧急存入）
+      this._onArrivedBase(hu);
+      return;
+    }
+
+    const waypoints: Array<[number, number]> = result.path.map(
+      ([gx, gz]) => this._navMap.gridToWorld(gx, gz),
+    );
+    hu.agent.followPath(waypoints);
+  }
+
+  /** DEPOSIT_LINGER 结束后执行存入并决定下一步。 */
+  private _finishDeposit(hu: HarvestUnit): void {
+    // 存入资源
+    if (hu.carriedGold > 0) {
+      this._resourceState.addGold(hu.carriedGold);
+      hu.carriedGold = 0;
+    }
+    if (hu.carriedWood > 0) {
+      this._resourceState.addWood(hu.carriedWood);
+      hu.carriedWood = 0;
+    }
+
+    // 决定下一个目标
+    const targetNode =
+      (hu.targetNode && hu.targetNode.amount > 0)
+        ? hu.targetNode
+        : this._findNearestNode(hu);
+
+    if (targetNode) {
+      hu.targetNode    = targetNode;
+      hu.headingToBase = false;
+      if (!hu.sm.transition('moving')) return;
+      this._emitStateChange(hu, 'moving');
+      this._moveTo(hu, targetNode.x, targetNode.z);
+    } else {
+      // 无资源可采：进入 idle
+      hu.sm.transition('idle');
+      this._emitStateChange(hu, 'idle');
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────
+  // 私有：工具方法
+  // ─────────────────────────────────────────────────────────
+
+  private _carriedTotal(hu: HarvestUnit): number {
+    return hu.carriedGold + hu.carriedWood;
+  }
+
+  /** 从 _resourceNodes 找离当前单位最近且有储量的资源点。 */
+  private _findNearestNode(hu: HarvestUnit): ResourceNode | null {
+    const unit = this._unitManager.units[hu.id];
+    if (!unit) return null;
+
+    let nearest: ResourceNode | null = null;
+    let minDist = Infinity;
+
+    for (const node of this._resourceNodes) {
+      if (node.amount <= 0) continue;
+      const dx = node.x - unit.x;
+      const dz = node.z - unit.z;
+      const d2 = dx * dx + dz * dz;
+      if (d2 < minDist) {
+        minDist  = d2;
+        nearest  = node;
+      }
+    }
+    return nearest;
+  }
+
+  /** 安全转换状态机（忽略非法转换，不抛异常）。 */
+  private _safeTransition(hu: HarvestUnit, to: HarvestState): void {
+    hu.sm.transition(to);
+  }
+
+  /** 向全局事件总线发送单位状态变更事件。 */
+  private _emitStateChange(hu: HarvestUnit, state: HarvestState): void {
+    this._resourceState.events.emit('unit.state.changed', hu.id, state);
+  }
+}

--- a/examples/slg-3d/src/resource-state.ts
+++ b/examples/slg-3d/src/resource-state.ts
@@ -1,0 +1,45 @@
+/**
+ * ResourceState — 全局资源状态 + EventEmitter。
+ *
+ * 事件：
+ *   resource.changed     — 资源数量变化时触发（gold 或 wood 变动）
+ *   unit.state.changed   — 单位采集状态变化时触发
+ *
+ * 全局访问：实例挂载到 window.__game.resources 供测试读取。
+ */
+import { EventEmitter } from '../../../src/gameplay/event-emitter';
+
+export interface Resources {
+  gold: number;
+  wood: number;
+}
+
+export type GameEvents = {
+  'resource.changed':   (resources: Resources) => void;
+  'unit.state.changed': (unitId: number, state: string) => void;
+};
+
+export class ResourceState {
+  private _gold = 0;
+  private _wood = 0;
+
+  /** 游戏全局事件总线（resource + unit 状态事件均走此处） */
+  readonly events = new EventEmitter<GameEvents>();
+
+  get gold(): number { return this._gold; }
+  get wood(): number { return this._wood; }
+
+  addGold(amount: number): void {
+    this._gold += amount;
+    this.events.emit('resource.changed', { gold: this._gold, wood: this._wood });
+  }
+
+  addWood(amount: number): void {
+    this._wood += amount;
+    this.events.emit('resource.changed', { gold: this._gold, wood: this._wood });
+  }
+
+  getResources(): Resources {
+    return { gold: this._gold, wood: this._wood };
+  }
+}

--- a/examples/slg-3d/test/integration/harvest.test.ts
+++ b/examples/slg-3d/test/integration/harvest.test.ts
@@ -1,0 +1,493 @@
+/**
+ * 集成测试：M3.4 资源采集循环
+ *
+ * 验收标准：
+ * - 至少 10 个我方单位能并发采集不冲突
+ * - 资源计数随采集事件增长
+ * - StateMachine 4 状态切换无遗漏
+ * - EventEmitter 事件可被测试监听
+ * - 30 秒内资源增加超过阈值（模拟时间：1800 帧 × 1/60s）
+ * - headless 压力测试 1800 帧采集循环不崩溃
+ * - 不修改 src/ 任何文件
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { UnitManager } from '../../src/units';
+import { buildNavMap, NavMap } from '../../src/nav';
+import { ResourceState } from '../../src/resource-state';
+import { createBase, createResourceNodes, type ResourceNode, type BaseBuilding } from '../../src/buildings';
+import { HarvestSystem, type HarvestState } from '../../src/harvest';
+
+// ────────────────────────────────────────────────────────────
+// 辅助：构建一套完整的测试环境
+// ────────────────────────────────────────────────────────────
+function buildEnv() {
+  const unitManager    = new UnitManager();
+  const navMap         = buildNavMap();
+  const resourceState  = new ResourceState();
+  const base           = createBase();
+  const resourceNodes  = createResourceNodes();
+  const harvestSystem  = new HarvestSystem(
+    unitManager, navMap, resourceState, base, resourceNodes,
+  );
+  const allyUnits = unitManager.units.filter(u => u.faction === 'ally');
+  return { unitManager, navMap, resourceState, base, resourceNodes, harvestSystem, allyUnits };
+}
+
+// ────────────────────────────────────────────────────────────
+// ResourceState — 全局资源 + EventEmitter
+// ────────────────────────────────────────────────────────────
+describe('ResourceState — 全局资源与事件', () => {
+  it('初始 gold=0, wood=0', () => {
+    const rs = new ResourceState();
+    expect(rs.gold).toBe(0);
+    expect(rs.wood).toBe(0);
+  });
+
+  it('addGold 增加金矿并触发 resource.changed 事件', () => {
+    const rs = new ResourceState();
+    let called = 0;
+    let payload = { gold: 0, wood: 0 };
+    rs.events.on('resource.changed', (r) => { called++; payload = r; });
+    rs.addGold(50);
+    expect(rs.gold).toBe(50);
+    expect(called).toBe(1);
+    expect(payload.gold).toBe(50);
+  });
+
+  it('addWood 增加木材并触发 resource.changed 事件', () => {
+    const rs = new ResourceState();
+    let called = 0;
+    rs.events.on('resource.changed', () => called++);
+    rs.addWood(30);
+    expect(rs.wood).toBe(30);
+    expect(called).toBe(1);
+  });
+
+  it('多次 addGold 累积计数', () => {
+    const rs = new ResourceState();
+    rs.addGold(50);
+    rs.addGold(50);
+    rs.addGold(50);
+    expect(rs.gold).toBe(150);
+  });
+
+  it('getResources 返回当前快照', () => {
+    const rs = new ResourceState();
+    rs.addGold(100);
+    rs.addWood(200);
+    const snap = rs.getResources();
+    expect(snap.gold).toBe(100);
+    expect(snap.wood).toBe(200);
+  });
+
+  it('unit.state.changed 事件可被监听', () => {
+    const rs = new ResourceState();
+    const stateLog: Array<{ id: number; state: string }> = [];
+    rs.events.on('unit.state.changed', (id, state) => stateLog.push({ id, state }));
+    rs.events.emit('unit.state.changed', 0, 'moving');
+    rs.events.emit('unit.state.changed', 1, 'gathering');
+    expect(stateLog).toHaveLength(2);
+    expect(stateLog[0]).toEqual({ id: 0, state: 'moving' });
+    expect(stateLog[1]).toEqual({ id: 1, state: 'gathering' });
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Buildings — 基地与资源点
+// ────────────────────────────────────────────────────────────
+describe('Buildings — 基地与资源点', () => {
+  it('createBase 返回有效基地', () => {
+    const base = createBase();
+    expect(base).toBeDefined();
+    expect(typeof base.x).toBe('number');
+    expect(typeof base.z).toBe('number');
+    expect(base.radius).toBeGreaterThan(0);
+  });
+
+  it('createResourceNodes 返回 ≥3 个资源点', () => {
+    const nodes = createResourceNodes();
+    expect(nodes.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('资源点有正储量', () => {
+    const nodes = createResourceNodes();
+    for (const node of nodes) {
+      expect(node.amount).toBeGreaterThan(0);
+      expect(node.maxAmount).toBeGreaterThan(0);
+    }
+  });
+
+  it('资源点 id 不重复', () => {
+    const nodes = createResourceNodes();
+    const ids = new Set(nodes.map(n => n.id));
+    expect(ids.size).toBe(nodes.length);
+  });
+
+  it('资源点包含 gold 和 wood 两种类型', () => {
+    const nodes = createResourceNodes();
+    const types = new Set(nodes.map(n => n.type));
+    expect(types.has('gold')).toBe(true);
+    expect(types.has('wood')).toBe(true);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// HarvestSystem — 初始化
+// ────────────────────────────────────────────────────────────
+describe('HarvestSystem — 初始化', () => {
+  it('创建不抛出异常', () => {
+    expect(() => buildEnv()).not.toThrow();
+  });
+
+  it('commandGather 不抛出异常', () => {
+    const { harvestSystem, allyUnits, resourceNodes } = buildEnv();
+    const ids = allyUnits.slice(0, 3).map(u => u.id);
+    expect(() => harvestSystem.commandGather(ids, resourceNodes[0])).not.toThrow();
+  });
+
+  it('commandGather 后单位进入 moving 或仍为 idle（路径不通时）', () => {
+    const { harvestSystem, allyUnits, resourceNodes } = buildEnv();
+    const ids = allyUnits.slice(0, 5).map(u => u.id);
+    harvestSystem.commandGather(ids, resourceNodes[0]);
+    for (const id of ids) {
+      const state = harvestSystem.getState(id);
+      expect(['idle', 'moving']).toContain(state);
+    }
+  });
+
+  it('未注册单位 getState 返回 null', () => {
+    const { harvestSystem } = buildEnv();
+    expect(harvestSystem.getState(9999)).toBeNull();
+  });
+
+  it('未注册单位 getCarried 返回 null', () => {
+    const { harvestSystem } = buildEnv();
+    expect(harvestSystem.getCarried(9999)).toBeNull();
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// StateMachine 4 状态切换验证
+// ────────────────────────────────────────────────────────────
+describe('StateMachine — 4 状态切换', () => {
+  /**
+   * 使用单独放置在资源点旁的单位，强制快速到达采集点，
+   * 验证 idle → moving → gathering → moving → depositing → moving 完整循环。
+   */
+  it('单位执行 commandGather 后能进入 moving 状态', () => {
+    const { harvestSystem, allyUnits, resourceNodes } = buildEnv();
+    // 找一个可寻路到资源点的单位
+    const id = allyUnits[0].id;
+    harvestSystem.commandGather([id], resourceNodes[0]);
+    const state = harvestSystem.getState(id);
+    expect(['idle', 'moving']).toContain(state);
+  });
+
+  it('能观察到 gathering 状态（模拟足够帧到达资源点）', () => {
+    const { unitManager, navMap, resourceState, base, resourceNodes, harvestSystem, allyUnits } = buildEnv();
+
+    // 找一个位置可通行的单位，选最近的资源点
+    let gatheringObserved = false;
+
+    for (const unit of allyUnits) {
+      if (!navMap.isWalkableWorld(unit.x, unit.z)) continue;
+
+      harvestSystem.commandGather([unit.id], resourceNodes[0]);
+      if (harvestSystem.getState(unit.id) !== 'moving') continue;
+
+      // 运行至多 600 帧（10 秒），等待到达并采集
+      for (let i = 0; i < 600; i++) {
+        harvestSystem.update(1 / 60);
+        if (harvestSystem.getState(unit.id) === 'gathering') {
+          gatheringObserved = true;
+          break;
+        }
+      }
+      if (gatheringObserved) break;
+    }
+
+    expect(gatheringObserved).toBe(true);
+  });
+
+  it('能观察到 depositing 状态（背包满后前往基地）', () => {
+    const { navMap, harvestSystem, allyUnits, resourceNodes } = buildEnv();
+
+    let depositingObserved = false;
+
+    for (const unit of allyUnits) {
+      if (!navMap.isWalkableWorld(unit.x, unit.z)) continue;
+
+      harvestSystem.commandGather([unit.id], resourceNodes[0]);
+      if (harvestSystem.getState(unit.id) !== 'moving') continue;
+
+      // 运行至多 3600 帧（60 秒），等待整个采集→存入循环
+      for (let i = 0; i < 3600; i++) {
+        harvestSystem.update(1 / 60);
+        if (harvestSystem.getState(unit.id) === 'depositing') {
+          depositingObserved = true;
+          break;
+        }
+      }
+      if (depositingObserved) break;
+    }
+
+    expect(depositingObserved).toBe(true);
+  });
+
+  it('4 个合法状态值均包含在枚举范围内', () => {
+    const validStates: HarvestState[] = ['idle', 'moving', 'gathering', 'depositing'];
+    expect(validStates).toContain('idle');
+    expect(validStates).toContain('moving');
+    expect(validStates).toContain('gathering');
+    expect(validStates).toContain('depositing');
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// EventEmitter 事件可被测试监听
+// ────────────────────────────────────────────────────────────
+describe('EventEmitter — 事件监听', () => {
+  it('resource.changed 事件在 addGold/addWood 时触发', () => {
+    const rs = new ResourceState();
+    const events: Array<{ gold: number; wood: number }> = [];
+    rs.events.on('resource.changed', (r) => events.push({ ...r }));
+
+    rs.addGold(50);
+    rs.addWood(30);
+
+    expect(events).toHaveLength(2);
+    expect(events[0].gold).toBe(50);
+    expect(events[1].wood).toBe(30);
+  });
+
+  it('unit.state.changed 在 HarvestSystem 触发状态变化时被调用', () => {
+    const { harvestSystem, resourceState, allyUnits, resourceNodes, navMap } = buildEnv();
+
+    const stateChanges: Array<{ id: number; state: string }> = [];
+    resourceState.events.on('unit.state.changed', (id, state) => {
+      stateChanges.push({ id, state });
+    });
+
+    const unit = allyUnits.find(u => navMap.isWalkableWorld(u.x, u.z));
+    if (!unit) return; // 若无可通行单位跳过
+
+    harvestSystem.commandGather([unit.id], resourceNodes[0]);
+
+    // 至少应有一次 unit.state.changed 事件（commandGather → moving）
+    expect(stateChanges.length).toBeGreaterThanOrEqual(1);
+    const movingEvent = stateChanges.find(e => e.id === unit.id && e.state === 'moving');
+    expect(movingEvent).toBeDefined();
+  });
+
+  it('off 之后不再收到事件', () => {
+    const rs = new ResourceState();
+    let count = 0;
+    const listener = () => { count++; };
+    rs.events.on('resource.changed', listener);
+    rs.addGold(10); // count = 1
+    rs.events.off('resource.changed', listener);
+    rs.addGold(10); // count 应保持 1
+    expect(count).toBe(1);
+  });
+
+  it('removeAllListeners 清空所有监听', () => {
+    const rs = new ResourceState();
+    let count = 0;
+    rs.events.on('resource.changed', () => count++);
+    rs.events.on('resource.changed', () => count++);
+    rs.events.removeAllListeners('resource.changed');
+    rs.addGold(10);
+    expect(count).toBe(0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// 并发采集（≥10 个单位）
+// ────────────────────────────────────────────────────────────
+describe('并发采集 — ≥10 个单位', () => {
+  it('10 个我方单位同时 commandGather 不崩溃', () => {
+    const { harvestSystem, allyUnits, resourceNodes } = buildEnv();
+    const ids = allyUnits.slice(0, 10).map(u => u.id);
+    expect(() => {
+      harvestSystem.commandGather(ids, resourceNodes[0]);
+    }).not.toThrow();
+  });
+
+  it('10 个单位 commandGather 后 update 100 帧不崩溃', () => {
+    const { harvestSystem, allyUnits, resourceNodes } = buildEnv();
+    const ids = allyUnits.slice(0, 10).map(u => u.id);
+    harvestSystem.commandGather(ids, resourceNodes[0]);
+    expect(() => {
+      for (let i = 0; i < 100; i++) harvestSystem.update(1 / 60);
+    }).not.toThrow();
+  });
+
+  it('10 个单位采集后所有状态均为合法值', () => {
+    const { harvestSystem, allyUnits, resourceNodes } = buildEnv();
+    const ids = allyUnits.slice(0, 10).map(u => u.id);
+    harvestSystem.commandGather(ids, resourceNodes[0]);
+
+    for (let i = 0; i < 300; i++) harvestSystem.update(1 / 60);
+
+    const validStates: HarvestState[] = ['idle', 'moving', 'gathering', 'depositing'];
+    for (const id of ids) {
+      const state = harvestSystem.getState(id);
+      expect(validStates).toContain(state);
+    }
+  });
+
+  it('40 个我方单位全部采集不崩溃', () => {
+    const { harvestSystem, allyUnits, resourceNodes } = buildEnv();
+    const ids = allyUnits.map(u => u.id);
+    expect(ids.length).toBeGreaterThanOrEqual(10);
+
+    expect(() => {
+      harvestSystem.commandGather(ids, resourceNodes[0]);
+      for (let i = 0; i < 300; i++) harvestSystem.update(1 / 60);
+    }).not.toThrow();
+  });
+
+  it('多单位分配不同资源点不崩溃', () => {
+    const { harvestSystem, allyUnits, resourceNodes } = buildEnv();
+    expect(() => {
+      for (let i = 0; i < 10; i++) {
+        const node = resourceNodes[i % resourceNodes.length];
+        harvestSystem.commandGather([allyUnits[i].id], node);
+      }
+      for (let i = 0; i < 300; i++) harvestSystem.update(1 / 60);
+    }).not.toThrow();
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// 集成测试：30 秒内资源增加超过阈值
+// ────────────────────────────────────────────────────────────
+describe('集成测试 — 30 秒内资源增加超过阈值', () => {
+  it('10 个单位 1800 帧后总资源 > 50（至少完成一次采集循环）', () => {
+    const { harvestSystem, resourceState, allyUnits, resourceNodes } = buildEnv();
+
+    // 命令所有我方单位去第一个资源点
+    const ids = allyUnits.slice(0, 10).map(u => u.id);
+    harvestSystem.commandGather(ids, resourceNodes[0]);
+
+    // 模拟 30 秒（1800 帧 × 1/60s）
+    for (let i = 0; i < 1800; i++) {
+      harvestSystem.update(1 / 60);
+    }
+
+    const total = resourceState.gold + resourceState.wood;
+    // 理论最低：若有任意一个单位完成一次存入，则为 50
+    // 考虑移动延迟，保守阈值设为 50
+    expect(total).toBeGreaterThan(50);
+  });
+
+  it('40 个单位 1800 帧后总资源 > 100', () => {
+    const { harvestSystem, resourceState, allyUnits, resourceNodes } = buildEnv();
+
+    const ids = allyUnits.map(u => u.id);
+    // 分配到多个资源点
+    for (let i = 0; i < ids.length; i++) {
+      harvestSystem.commandGather([ids[i]], resourceNodes[i % resourceNodes.length]);
+    }
+
+    for (let i = 0; i < 1800; i++) {
+      harvestSystem.update(1 / 60);
+    }
+
+    const total = resourceState.gold + resourceState.wood;
+    expect(total).toBeGreaterThan(100);
+  });
+
+  it('resource.changed 事件累积触发次数 > 0', () => {
+    const { harvestSystem, resourceState, allyUnits, resourceNodes } = buildEnv();
+
+    let changeCount = 0;
+    resourceState.events.on('resource.changed', () => { changeCount++; });
+
+    const ids = allyUnits.slice(0, 10).map(u => u.id);
+    harvestSystem.commandGather(ids, resourceNodes[0]);
+
+    for (let i = 0; i < 1800; i++) {
+      harvestSystem.update(1 / 60);
+    }
+
+    expect(changeCount).toBeGreaterThan(0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// headless 压力测试：1800 帧采集循环不崩溃
+// ────────────────────────────────────────────────────────────
+describe('headless 压力测试 — 1800 帧', () => {
+  it('10 个单位 1800 帧采集循环不崩溃', () => {
+    const { harvestSystem, allyUnits, resourceNodes } = buildEnv();
+    const ids = allyUnits.slice(0, 10).map(u => u.id);
+
+    expect(() => {
+      harvestSystem.commandGather(ids, resourceNodes[0]);
+      for (let i = 0; i < 1800; i++) {
+        harvestSystem.update(1 / 60);
+      }
+    }).not.toThrow();
+  });
+
+  it('全部 40 个我方单位 1800 帧稳定运行', () => {
+    const { harvestSystem, allyUnits, resourceNodes } = buildEnv();
+    const ids = allyUnits.map(u => u.id);
+
+    expect(() => {
+      for (let i = 0; i < ids.length; i++) {
+        harvestSystem.commandGather([ids[i]], resourceNodes[i % resourceNodes.length]);
+      }
+      for (let i = 0; i < 1800; i++) {
+        harvestSystem.update(1 / 60);
+      }
+    }).not.toThrow();
+  });
+
+  it('1800 帧后所有单位状态仍为合法值', () => {
+    const { harvestSystem, allyUnits, resourceNodes } = buildEnv();
+    const ids = allyUnits.slice(0, 10).map(u => u.id);
+    harvestSystem.commandGather(ids, resourceNodes[0]);
+
+    for (let i = 0; i < 1800; i++) harvestSystem.update(1 / 60);
+
+    const validStates: HarvestState[] = ['idle', 'moving', 'gathering', 'depositing'];
+    for (const id of ids) {
+      const state = harvestSystem.getState(id);
+      expect(validStates).toContain(state);
+    }
+  });
+
+  it('中途切换目标资源点 1800 帧不崩溃', () => {
+    const { harvestSystem, allyUnits, resourceNodes } = buildEnv();
+    const ids = allyUnits.slice(0, 10).map(u => u.id);
+
+    expect(() => {
+      harvestSystem.commandGather(ids, resourceNodes[0]);
+      for (let frame = 0; frame < 1800; frame++) {
+        // 每 600 帧切换目标资源点，模拟玩家重新下达命令
+        if (frame === 600) harvestSystem.commandGather(ids, resourceNodes[1]);
+        if (frame === 1200) harvestSystem.commandGather(ids, resourceNodes[2]);
+        harvestSystem.update(1 / 60);
+      }
+    }).not.toThrow();
+  });
+
+  it('资源全部耗尽后单位不崩溃', () => {
+    const { unitManager, navMap, resourceState, base } = buildEnv();
+
+    // 创建只有 1 金储量的极小资源点
+    const tinyNodes: ResourceNode[] = [
+      { id: 0, x: 30, z: -40, type: 'gold', amount: 10, maxAmount: 10 },
+    ];
+    const hs = new HarvestSystem(unitManager, navMap, resourceState, base, tinyNodes);
+
+    const ids = unitManager.units.filter(u => u.faction === 'ally').slice(0, 5).map(u => u.id);
+
+    expect(() => {
+      hs.commandGather(ids, tinyNodes[0]);
+      for (let i = 0; i < 1800; i++) hs.update(1 / 60);
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## 关联 Issue

close #244

## 改动概述

实现 SLG 最核心的经济循环：单位去资源点采集 → 背包满后回基地存入 → 资源计数增加 → 自动返回继续采集。

## 新增文件

| 文件 | 说明 |
|------|------|
| `examples/slg-3d/src/resource-state.ts` | 全局资源状态 + GameEvents EventEmitter |
| `examples/slg-3d/src/buildings.ts` | 我方基地 + 5 个资源点（金矿/木材）工厂函数 |
| `examples/slg-3d/src/harvest.ts` | HarvestSystem — 4 状态采集循环核心逻辑 |
| `examples/slg-3d/test/integration/harvest.test.ts` | 37 项集成测试 |

## 验收标准

- [x] 至少 10 个我方单位能并发采集不冲突
- [x] 资源计数随采集事件增长
- [x] StateMachine 4 状态切换无遗漏（idle/moving/gathering/depositing）
- [x] EventEmitter 事件可被测试监听
- [x] 集成测试验证 30 秒内资源增加超过阈值
- [x] headless 压力测试 1800 帧不崩溃
- [x] 不修改 src/ 任何文件

## 测试结果

```
Test Files  5 passed (5)
     Tests  156 passed (156)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)