### PR TITLE
feat: M4.4 多人网络同步 — Mock 网络 + 12 人状态同步 (#256)

### DIFF
--- a/examples/br-12p/src/net/message-protocol.ts
+++ b/examples/br-12p/src/net/message-protocol.ts
@@ -1,0 +1,77 @@
+/**
+ * message-protocol.ts — 多人网络同步消息协议。
+ * 定义 12 人 BR 游戏所需的消息类型：join/leave/state/fire/hit/die/respawn。
+ */
+
+export type MessageType =
+  | 'player.join'
+  | 'player.leave'
+  | 'player.state'
+  | 'player.fire'
+  | 'player.hit'
+  | 'player.die'
+  | 'player.respawn';
+
+export interface Vec3Data { x: number; y: number; z: number; }
+
+/** 新玩家加入房间 */
+export interface PlayerJoinMsg {
+  type: 'player.join';
+  id: string;
+  name: string;
+  position: Vec3Data;
+}
+
+/** 玩家离开房间 */
+export interface PlayerLeaveMsg {
+  type: 'player.leave';
+  id: string;
+}
+
+/** 高频位置/状态快照（~10Hz） */
+export interface PlayerStateMsg {
+  type: 'player.state';
+  id: string;
+  position: Vec3Data;
+  rotation: number;
+  health: number;
+}
+
+/** 射击事件 */
+export interface PlayerFireMsg {
+  type: 'player.fire';
+  id: string;
+  origin: Vec3Data;
+  direction: Vec3Data;
+  weaponId: string;
+}
+
+/** 命中事件 */
+export interface PlayerHitMsg {
+  type: 'player.hit';
+  attackerId: string;
+  targetId: string;
+  damage: number;
+}
+
+/** 死亡事件 */
+export interface PlayerDieMsg {
+  type: 'player.die';
+  id: string;
+}
+
+/** 复活事件 */
+export interface PlayerRespawnMsg {
+  type: 'player.respawn';
+  id: string;
+  position: Vec3Data;
+}
+
+export type NetworkMessage =
+  | PlayerJoinMsg
+  | PlayerLeaveMsg
+  | PlayerStateMsg
+  | PlayerFireMsg
+  | PlayerHitMsg
+  | PlayerDieMsg
+  | PlayerRespawnMsg;

--- a/examples/br-12p/src/net/mock-network.ts
+++ b/examples/br-12p/src/net/mock-network.ts
@@ -1,0 +1,81 @@
+/**
+ * mock-network.ts — 本地 Mock 网络。
+ * 用 EventEmitter 模拟 WebSocket 广播，无需真实服务器，支持 headless 测试。
+ */
+
+import { EventEmitter } from '../../../../src/gameplay/event-emitter';
+import type { NetworkMessage, MessageType } from './message-protocol';
+
+type MockNetworkEvents = {
+  [K in MessageType]: (msg: NetworkMessage & { type: K }) => void;
+} & {
+  'connected': () => void;
+  'disconnected': () => void;
+};
+
+/** 单例 Mock 广播总线 —— 所有客户端共享此总线，模拟同一房间。 */
+let _globalBus: EventEmitter<MockNetworkEvents> | null = null;
+
+function getGlobalBus(): EventEmitter<MockNetworkEvents> {
+  if (!_globalBus) {
+    _globalBus = new EventEmitter<MockNetworkEvents>();
+  }
+  return _globalBus;
+}
+
+/** 重置全局总线（测试隔离用） */
+export function resetMockNetwork(): void {
+  _globalBus = new EventEmitter<MockNetworkEvents>();
+}
+
+/**
+ * MockNetwork — 模拟 WebSocket 连接。
+ * 连接到全局 Mock 总线，实现消息发送与接收。
+ */
+export class MockNetwork {
+  private _bus: EventEmitter<MockNetworkEvents>;
+  private _connected = false;
+
+  constructor() {
+    this._bus = getGlobalBus();
+  }
+
+  get isConnected(): boolean { return this._connected; }
+
+  connect(): void {
+    this._connected = true;
+    this._bus.emit('connected');
+  }
+
+  disconnect(): void {
+    this._connected = false;
+    this._bus.emit('disconnected');
+  }
+
+  /** 向所有客户端广播消息（包括自身，模拟服务器回显） */
+  send(msg: NetworkMessage): void {
+    if (!this._connected) return;
+    const bus = this._bus;
+    // 通过 EventEmitter emit 分发到订阅者
+    (bus as any).emit(msg.type, msg);
+  }
+
+  /** 订阅指定类型消息 */
+  on<K extends MessageType>(
+    type: K,
+    handler: (msg: NetworkMessage & { type: K }) => void,
+  ): void {
+    this._bus.on(type as any, handler as any);
+  }
+
+  /** 取消订阅 */
+  off<K extends MessageType>(
+    type: K,
+    handler: (msg: NetworkMessage & { type: K }) => void,
+  ): void {
+    this._bus.off(type as any, handler as any);
+  }
+
+  /** 获取底层总线（测试用） */
+  get bus(): EventEmitter<MockNetworkEvents> { return this._bus; }
+}

--- a/examples/br-12p/src/net/network-client.ts
+++ b/examples/br-12p/src/net/network-client.ts
@@ -1,0 +1,117 @@
+/**
+ * network-client.ts — 本地玩家网络客户端。
+ * 负责将本地玩家状态广播出去，以及处理玩家自身受到的网络命中事件。
+ */
+
+import type { MockNetwork } from './mock-network';
+import type { StateSync } from './state-sync';
+import type { PlayerHitMsg } from './message-protocol';
+
+/** 状态发送频率（Hz） */
+const STATE_SEND_HZ = 10;
+const STATE_SEND_INTERVAL = 1 / STATE_SEND_HZ;
+
+export class NetworkClient {
+  private readonly _net: MockNetwork;
+  private readonly _sync: StateSync;
+  readonly localId: string;
+  readonly localName: string;
+
+  private _sendTimer = 0;
+
+  /** 本地玩家的位置/旋转获取函数 */
+  private _getPosition?: () => { x: number; y: number; z: number };
+  private _getRotation?: () => number;
+  private _getHealth?: () => number;
+
+  /** 本地受到命中的回调（供 Game 注册） */
+  private _onLocalHit?: (attackerId: string, damage: number) => void;
+
+  constructor(net: MockNetwork, sync: StateSync, id: string, name: string) {
+    this._net = net;
+    this._sync = sync;
+    this.localId = id;
+    this.localName = name;
+
+    // 监听命中事件，过滤出针对本地玩家的
+    this._net.on('player.hit', (msg: PlayerHitMsg) => {
+      if (msg.targetId === this.localId) {
+        this._onLocalHit?.(msg.attackerId, msg.damage);
+      }
+    });
+  }
+
+  /** 绑定本地状态获取函数 */
+  bindLocalState(
+    getPosition: () => { x: number; y: number; z: number },
+    getRotation: () => number,
+    getHealth: () => number,
+  ): void {
+    this._getPosition = getPosition;
+    this._getRotation = getRotation;
+    this._getHealth = getHealth;
+  }
+
+  /** 注册本地受命中回调 */
+  onLocalHit(cb: (attackerId: string, damage: number) => void): void {
+    this._onLocalHit = cb;
+  }
+
+  /** 广播加入消息 */
+  join(): void {
+    const pos = this._getPosition?.() ?? { x: 0, y: 0, z: 0 };
+    this._net.send({
+      type: 'player.join',
+      id: this.localId,
+      name: this.localName,
+      position: pos,
+    });
+  }
+
+  /** 广播离开消息 */
+  leave(): void {
+    this._net.send({ type: 'player.leave', id: this.localId });
+  }
+
+  /** 广播射击事件 */
+  fire(origin: { x: number; y: number; z: number }, direction: { x: number; y: number; z: number }, weaponId = 'default'): void {
+    this._net.send({
+      type: 'player.fire',
+      id: this.localId,
+      origin,
+      direction,
+      weaponId,
+    });
+  }
+
+  /** 广播死亡 */
+  die(): void {
+    this._net.send({ type: 'player.die', id: this.localId });
+  }
+
+  /** 广播复活 */
+  respawn(position: { x: number; y: number; z: number }): void {
+    this._net.send({ type: 'player.respawn', id: this.localId, position });
+  }
+
+  /** 每帧调用：按频率广播本地状态 */
+  update(dt: number): void {
+    this._sendTimer += dt;
+    if (this._sendTimer >= STATE_SEND_INTERVAL) {
+      this._sendTimer -= STATE_SEND_INTERVAL;
+      this._broadcastState();
+    }
+    this._sync.update(dt);
+  }
+
+  private _broadcastState(): void {
+    if (!this._getPosition) return;
+    this._net.send({
+      type: 'player.state',
+      id: this.localId,
+      position: this._getPosition(),
+      rotation: this._getRotation?.() ?? 0,
+      health: this._getHealth?.() ?? 100,
+    });
+  }
+}

--- a/examples/br-12p/src/net/remote-player.ts
+++ b/examples/br-12p/src/net/remote-player.ts
@@ -1,0 +1,167 @@
+/**
+ * remote-player.ts — 远程玩家实例。
+ * 由网络事件驱动位置/动画，不运行本地 AI 逻辑。
+ * 使用简单线性插值平滑位置抖动。
+ */
+
+import { Node3D } from '../../../../src/core/node3d';
+import { AnimationMixer } from '../../../../src/animation/animation-mixer';
+import { AnimationClip } from '../../../../src/animation/animation-clip';
+import { Skeleton, type BoneData } from '../../../../src/animation/skeleton';
+import { Health } from '../health';
+import { MAP_SIZE } from '../map';
+
+/** 复活延迟（秒） */
+const RESPAWN_DELAY = 3.0;
+/** 位置插值速度（lerp 因子 per second） */
+const LERP_SPEED = 10.0;
+
+function createDummySkeleton(): Skeleton {
+  const bones: BoneData[] = [{ name: 'root', parentIndex: -1 }];
+  const ibm = new Float32Array(16);
+  ibm[0] = 1; ibm[5] = 1; ibm[10] = 1; ibm[15] = 1;
+  return new Skeleton(bones, ibm);
+}
+
+function createClips(): Record<string, AnimationClip> {
+  return {
+    idle:  new AnimationClip('idle',  []),
+    run:   new AnimationClip('run',   []),
+    shoot: new AnimationClip('shoot', []),
+    die:   new AnimationClip('die',   []),
+  };
+}
+
+export type RemotePlayerState = 'alive' | 'dead';
+
+export class RemotePlayer {
+  readonly id: string;
+  readonly name: string;
+  readonly node: Node3D;
+  readonly health: Health;
+  readonly mixer: AnimationMixer;
+
+  private readonly _clips: Record<string, AnimationClip>;
+
+  /** 目标位置（网络接收） */
+  private _targetX = 0;
+  private _targetZ = 0;
+
+  /** 当前渲染旋转 */
+  rotation = 0;
+
+  private _state: RemotePlayerState = 'alive';
+  private _deadTimer = 0;
+  private _currentAnim = 'idle';
+
+  /** 复活回调（由 StateSync 注册，完成复活后重置状态） */
+  onRespawnNeeded?: (id: string) => void;
+
+  constructor(id: string, name: string, position: { x: number; y: number; z: number }) {
+    this.id = id;
+    this.name = name;
+
+    this.node = new Node3D(`remote-${id}`);
+    this.node.position[0] = position.x;
+    this.node.position[1] = position.y;
+    this.node.position[2] = position.z;
+
+    this._targetX = position.x;
+    this._targetZ = position.z;
+
+    this.health = new Health(100);
+    this.health.on('health.died', () => {
+      this._state = 'dead';
+      this._deadTimer = 0;
+      this._playAnim('die');
+    });
+
+    const skeleton = createDummySkeleton();
+    this.mixer = new AnimationMixer(skeleton);
+    this._clips = createClips();
+    this._playAnim('idle');
+  }
+
+  get state(): RemotePlayerState { return this._state; }
+  get isDead(): boolean { return this._state === 'dead'; }
+
+  /** 网络快照更新：设置目标位置（插值平滑） */
+  applyState(position: { x: number; y: number; z: number }, rotation: number, health: number): void {
+    if (this._state === 'dead') return;
+    this._targetX = position.x;
+    this._targetZ = position.z;
+    this.rotation = rotation;
+
+    // 直接更新血量（服务器权威）
+    const delta = health - this.health.current;
+    if (delta < 0) {
+      this.health.takeDamage(-delta);
+    }
+
+    // 有移动则播 run 动画
+    const dx = this._targetX - this.node.position[0];
+    const dz = this._targetZ - this.node.position[2];
+    const moving = Math.sqrt(dx * dx + dz * dz) > 0.05;
+    if (moving && this._currentAnim !== 'run') {
+      this._playAnim('run');
+    } else if (!moving && this._currentAnim === 'run') {
+      this._playAnim('idle');
+    }
+  }
+
+  /** 施加伤害（命中事件触发） */
+  applyDamage(amount: number): void {
+    if (this._state === 'dead') return;
+    this.health.takeDamage(amount);
+  }
+
+  /** 复活到指定位置 */
+  respawn(position: { x: number; y: number; z: number }): void {
+    this._state = 'alive';
+    this._deadTimer = 0;
+    this.node.position[0] = position.x;
+    this.node.position[1] = position.y;
+    this.node.position[2] = position.z;
+    this._targetX = position.x;
+    this._targetZ = position.z;
+    // 重置血量：通过创建新 Health 对象代替（Health 无 reset API）
+    // 这里通过多次 takeDamage 反向模式：直接更新内部 _current
+    // 由于 Health 无 reset，我们需要记录一个复活标志并忽略血量
+    (this.health as any)._current = 100;
+    this._playAnim('idle');
+  }
+
+  /** 每帧更新：位置插值 + 死亡计时 + 动画 */
+  update(dt: number): void {
+    if (this._state === 'dead') {
+      this._deadTimer += dt;
+      if (this._deadTimer >= RESPAWN_DELAY) {
+        this.onRespawnNeeded?.(this.id);
+      }
+    } else {
+      // 插值平滑
+      const alpha = Math.min(1, LERP_SPEED * dt);
+      this.node.position[0] += (this._targetX - this.node.position[0]) * alpha;
+      this.node.position[2] += (this._targetZ - this.node.position[2]) * alpha;
+    }
+    this.mixer.update(dt);
+  }
+
+  private _playAnim(name: string): void {
+    this._currentAnim = name;
+    const clip = this._clips[name];
+    if (clip) {
+      this.mixer.play(clip, { loop: name !== 'die' });
+    }
+  }
+
+  /** 生成随机复活位置 */
+  static randomSpawnPosition(): { x: number; y: number; z: number } {
+    const half = MAP_SIZE / 2 - 5;
+    return {
+      x: (Math.random() * 2 - 1) * half,
+      y: 0,
+      z: (Math.random() * 2 - 1) * half,
+    };
+  }
+}

--- a/examples/br-12p/src/net/state-sync.ts
+++ b/examples/br-12p/src/net/state-sync.ts
@@ -1,0 +1,122 @@
+/**
+ * state-sync.ts — 多人状态同步层。
+ * 接收网络消息 → 管理远程玩家实例 → 应用状态快照。
+ */
+
+import { RemotePlayer } from './remote-player';
+import type { MockNetwork } from './mock-network';
+import type {
+  PlayerJoinMsg,
+  PlayerLeaveMsg,
+  PlayerStateMsg,
+  PlayerFireMsg,
+  PlayerHitMsg,
+  PlayerDieMsg,
+  PlayerRespawnMsg,
+} from './message-protocol';
+
+export type StateSyncEvents = {
+  'player.joined': (player: RemotePlayer) => void;
+  'player.left': (id: string) => void;
+  'player.fired': (id: string, origin: { x: number; y: number; z: number }, direction: { x: number; y: number; z: number }, weaponId: string) => void;
+};
+
+/**
+ * StateSync — 管理 11 个远程玩家的生命周期和状态同步。
+ */
+export class StateSync {
+  private readonly _players = new Map<string, RemotePlayer>();
+  private readonly _net: MockNetwork;
+  /** 本地玩家 ID，收到自己的消息时忽略 */
+  private readonly _localId: string;
+
+  private _onJoined?: (player: RemotePlayer) => void;
+  private _onLeft?: (id: string) => void;
+  private _onFired?: (id: string, origin: { x: number; y: number; z: number }, direction: { x: number; y: number; z: number }, weaponId: string) => void;
+
+  constructor(net: MockNetwork, localId = '') {
+    this._net = net;
+    this._localId = localId;
+    this._registerHandlers();
+  }
+
+  get players(): ReadonlyMap<string, RemotePlayer> { return this._players; }
+
+  get playerCount(): number { return this._players.size; }
+
+  onPlayerJoined(cb: (player: RemotePlayer) => void): void {
+    this._onJoined = cb;
+  }
+
+  onPlayerLeft(cb: (id: string) => void): void {
+    this._onLeft = cb;
+  }
+
+  onPlayerFired(cb: (id: string, origin: { x: number; y: number; z: number }, direction: { x: number; y: number; z: number }, weaponId: string) => void): void {
+    this._onFired = cb;
+  }
+
+  /** 每帧更新所有远程玩家 */
+  update(dt: number): void {
+    for (const player of this._players.values()) {
+      player.update(dt);
+    }
+  }
+
+  private _registerHandlers(): void {
+    this._net.on('player.join', (msg: PlayerJoinMsg) => {
+      if (msg.id === this._localId || this._players.has(msg.id)) return;
+      const player = new RemotePlayer(msg.id, msg.name, msg.position);
+      player.onRespawnNeeded = (id) => this._handleRespawnNeeded(id);
+      this._players.set(msg.id, player);
+      this._onJoined?.(player);
+    });
+
+    this._net.on('player.leave', (msg: PlayerLeaveMsg) => {
+      if (this._players.delete(msg.id)) {
+        this._onLeft?.(msg.id);
+      }
+    });
+
+    this._net.on('player.state', (msg: PlayerStateMsg) => {
+      const player = this._players.get(msg.id);
+      if (!player) return;
+      player.applyState(msg.position, msg.rotation, msg.health);
+    });
+
+    this._net.on('player.fire', (msg: PlayerFireMsg) => {
+      this._onFired?.(msg.id, msg.origin, msg.direction, msg.weaponId);
+    });
+
+    this._net.on('player.hit', (msg: PlayerHitMsg) => {
+      const target = this._players.get(msg.targetId);
+      if (target) {
+        target.applyDamage(msg.damage);
+      }
+    });
+
+    this._net.on('player.die', (msg: PlayerDieMsg) => {
+      const player = this._players.get(msg.id);
+      if (player && !player.isDead) {
+        player.applyDamage(player.health.current);
+      }
+    });
+
+    this._net.on('player.respawn', (msg: PlayerRespawnMsg) => {
+      const player = this._players.get(msg.id);
+      if (player) {
+        player.respawn(msg.position);
+      }
+    });
+  }
+
+  private _handleRespawnNeeded(id: string): void {
+    const pos = RemotePlayer.randomSpawnPosition();
+    // 广播复活消息（通知所有客户端）
+    this._net.send({
+      type: 'player.respawn',
+      id,
+      position: pos,
+    });
+  }
+}

--- a/examples/br-12p/test/integration/network.test.ts
+++ b/examples/br-12p/test/integration/network.test.ts
@@ -1,0 +1,439 @@
+/**
+ * network.test.ts — BR-12P M4.4 多人网络同步集成测试。
+ * 使用 Mock 网络，无需真实 WebSocket 服务器，headless 可运行。
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Game } from '../../src/game';
+import { MockNetwork, resetMockNetwork } from '../../src/net/mock-network';
+import { StateSync } from '../../src/net/state-sync';
+import { NetworkClient } from '../../src/net/network-client';
+import { RemotePlayer } from '../../src/net/remote-player';
+
+// ── 测试辅助 ──────────────────────────────────────────────────────────
+
+/** 创建一个标准 12 人场景（1 本地 + 11 远程） */
+function createNetworkScene() {
+  resetMockNetwork();
+
+  const game = new Game({ headless: true });
+  const net = new MockNetwork();
+  net.connect();
+
+  const sync = new StateSync(net, 'local-0');
+  const client = new NetworkClient(net, sync, 'local-0', '本地玩家');
+
+  client.bindLocalState(
+    () => {
+      const p = game.player.position;
+      return { x: p[0], y: p[1], z: p[2] };
+    },
+    () => game.fpsCamera.yaw,
+    () => 100,
+  );
+
+  return { game, net, sync, client };
+}
+
+/** 模拟 N 个远程玩家加入 */
+function joinRemotePlayers(net: MockNetwork, count: number): string[] {
+  const ids: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const id = `remote-${i}`;
+    ids.push(id);
+    net.send({
+      type: 'player.join',
+      id,
+      name: `玩家${i}`,
+      position: { x: i * 3, y: 0, z: i * 3 },
+    });
+  }
+  return ids;
+}
+
+// ── 1. 初始化 + PlayerJoin ─────────────────────────────────────────────
+
+describe('M4.4 网络同步 — 玩家加入', () => {
+  beforeEach(() => { resetMockNetwork(); });
+
+  it('Game headless 模式可正常创建', () => {
+    const game = new Game({ headless: true });
+    expect(game).toBeDefined();
+  });
+
+  it('MockNetwork connect() 标记为已连接', () => {
+    const net = new MockNetwork();
+    net.connect();
+    expect(net.isConnected).toBe(true);
+  });
+
+  it('11 个远程玩家 PlayerJoin 后 StateSync 存有 11 个玩家', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 11);
+    expect(sync.playerCount).toBe(11);
+  });
+
+  it('PlayerJoin 触发 onPlayerJoined 回调', () => {
+    const { net, sync } = createNetworkScene();
+    const joined: string[] = [];
+    sync.onPlayerJoined((p) => joined.push(p.id));
+    joinRemotePlayers(net, 3);
+    expect(joined).toHaveLength(3);
+    expect(joined).toContain('remote-0');
+  });
+
+  it('远程玩家实例化后位置与 Join 消息一致', () => {
+    const { net, sync } = createNetworkScene();
+    net.send({
+      type: 'player.join',
+      id: 'p1',
+      name: '测试',
+      position: { x: 5, y: 0, z: 10 },
+    });
+    const player = sync.players.get('p1');
+    expect(player).toBeInstanceOf(RemotePlayer);
+    expect(player!.node.position[0]).toBeCloseTo(5, 3);
+    expect(player!.node.position[2]).toBeCloseTo(10, 3);
+  });
+
+  it('快进 1s 后 11 个远程玩家都已实例化', () => {
+    const { game, net, sync, client } = createNetworkScene();
+    joinRemotePlayers(net, 11);
+    // 模拟 1 秒（60 帧）
+    for (let i = 0; i < 60; i++) {
+      game.update(1 / 60);
+      client.update(1 / 60);
+    }
+    expect(sync.playerCount).toBe(11);
+    for (const player of sync.players.values()) {
+      expect(player).toBeInstanceOf(RemotePlayer);
+    }
+  });
+});
+
+// ── 2. PlayerLeave ──────────────────────────────────────────────────────
+
+describe('M4.4 网络同步 — 玩家离开', () => {
+  beforeEach(() => { resetMockNetwork(); });
+
+  it('PlayerLeave 后玩家从 sync 中移除', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 3);
+    expect(sync.playerCount).toBe(3);
+
+    net.send({ type: 'player.leave', id: 'remote-0' });
+    expect(sync.playerCount).toBe(2);
+    expect(sync.players.has('remote-0')).toBe(false);
+  });
+
+  it('PlayerLeave 触发 onPlayerLeft 回调', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 2);
+    const left: string[] = [];
+    sync.onPlayerLeft((id) => left.push(id));
+
+    net.send({ type: 'player.leave', id: 'remote-1' });
+    expect(left).toContain('remote-1');
+  });
+});
+
+// ── 3. 本地玩家状态广播 ──────────────────────────────────────────────────
+
+describe('M4.4 网络同步 — 本地状态广播', () => {
+  beforeEach(() => { resetMockNetwork(); });
+
+  it('client.update 超过 0.1s 后广播 PlayerState 消息', () => {
+    const { net, client } = createNetworkScene();
+    const received: string[] = [];
+    net.on('player.state', (msg) => received.push(msg.id));
+
+    // 0.1s = STATE_SEND_INTERVAL
+    client.update(0.11);
+    expect(received).toContain('local-0');
+  });
+
+  it('本地射击广播 PlayerFire 消息', () => {
+    const { net, client } = createNetworkScene();
+    const fired: string[] = [];
+    net.on('player.fire', (msg) => fired.push(msg.id));
+
+    client.fire({ x: 0, y: 1, z: 0 }, { x: 0, y: 0, z: -1 }, 'ak47');
+    expect(fired).toContain('local-0');
+  });
+
+  it('PlayerFire 消息包含正确的 origin 和 direction', () => {
+    const { net, client } = createNetworkScene();
+    let capturedOrigin: any = null;
+    let capturedDir: any = null;
+    net.on('player.fire', (msg) => {
+      capturedOrigin = msg.origin;
+      capturedDir = msg.direction;
+    });
+
+    client.fire({ x: 1, y: 2, z: 3 }, { x: 0, y: 0, z: -1 });
+    expect(capturedOrigin).toEqual({ x: 1, y: 2, z: 3 });
+    expect(capturedDir).toEqual({ x: 0, y: 0, z: -1 });
+  });
+});
+
+// ── 4. 远程玩家位置同步 ──────────────────────────────────────────────────
+
+describe('M4.4 网络同步 — 远程位置同步', () => {
+  beforeEach(() => { resetMockNetwork(); });
+
+  it('接收 PlayerState 后远程玩家目标位置更新', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 1);
+
+    net.send({
+      type: 'player.state',
+      id: 'remote-0',
+      position: { x: 15, y: 0, z: 20 },
+      rotation: 0.5,
+      health: 100,
+    });
+
+    // 推进一帧让插值生效
+    sync.update(0.1);
+
+    const player = sync.players.get('remote-0')!;
+    // 插值后接近目标（不一定完全到达）
+    expect(player.node.position[0]).toBeGreaterThan(0);
+  });
+
+  it('11 个远程玩家同时接收 PlayerState 后各自位置更新', () => {
+    const { net, sync } = createNetworkScene();
+    const ids = joinRemotePlayers(net, 11);
+
+    for (let i = 0; i < 11; i++) {
+      net.send({
+        type: 'player.state',
+        id: ids[i],
+        position: { x: (i + 1) * 5, y: 0, z: 0 },
+        rotation: 0,
+        health: 100,
+      });
+    }
+    sync.update(0.5);
+
+    // 每个玩家位置都应该有所移动（不完全在原位）
+    let movedCount = 0;
+    for (let i = 0; i < 11; i++) {
+      const p = sync.players.get(ids[i])!;
+      if (p.node.position[0] > 0.1) movedCount++;
+    }
+    expect(movedCount).toBeGreaterThanOrEqual(10);
+  });
+});
+
+// ── 5. 射击/命中/死亡 ──────────────────────────────────────────────────
+
+describe('M4.4 网络同步 — 战斗循环', () => {
+  beforeEach(() => { resetMockNetwork(); });
+
+  it('PlayerFire 事件被 onPlayerFired 回调捕获', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 1);
+
+    let capturedId = '';
+    sync.onPlayerFired((id) => { capturedId = id; });
+
+    net.send({
+      type: 'player.fire',
+      id: 'remote-0',
+      origin: { x: 0, y: 1, z: 0 },
+      direction: { x: 0, y: 0, z: -1 },
+      weaponId: 'rifle',
+    });
+
+    expect(capturedId).toBe('remote-0');
+  });
+
+  it('PlayerHit 使目标玩家血量减少', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 2);
+
+    const before = sync.players.get('remote-1')!.health.current;
+    net.send({
+      type: 'player.hit',
+      attackerId: 'remote-0',
+      targetId: 'remote-1',
+      damage: 30,
+    });
+
+    expect(sync.players.get('remote-1')!.health.current).toBe(before - 30);
+  });
+
+  it('本地玩家被 PlayerHit 后触发 onLocalHit 回调', () => {
+    const { net, client } = createNetworkScene();
+    let hitDamage = 0;
+    let hitAttacker = '';
+    client.onLocalHit((attId, dmg) => {
+      hitAttacker = attId;
+      hitDamage = dmg;
+    });
+
+    net.send({
+      type: 'player.hit',
+      attackerId: 'remote-0',
+      targetId: 'local-0',
+      damage: 25,
+    });
+
+    expect(hitDamage).toBe(25);
+    expect(hitAttacker).toBe('remote-0');
+  });
+
+  it('PlayerDie 消息使远程玩家进入 dead 状态', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 1);
+
+    net.send({ type: 'player.die', id: 'remote-0' });
+    expect(sync.players.get('remote-0')!.isDead).toBe(true);
+  });
+
+  it('血量降为 0 时玩家进入 dead 状态', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 1);
+
+    net.send({
+      type: 'player.hit',
+      attackerId: 'local-0',
+      targetId: 'remote-0',
+      damage: 200,
+    });
+
+    expect(sync.players.get('remote-0')!.isDead).toBe(true);
+  });
+});
+
+// ── 6. 死亡/复活循环 ──────────────────────────────────────────────────
+
+describe('M4.4 网络同步 — 死亡与复活', () => {
+  beforeEach(() => { resetMockNetwork(); });
+
+  it('PlayerRespawn 消息使已死亡玩家恢复 alive 状态', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 1);
+
+    net.send({ type: 'player.die', id: 'remote-0' });
+    expect(sync.players.get('remote-0')!.isDead).toBe(true);
+
+    net.send({
+      type: 'player.respawn',
+      id: 'remote-0',
+      position: { x: 10, y: 0, z: 10 },
+    });
+
+    expect(sync.players.get('remote-0')!.isDead).toBe(false);
+  });
+
+  it('PlayerRespawn 后玩家位置更新到复活坐标', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 1);
+
+    net.send({ type: 'player.die', id: 'remote-0' });
+    net.send({
+      type: 'player.respawn',
+      id: 'remote-0',
+      position: { x: 7, y: 0, z: 13 },
+    });
+
+    const p = sync.players.get('remote-0')!;
+    expect(p.node.position[0]).toBeCloseTo(7, 3);
+    expect(p.node.position[2]).toBeCloseTo(13, 3);
+  });
+
+  it('死亡后 3s 自动触发复活消息', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 1);
+
+    net.send({ type: 'player.die', id: 'remote-0' });
+    expect(sync.players.get('remote-0')!.isDead).toBe(true);
+
+    // 推进超过 3s
+    sync.update(3.5);
+    // 复活后应不再是 dead 状态
+    expect(sync.players.get('remote-0')!.isDead).toBe(false);
+  });
+
+  it('完整生命周期：join → 同步 → 射击 → 命中 → 死亡 → 复活', () => {
+    const { net, sync, client } = createNetworkScene();
+    const ids = joinRemotePlayers(net, 11);
+
+    // 同步位置
+    for (const id of ids) {
+      net.send({
+        type: 'player.state',
+        id,
+        position: { x: Math.random() * 20, y: 0, z: Math.random() * 20 },
+        rotation: 0,
+        health: 100,
+      });
+    }
+    sync.update(0.1);
+
+    // 本地玩家开枪
+    let fireCaptured = false;
+    sync.onPlayerFired(() => { fireCaptured = true; });
+    client.fire({ x: 0, y: 1, z: 0 }, { x: 0, y: 0, z: -1 });
+
+    // 命中远程玩家
+    net.send({
+      type: 'player.hit',
+      attackerId: 'local-0',
+      targetId: ids[0],
+      damage: 200,
+    });
+    expect(sync.players.get(ids[0])!.isDead).toBe(true);
+
+    // 3s 后复活
+    sync.update(3.5);
+    expect(sync.players.get(ids[0])!.isDead).toBe(false);
+
+    // 验证所有 11 个玩家仍在
+    expect(sync.playerCount).toBe(11);
+  });
+});
+
+// ── 7. 12 人场景完整性 ──────────────────────────────────────────────────
+
+describe('M4.4 网络同步 — 12 人场景', () => {
+  beforeEach(() => { resetMockNetwork(); });
+
+  it('1 本地 + 11 远程 = 12 人游戏', () => {
+    const { net, sync, client } = createNetworkScene();
+    client.join();
+    joinRemotePlayers(net, 11);
+
+    // 本地玩家不计入 sync（sync 只管远程）
+    // 远程玩家 11 个
+    expect(sync.playerCount).toBe(11);
+  });
+
+  it('所有 11 个远程玩家都有独立 Node3D + AnimationMixer', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 11);
+
+    for (const player of sync.players.values()) {
+      expect(player.node).toBeDefined();
+      expect(player.mixer).toBeDefined();
+    }
+  });
+
+  it('11 个远程玩家各自 id 唯一', () => {
+    const { net, sync } = createNetworkScene();
+    joinRemotePlayers(net, 11);
+
+    const ids = Array.from(sync.players.keys());
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(11);
+  });
+
+  it('重复 PlayerJoin 同一 id 不重复创建', () => {
+    const { net, sync } = createNetworkScene();
+    net.send({ type: 'player.join', id: 'dup', name: '重复', position: { x: 0, y: 0, z: 0 } });
+    net.send({ type: 'player.join', id: 'dup', name: '重复2', position: { x: 1, y: 0, z: 1 } });
+    expect(sync.playerCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- 实现 `examples/br-12p/src/net/` 多人网络同步模块（Mock 路径）
- `message-protocol.ts`：定义 7 种消息类型（join/leave/state/fire/hit/die/respawn）
- `mock-network.ts`：本地 EventEmitter 广播总线，模拟 WebSocket，支持 headless 测试
- `remote-player.ts`：远程玩家实例，Lerp 位置插值平滑 + AnimationMixer 状态驱动
- `state-sync.ts`：管理 11 个远程玩家生命周期，3s 后自动复活
- `network-client.ts`：本地客户端，10Hz 状态广播 + 战斗事件发送

## 测试

集成测试 `test/integration/network.test.ts`（26 项全通过）：
- ✅ PlayerJoin/Leave 生命周期
- ✅ 本地状态广播（10Hz）
- ✅ 远程位置同步（Lerp 插值）
- ✅ 战斗循环（Fire/Hit/Die）
- ✅ 死亡后 3s 自动复活
- ✅ 完整 12 人游戏循环

## 反向驱动 Issues（预期产出）

- #264 `api-friction`: Health 缺少 `reset()` 方法
- #265 `api-friction`: `src/net/` 应提升为引擎零件（NetworkClient/StateSync/Interpolator）

## Test plan

- [x] `npx vitest run test/integration/network.test.ts` — 26/26 通过
- [x] `pnpm -w run test` — 1535/1535 单元测试通过，0 失败

close #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)