### PR TITLE
feat: PhongMaterial envMap CubeTexture 环境映射反射 (#280)

### DIFF
--- a/src/renderer/phong-material.ts
+++ b/src/renderer/phong-material.ts
@@ -1,11 +1,12 @@
 /**
  * PhongMaterial — Blinn-Phong 光照材质
- * 支持：漫反射贴图、自发光、多光源
+ * 支持：漫反射贴图、自发光、多光源、环境映射
  */
 
 import { type Vec3, vec3 } from '../math/vec3';
 import { Material } from './material';
 import { Texture } from './texture';
+import type { CubeTexture } from './cube-texture';
 
 const PHONG_VERTEX_SHADER = `
   attribute vec3 a_position;
@@ -32,7 +33,20 @@ const PHONG_VERTEX_SHADER = `
   }
 `;
 
-const PHONG_FRAGMENT_SHADER = `
+function buildFragmentShader(hasEnvMap: boolean): string {
+  const envUniforms = hasEnvMap ? `
+  // 环境映射
+  uniform samplerCube u_envMap;
+  uniform float u_envMapIntensity;
+  uniform float u_reflectivity;` : '';
+
+  const envCode = hasEnvMap ? `
+    vec3 envI = normalize(v_worldPos - u_cameraPos);
+    vec3 envR = reflect(envI, N);
+    vec3 envColor = textureCube(u_envMap, envR).rgb * u_envMapIntensity;
+    finalColor = mix(finalColor, envColor, u_reflectivity);` : '';
+
+  return `
   precision mediump float;
   // 向后兼容（单光源，保留声明供旧测试检查）
   uniform vec3 u_lightDir;
@@ -75,6 +89,7 @@ const PHONG_FRAGMENT_SHADER = `
   // 高光贴图
   uniform sampler2D u_specularMap;
   uniform float u_hasSpecularMap;
+  ${envUniforms}
   varying vec3 v_normal;
   varying vec3 v_worldPos;
   varying vec2 v_uv;
@@ -154,11 +169,7 @@ const PHONG_FRAGMENT_SHADER = `
       }
       // 锥形衰减（smoothstep）
       float cosOuter = u_spotLightCosAngles[i];
-      float penumbra = u_spotLightPenumbras[i];
-      // cosInner = cos(angle * (1.0 - penumbra))，通过 cosOuter 反推 angle 再乘 (1-penumbra)
-      // 直接用 acos 会在 GLSL 1.0 中精度不稳，改为在 CPU 端传 cosInner
-      // 这里复用 penumbra 字段存储 cosInner
-      float cosInner = penumbra; // 注：renderer 中传 cos(angle*(1-penumbra))
+      float cosInner = u_spotLightPenumbras[i]; // 注：renderer 中传 cos(angle*(1-penumbra))
       float spotEffect = dot(normalize(v_worldPos - u_spotLightPositions[i]), u_spotLightDirs[i]);
       float spotAttenuation = smoothstep(cosOuter, cosInner, spotEffect);
       float attenuation = distAttenuation * spotAttenuation;
@@ -170,9 +181,12 @@ const PHONG_FRAGMENT_SHADER = `
       ? u_emissive * texture2D(u_emissiveMap, v_uv).rgb
       : u_emissive;
 
-    gl_FragColor = vec4(color + emissiveColor, 1.0);
+    vec3 finalColor = color + emissiveColor;
+    ${envCode}
+    gl_FragColor = vec4(finalColor, 1.0);
   }
 `;
+}
 
 export interface PhongMaterialOptions {
   ambient?: Vec3;
@@ -185,6 +199,9 @@ export interface PhongMaterialOptions {
   normalMap?: Texture;
   normalScale?: number;
   specularMap?: Texture;
+  envMap?: CubeTexture | null;
+  envMapIntensity?: number;
+  reflectivity?: number;
 }
 
 export class PhongMaterial extends Material {
@@ -198,25 +215,31 @@ export class PhongMaterial extends Material {
   normalMap: Texture | null;
   normalScale: number;
   specularMap: Texture | null;
+  envMap: CubeTexture | null;
+  envMapIntensity: number;
+  reflectivity: number;
 
   constructor(opts: PhongMaterialOptions = {}) {
     super({
       vertexShader: PHONG_VERTEX_SHADER,
-      fragmentShader: PHONG_FRAGMENT_SHADER,
+      fragmentShader: buildFragmentShader(opts.envMap != null),
     });
-    this.ambient      = opts.ambient      ?? vec3(0.1, 0.1, 0.1);
-    this.diffuse      = opts.diffuse      ?? vec3(0.8, 0.8, 0.8);
-    this.specular     = opts.specular     ?? vec3(1.0, 1.0, 1.0);
-    this.shininess    = opts.shininess    ?? 32;
-    this.map          = opts.map          ?? null;
-    this.emissive     = opts.emissive     ?? vec3(0, 0, 0);
-    this.emissiveMap  = opts.emissiveMap  ?? null;
-    this.normalMap    = opts.normalMap    ?? null;
-    this.normalScale  = opts.normalScale  ?? 1.0;
-    this.specularMap  = opts.specularMap  ?? null;
+    this.ambient          = opts.ambient          ?? vec3(0.1, 0.1, 0.1);
+    this.diffuse          = opts.diffuse          ?? vec3(0.8, 0.8, 0.8);
+    this.specular         = opts.specular         ?? vec3(1.0, 1.0, 1.0);
+    this.shininess        = opts.shininess        ?? 32;
+    this.map              = opts.map              ?? null;
+    this.emissive         = opts.emissive         ?? vec3(0, 0, 0);
+    this.emissiveMap      = opts.emissiveMap      ?? null;
+    this.normalMap        = opts.normalMap        ?? null;
+    this.normalScale      = opts.normalScale      ?? 1.0;
+    this.specularMap      = opts.specularMap      ?? null;
+    this.envMap           = opts.envMap           ?? null;
+    this.envMapIntensity  = opts.envMapIntensity  ?? 1.0;
+    this.reflectivity     = opts.reflectivity     ?? 0;
   }
 
-  /** 克隆 Phong 材质（Vec3 属性深拷贝，Texture 引用共享） */
+  /** 克隆 Phong 材质（Vec3 属性深拷贝，Texture/CubeTexture 引用共享） */
   clone(): PhongMaterial {
     const m = new PhongMaterial({
       ambient:     vec3(this.ambient[0],  this.ambient[1],  this.ambient[2]),
@@ -229,6 +252,9 @@ export class PhongMaterial extends Material {
       normalMap:   this.normalMap    ?? undefined,
       normalScale: this.normalScale,
       specularMap: this.specularMap  ?? undefined,
+      envMap:      this.envMap       ?? undefined,
+      envMapIntensity: this.envMapIntensity,
+      reflectivity:    this.reflectivity,
     });
     m.opacity     = this.opacity;
     m.transparent = this.transparent;

--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -75,6 +75,10 @@ interface PhongLocations {
   // 高光贴图
   uSpecularMap: WebGLUniformLocation | null;
   uHasSpecularMap: WebGLUniformLocation | null;
+  // 环境映射
+  uEnvMap: WebGLUniformLocation | null;
+  uEnvMapIntensity: WebGLUniformLocation | null;
+  uReflectivity: WebGLUniformLocation | null;
   // 多方向光
   uNumDirLights: WebGLUniformLocation | null;
   uDirLightDirs: Array<WebGLUniformLocation | null>;
@@ -342,6 +346,7 @@ export class WebGLRenderer {
   private fogProgramCache: WeakMap<Material, CompiledProgram> = new WeakMap();
   private geometryCache: WeakMap<Geometry, UploadedGeometry> = new WeakMap();
   private textureCache: WeakMap<Texture, { glTex: WebGLTexture; version: number }> = new WeakMap();
+  private cubeTextureCache: WeakMap<CubeTexture, WebGLTexture> = new WeakMap();
   readonly info: RenderInfo = createRenderInfo();
   private skinningProgram: SkinningProgram | null = null;
   private lineProgramCache: WeakMap<LineMaterial, LineProgramInfo> = new WeakMap();
@@ -617,6 +622,33 @@ export class WebGLRenderer {
     return webglTex;
   }
 
+  private _getCubeTexture(texture: CubeTexture): WebGLTexture {
+    const gl = this.gl;
+    const cached = this.cubeTextureCache.get(texture);
+    if (cached && !texture.needsUpdate) return cached;
+
+    const glTex = cached ?? gl.createTexture()!;
+    gl.bindTexture(gl.TEXTURE_CUBE_MAP, glTex);
+
+    for (let i = 0; i < 6; i++) {
+      const face = texture.faces[i];
+      if (face !== null) {
+        gl.texImage2D(
+          gl.TEXTURE_CUBE_MAP_POSITIVE_X + i,
+          0, gl.RGBA, texture.faceSize, texture.faceSize,
+          0, gl.RGBA, gl.UNSIGNED_BYTE, face,
+        );
+      }
+    }
+
+    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+
+    this.cubeTextureCache.set(texture, glTex);
+    texture.needsUpdate = false;
+    return glTex;
+  }
+
   // ── Private helpers ─────────────────────────────────────────────
 
   private _getProgram(material: Material, hasFog = false): CompiledProgram {
@@ -697,6 +729,9 @@ export class WebGLRenderer {
         uNormalScale:       gl.getUniformLocation(program, 'u_normalScale'),
         uSpecularMap:       gl.getUniformLocation(program, 'u_specularMap'),
         uHasSpecularMap:    gl.getUniformLocation(program, 'u_hasSpecularMap'),
+        uEnvMap:            gl.getUniformLocation(program, 'u_envMap'),
+        uEnvMapIntensity:   gl.getUniformLocation(program, 'u_envMapIntensity'),
+        uReflectivity:      gl.getUniformLocation(program, 'u_reflectivity'),
         uNumDirLights:      gl.getUniformLocation(program, 'u_numDirLights'),
         uDirLightDirs:      dirDirs,
         uDirLightColors:    dirColors,
@@ -1110,6 +1145,16 @@ export class WebGLRenderer {
         }
       } else {
         if (phong.uHasSpecularMap) gl.uniform1f(phong.uHasSpecularMap, 0.0);
+      }
+
+      // 环境映射（纹理单元 4）
+      if (mat.envMap != null) {
+        const cubeTex = this._getCubeTexture(mat.envMap);
+        gl.activeTexture(gl.TEXTURE4);
+        gl.bindTexture(gl.TEXTURE_CUBE_MAP, cubeTex);
+        if (phong.uEnvMap)          gl.uniform1i(phong.uEnvMap, 4);
+        if (phong.uEnvMapIntensity) gl.uniform1f(phong.uEnvMapIntensity, mat.envMapIntensity);
+        if (phong.uReflectivity)    gl.uniform1f(phong.uReflectivity, mat.reflectivity);
       }
     }
 

--- a/test/unit/renderer/phong-material.env-map.test.ts
+++ b/test/unit/renderer/phong-material.env-map.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { PhongMaterial } from '../../../src/renderer/phong-material';
+import { CubeTexture, CubeTextureFace } from '../../../src/renderer/cube-texture';
+
+describe('PhongMaterial — envMap 环境映射', () => {
+  const makeCube = () => {
+    const ct = new CubeTexture(1);
+    const face = new Uint8Array(4);
+    for (let i = 0; i < 6; i++) {
+      ct.setFace(i as CubeTextureFace, face);
+    }
+    return ct;
+  };
+
+  it('constructs without envMap (backward compat)', () => {
+    const mat = new PhongMaterial({ diffuse: [1, 0, 0] as any });
+    expect(mat.envMap).toBeNull();
+    expect(mat.reflectivity).toBe(0);
+  });
+
+  it('accepts envMap option', () => {
+    const cube = makeCube();
+    const mat = new PhongMaterial({ envMap: cube, reflectivity: 0.5 });
+    expect(mat.envMap).toBe(cube);
+    expect(mat.reflectivity).toBe(0.5);
+  });
+
+  it('envMapIntensity defaults to 1.0', () => {
+    const mat = new PhongMaterial({ envMap: makeCube(), reflectivity: 1 });
+    expect(mat.envMapIntensity).toBe(1.0);
+  });
+
+  it('envMapIntensity is read/write', () => {
+    const mat = new PhongMaterial({ envMap: makeCube() });
+    mat.envMapIntensity = 2.5;
+    expect(mat.envMapIntensity).toBe(2.5);
+  });
+
+  it('reflectivity defaults to 0 (no reflection unless opted-in)', () => {
+    const mat = new PhongMaterial({ envMap: makeCube() });
+    expect(mat.reflectivity).toBe(0);
+  });
+
+  it('fragment shader includes reflect and textureCube when envMap present', () => {
+    const mat = new PhongMaterial({ envMap: makeCube(), reflectivity: 0.5 });
+    const fs = (mat as any).fragmentShader as string;
+    expect(fs).toMatch(/reflect\(/);
+    expect(fs).toMatch(/textureCube\(/);
+    expect(fs).toContain('u_envMap');
+  });
+
+  it('fragment shader excludes envMap uniforms when envMap is null', () => {
+    const mat = new PhongMaterial({ diffuse: [1, 0, 0] as any });
+    const fs = (mat as any).fragmentShader as string;
+    expect(fs).not.toContain('u_envMap');
+  });
+
+  it('envMap can be set to null to disable', () => {
+    const mat = new PhongMaterial({ envMap: makeCube(), reflectivity: 0.5 });
+    mat.envMap = null;
+    expect(mat.envMap).toBeNull();
+  });
+});


### PR DESCRIPTION
## 变更摘要

- `PhongMaterial` 新增 `envMap: CubeTexture | null`、`envMapIntensity: number`（默认 1.0）、`reflectivity: number`（默认 0）属性
- 构造时根据 `opts.envMap` 动态生成 fragment shader：有 envMap 时注入 `reflect`/`textureCube`/`u_envMap` 代码；无 envMap 时 shader 完全不含这些 uniform（零开销、向后兼容）
- `WebGLRenderer` 新增 `_getCubeTexture` 方法，将 `CubeTexture` 上传到 GPU 并绑定至纹理单元 4（复用 skybox 的 cube map upload 逻辑）
- 新增测试文件 `test/unit/renderer/phong-material.env-map.test.ts`（8 个测试全部通过）

## 测试计划

- [x] 新增 envMap 测试 8/8 通过
- [x] 现有 PhongMaterial 测试 11/11 通过（无回归）
- [x] 全量测试 1607/1622 通过（15 skip 为已有 stub）
- [x] `pnpm build` 编译通过

close #280