### PR TITLE
feat: Health 提升到 src/gameplay/ + heal()/reset() (#268)

### DIFF
--- a/examples/br-12p/src/enemy.ts
+++ b/examples/br-12p/src/enemy.ts
@@ -11,7 +11,7 @@ import { Skeleton, type BoneData } from '../../../src/animation/skeleton';
 import { StateMachine } from '../../../src/gameplay/state-machine';
 import { CollisionWorld } from '../../../src/physics/collision';
 import { type Vec3, vec3, sub, length } from '../../../src/math/vec3';
-import { Health } from './health';
+import { Health } from '../../../src/gameplay/health';
 import { type AIState } from './enemy-ai';
 import { MAP_SIZE } from './map';
 

--- a/examples/br-12p/src/net/remote-player.ts
+++ b/examples/br-12p/src/net/remote-player.ts
@@ -8,7 +8,7 @@ import { Node3D } from '../../../../src/core/node3d';
 import { AnimationMixer } from '../../../../src/animation/animation-mixer';
 import { AnimationClip } from '../../../../src/animation/animation-clip';
 import { Skeleton, type BoneData } from '../../../../src/animation/skeleton';
-import { Health } from '../health';
+import { Health } from '../../../../src/gameplay/health';
 import { MAP_SIZE } from '../map';
 
 /** 复活延迟（秒） */

--- a/src/gameplay/health.ts
+++ b/src/gameplay/health.ts
@@ -1,5 +1,3 @@
-export const __STUB__ = true;
-
 import { EventEmitter } from './event-emitter';
 
 export type HealthEvents = {
@@ -8,14 +6,38 @@ export type HealthEvents = {
 };
 
 export class Health extends EventEmitter<HealthEvents> {
-  constructor(_max?: number) {
+  private _current: number;
+  private _max: number;
+
+  constructor(max = 100) {
     super();
-    throw new Error('Not implemented');
+    this._max = max;
+    this._current = max;
   }
-  takeDamage(_amount: number): void { throw new Error('Not implemented'); }
-  heal(_amount: number): void { throw new Error('Not implemented'); }
-  reset(_newMax?: number): void { throw new Error('Not implemented'); }
-  get current(): number { throw new Error('Not implemented'); }
-  get max(): number { throw new Error('Not implemented'); }
-  get isDead(): boolean { throw new Error('Not implemented'); }
+
+  takeDamage(amount: number): void {
+    if (this._current <= 0) return;
+    this._current = Math.max(0, this._current - amount);
+    this.emit('health.changed', this._current, this._max);
+    if (this._current <= 0) {
+      this.emit('health.died');
+    }
+  }
+
+  heal(amount: number): void {
+    this._current = Math.min(this._max, this._current + amount);
+    this.emit('health.changed', this._current, this._max);
+  }
+
+  reset(newMax?: number): void {
+    if (newMax !== undefined) {
+      this._max = newMax;
+    }
+    this._current = this._max;
+    this.emit('health.changed', this._current, this._max);
+  }
+
+  get current(): number { return this._current; }
+  get max(): number { return this._max; }
+  get isDead(): boolean { return this._current <= 0; }
 }


### PR DESCRIPTION
## Summary

- 将 `Health` 从 `examples/br-12p/src/health.ts` 提升为引擎零件 `src/gameplay/health.ts`
- 新增 `heal(amount)` 方法：恢复血量不超过 max，触发 `health.changed`
- 新增 `reset(newMax?)` 方法：重置到满值（可选新 max），触发 `health.changed`，支持复活 isDead 实体
- 更新 `examples/br-12p/src/enemy.ts` 和 `net/remote-player.ts` 导入路径指向引擎模块

## Test plan

- [x] `pnpm run test -- test/unit/gameplay/health.test.ts` — 14/14 通过
- [x] `pnpm run test` — 全量单元测试 1549 通过，无回归
- [x] `examples/br-12p/` 导入路径已更新

close #268
Ref: #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)