### PR TITLE
fix: br-12p MockNetwork 自回环修复网络同步 23 个测试失败

### DIFF
--- a/examples/br-12p/src/net/mock-network.ts
+++ b/examples/br-12p/src/net/mock-network.ts
@@ -44,6 +44,9 @@ export class MockNetwork {
   send(msg: NetworkMessage): void {
     if (!this._connected) return;
     this._net.send(msg.type, msg);
+    // 自回环：模拟服务器将消息广播回发送方（真实网络语义）
+    // br-12p 用单实例身兼发送端+接收端，引擎层 send() 不回环自身，需在此补回
+    (this._net as any)._deliver(msg.type, msg);
   }
 
   on<K extends MessageType>(


### PR DESCRIPTION
## 问题

`examples/br-12p/test/integration/network.test.ts` 中 23/26 个测试失败，浏览器 WASD/射击无响应，11 个 NPC 不出现。

## 根因

`src/net/mock-network.ts` 的 `send()` 遵循真实网络语义——不给自己投递消息。但 br-12p 测试和浏览器 demo 用同一个 `MockNetwork` 实例同时充当发送端和接收端（`net.send()` 发消息，`StateSync.on()` 订阅同一实例），导致订阅者始终收不到任何消息。

## 修复

在 `examples/br-12p/src/net/mock-network.ts` 的 wrapper `send()` 中，底层 send 后追加一次 `_deliver` 自回环，模拟"服务器将消息广播回发送方"的语义：

```typescript
send(msg: NetworkMessage): void {
  if (!this._connected) return;
  this._net.send(msg.type, msg);
  // 自回环：模拟服务器将消息广播回发送方（真实网络语义）
  (this._net as any)._deliver(msg.type, msg);
}
```

引擎 `src/net/` 代码**零改动**，不影响其他 demo。

## 验收

- [x] `examples/br-12p` — `pnpm test` 141/141 全绿（原 23 失败）
- [x] 根目录 `pnpm test` — 1565 passed，0 失败，无回归
- [x] 引擎 `src/net/` 真实网络语义保持不变

close #273