### PR TITLE
feat: ShaderMaterial — 自定义着色器材质 + 声明式 uniform 绑定

### DIFF
--- a/src/renderer/shader-material.ts
+++ b/src/renderer/shader-material.ts
@@ -15,8 +15,6 @@
  * @module renderer/shader-material
  */
 
-export const __STUB__ = true;
-
 import { Material } from './material';
 import type { Texture } from './texture';
 
@@ -38,19 +36,39 @@ export interface ShaderMaterialOptions {
 export class ShaderMaterial extends Material {
   uniforms: Record<string, UniformDef>;
 
-  constructor(_opts: ShaderMaterialOptions) {
-    super({ vertexShader: '', fragmentShader: '' });
+  constructor(opts: ShaderMaterialOptions) {
+    super({ vertexShader: opts.vertexShader, fragmentShader: opts.fragmentShader });
     this.uniforms = {};
-    throw new Error('Not implemented — stub');
+    if (opts.uniforms) {
+      for (const [name, def] of Object.entries(opts.uniforms)) {
+        this.uniforms[name] = { type: def.type, value: def.value };
+      }
+    }
   }
 
   /** Update value of an existing uniform. Throws if name not declared. */
-  setUniform(_name: string, _value: UniformDef['value']): void {
-    throw new Error('Not implemented — stub');
+  setUniform(name: string, value: UniformDef['value']): void {
+    if (!(name in this.uniforms)) {
+      throw new Error(`Uniform "${name}" is not declared in this ShaderMaterial`);
+    }
+    this.uniforms[name].value = value;
   }
 
   /** Deep clone including uniforms map. */
   clone(): ShaderMaterial {
-    throw new Error('Not implemented — stub');
+    const cloned = new ShaderMaterial({
+      vertexShader: this.vertexShader,
+      fragmentShader: this.fragmentShader,
+    });
+    for (const [name, def] of Object.entries(this.uniforms)) {
+      cloned.uniforms[name] = { type: def.type, value: copyValue(def.value) };
+    }
+    return cloned;
   }
+}
+
+function copyValue(value: UniformDef['value']): UniformDef['value'] {
+  if (value instanceof Float32Array) return new Float32Array(value);
+  if (Array.isArray(value)) return [...value];
+  return value;
 }

--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -17,6 +17,7 @@ import { Mesh } from './mesh';
 import { SkinnedMesh } from './skinned-mesh';
 import { Geometry } from './geometry';
 import { Material, Side, BlendMode } from './material';
+import { ShaderMaterial } from './shader-material';
 import { TextureMaterial } from './texture-material';
 import { Texture, TextureWrap, TextureFilter } from './texture';
 import { PhongMaterial } from './phong-material';
@@ -882,8 +883,8 @@ export class WebGLRenderer {
         break;
     }
 
-    // BitmapTextMaterial 不应用雾效
-    const applyFog = fog !== null && !(mesh.material instanceof BitmapTextMaterial);
+    // BitmapTextMaterial 和 ShaderMaterial 不注入雾效（ShaderMaterial 自行处理）
+    const applyFog = fog !== null && !(mesh.material instanceof BitmapTextMaterial) && !(mesh.material instanceof ShaderMaterial);
     const compiled  = this._getProgram(mesh.material, applyFog);
     const uploaded  = this._getGeometry(mesh.geometry);
 
@@ -1065,6 +1066,56 @@ export class WebGLRenderer {
         }
       } else {
         if (phong.uHasSpecularMap) gl.uniform1f(phong.uHasSpecularMap, 0.0);
+      }
+    }
+
+    // ShaderMaterial: 绑定 UV 属性 + 自定义 uniforms + 内置 uniforms
+    if (mesh.material instanceof ShaderMaterial) {
+      if (compiled.aUv >= 0 && uploaded.uvBuffer !== null) {
+        gl.bindBuffer(gl.ARRAY_BUFFER, uploaded.uvBuffer);
+        gl.enableVertexAttribArray(compiled.aUv);
+        gl.vertexAttribPointer(compiled.aUv, 2, gl.FLOAT, false, 0, 0);
+      }
+
+      // 内置 uniforms（可选 — shader 声明了才绑定）
+      const uModelMatrix = gl.getUniformLocation(compiled.program, 'u_modelMatrix');
+      gl.uniformMatrix4fv(uModelMatrix, false, mesh.worldMatrix);
+
+      // 自定义 uniforms
+      let textureUnit = 0;
+      for (const [name, def] of Object.entries(mesh.material.uniforms)) {
+        const loc = gl.getUniformLocation(compiled.program, name);
+        switch (def.type) {
+          case 'float':
+            gl.uniform1f(loc, def.value as number);
+            break;
+          case 'int':
+            gl.uniform1i(loc, def.value as number);
+            break;
+          case 'vec2':
+            gl.uniform2fv(loc, def.value as number[]);
+            break;
+          case 'vec3':
+            gl.uniform3fv(loc, def.value as number[]);
+            break;
+          case 'vec4':
+            gl.uniform4fv(loc, def.value as number[]);
+            break;
+          case 'mat3':
+            gl.uniformMatrix3fv(loc, false, def.value as Float32Array);
+            break;
+          case 'mat4':
+            gl.uniformMatrix4fv(loc, false, def.value as Float32Array);
+            break;
+          case 'sampler2D': {
+            const webglTex = this._getWebGLTexture(def.value as Texture);
+            gl.activeTexture(gl.TEXTURE0 + textureUnit);
+            gl.bindTexture(gl.TEXTURE_2D, webglTex);
+            gl.uniform1i(loc, textureUnit);
+            textureUnit++;
+            break;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## 概述

实现 `ShaderMaterial`，让 AI Agent 能编写任意 GLSL vertex/fragment shader 并通过声明式 `uniforms` map 绑定自定义变量。

closes #205

## 实现内容

### `src/renderer/shader-material.ts`
- 移除 `__STUB__` 标记，完整实现类
- `constructor`：存储 vertexShader/fragmentShader 到 base `Material`，浅拷贝 uniforms（保持 Float32Array 原始引用）
- `setUniform()`：验证 uniform 已声明，否则抛 `Error`
- `clone()`：深拷贝 uniforms（Float32Array/Array 新建副本，Texture/number 保持引用）

### `src/renderer/webgl-renderer.ts`
- 导入 `ShaderMaterial`
- `ShaderMaterial` 不注入雾效 GLSL（由 shader 作者自行处理）
- `_drawMesh()` 中检测 `material instanceof ShaderMaterial`，绑定：
  - `a_uv` 属性（如几何体有 UV）
  - 内置 `u_modelMatrix`
  - 所有声明的自定义 uniforms，按类型调用对应 GL 函数

## 测试

全量单元测试：108 文件 / 1580 断言全部通过