### PR TITLE
feat: 实现 Terrain heightmap 地形渲染 (#278)

### DIFF
--- a/src/terrain/terrain.ts
+++ b/src/terrain/terrain.ts
@@ -1,18 +1,3 @@
-/**
- * Terrain — Heightmap 驱动的地形 Mesh
- *
- * 用途：从 Float32Array/Uint8Array 高度图数据生成三角化地形网格。
- * 支持自定义分辨率、世界尺寸、垂直缩放。
- *
- * API 设计（Forge 实现时参考）：
- * - new Terrain({ heightmap, widthSegments, depthSegments, width, depth, heightScale })
- * - heightmap: Float32Array 长度必须等于 (widthSegments+1) * (depthSegments+1)
- * - 自动生成 position / uv / normal attributes
- * - getHeightAt(x, z): 双线性插值采样，用于角色贴地 / 碰撞查询
- */
-
-export const __STUB__ = true;
-
 export interface TerrainOptions {
   heightmap: Float32Array;
   widthSegments: number;
@@ -23,11 +8,117 @@ export interface TerrainOptions {
 }
 
 export class Terrain {
-  constructor(_opts: TerrainOptions) {
-    throw new Error('Not implemented');
+  geometry: {
+    positions: Float32Array;
+    uvs: Float32Array;
+    normals: Float32Array;
+  };
+
+  private _heightmap: Float32Array;
+  private _widthSegments: number;
+  private _depthSegments: number;
+  private _width: number;
+  private _depth: number;
+  private _heightScale: number;
+
+  constructor(opts: TerrainOptions) {
+    const {
+      heightmap,
+      widthSegments,
+      depthSegments,
+      width = widthSegments,
+      depth = depthSegments,
+      heightScale = 1,
+    } = opts;
+
+    const expectedLength = (widthSegments + 1) * (depthSegments + 1);
+    if (heightmap.length !== expectedLength) {
+      throw new Error(
+        `heightmap 长度 ${heightmap.length} 与期望 ${expectedLength} 不匹配`,
+      );
+    }
+
+    this._heightmap = heightmap;
+    this._widthSegments = widthSegments;
+    this._depthSegments = depthSegments;
+    this._width = width;
+    this._depth = depth;
+    this._heightScale = heightScale;
+
+    const vertexCount = (widthSegments + 1) * (depthSegments + 1);
+    const positions = new Float32Array(vertexCount * 3);
+    const uvs = new Float32Array(vertexCount * 2);
+    const normals = new Float32Array(vertexCount * 3);
+
+    // 行主序：行 i → x 方向，列 j → z 方向
+    for (let i = 0; i <= widthSegments; i++) {
+      for (let j = 0; j <= depthSegments; j++) {
+        const idx = i * (depthSegments + 1) + j;
+        const x = (i / widthSegments) * width;
+        const z = (j / depthSegments) * depth;
+        const y = heightmap[idx] * heightScale;
+
+        positions[idx * 3 + 0] = x;
+        positions[idx * 3 + 1] = y;
+        positions[idx * 3 + 2] = z;
+
+        uvs[idx * 2 + 0] = i / widthSegments;
+        uvs[idx * 2 + 1] = j / depthSegments;
+      }
+    }
+
+    // 有限差分法推导法线（斜率 → 切线叉积）
+    const dx = width / widthSegments;
+    const dz = depth / depthSegments;
+
+    const getH = (i: number, j: number): number => {
+      const ci = Math.max(0, Math.min(widthSegments, i));
+      const cj = Math.max(0, Math.min(depthSegments, j));
+      return heightmap[ci * (depthSegments + 1) + cj] * heightScale;
+    };
+
+    for (let i = 0; i <= widthSegments; i++) {
+      for (let j = 0; j <= depthSegments; j++) {
+        const idx = i * (depthSegments + 1) + j;
+
+        const nx = -(getH(i + 1, j) - getH(i - 1, j)) / (2 * dx);
+        const ny = 1;
+        const nz = -(getH(i, j + 1) - getH(i, j - 1)) / (2 * dz);
+
+        const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+        normals[idx * 3 + 0] = nx / len;
+        normals[idx * 3 + 1] = ny / len;
+        normals[idx * 3 + 2] = nz / len;
+      }
+    }
+
+    this.geometry = { positions, uvs, normals };
   }
 
-  getHeightAt(_x: number, _z: number): number {
-    throw new Error('Not implemented');
+  getHeightAt(x: number, z: number): number {
+    const { _heightmap, _widthSegments, _depthSegments, _width, _depth, _heightScale } = this;
+
+    // 世界坐标 → 网格浮点坐标，并夹紧边界
+    const gx = Math.max(0, Math.min(_widthSegments, (x / _width) * _widthSegments));
+    const gz = Math.max(0, Math.min(_depthSegments, (z / _depth) * _depthSegments));
+
+    const ix = Math.min(Math.floor(gx), _widthSegments - 1);
+    const iz = Math.min(Math.floor(gz), _depthSegments - 1);
+    const fx = gx - ix;
+    const fz = gz - iz;
+
+    const cols = _depthSegments + 1;
+    const h00 = _heightmap[ix * cols + iz];
+    const h10 = _heightmap[(ix + 1) * cols + iz];
+    const h01 = _heightmap[ix * cols + (iz + 1)];
+    const h11 = _heightmap[(ix + 1) * cols + (iz + 1)];
+
+    // 双线性插值
+    return (
+      h00 * (1 - fx) * (1 - fz) +
+      h10 * fx * (1 - fz) +
+      h01 * (1 - fx) * fz +
+      h11 * fx * fz
+    ) * _heightScale;
   }
 }


### PR DESCRIPTION
## 概述

从 heightmap Float32Array 生成三角化地形 Mesh，支持双线性高度采样。

## 实现细节

- **顶点布局**：行主序，行 → x 方向，列 → z 方向
- **geometry**：自动生成 `positions` / `uvs` / `normals`（Float32Array）
- **法线**：有限差分法推导，中央差分 + 边界夹紧
- **getHeightAt**：世界坐标 → 网格浮点坐标 → 双线性插值
- **heightScale**：直接乘以原始高度值
- **校验**：heightmap 长度不匹配时抛出 Error

## 测试

- 8 个预写单元测试全部通过
- 全量单元测试 110 个文件 1607 个用例 0 失败

close #278