### PR TITLE
feat: 实现 ShadowMap PCF 软阴影 (#284)

### DIFF
--- a/src/renderer/shadow-map.ts
+++ b/src/renderer/shadow-map.ts
@@ -12,12 +12,18 @@ import { RenderTarget } from './render-target';
 export interface ShadowMapOptions {
   /** 阴影贴图分辨率（正方形边长），默认 1024 */
   resolution?: number;
+  /** 阴影贴图宽度（与 height 同时使用时覆盖 resolution） */
+  width?: number;
+  /** 阴影贴图高度（与 width 同时使用时覆盖 resolution） */
+  height?: number;
   /** 深度偏移量，减少 shadow acne，默认 0.005 */
   bias?: number;
   /** 阴影相机近平面，默认 0.1 */
   near?: number;
   /** 阴影相机远平面，默认 100 */
   far?: number;
+  /** PCF 软阴影 kernel 大小：0 = 关闭(硬阴影), 1 = 3x3, 2 = 5x5。默认 0 */
+  softness?: 0 | 1 | 2;
 }
 
 export class ShadowMap {
@@ -25,6 +31,7 @@ export class ShadowMap {
   readonly bias: number;
   readonly near: number;
   readonly far: number;
+  readonly softness: 0 | 1 | 2;
   readonly renderTarget: RenderTarget;
 
   /** 光源视图矩阵 */
@@ -35,15 +42,35 @@ export class ShadowMap {
   lightVPMatrix: Mat4 | null = null;
 
   constructor(options?: ShadowMapOptions) {
-    this.resolution = options?.resolution ?? 1024;
+    const res = options?.resolution ?? 1024;
+    const w = options?.width ?? res;
+    const h = options?.height ?? res;
+    this.resolution = res;
     this.bias = options?.bias ?? 0.005;
     this.near = options?.near ?? 0.1;
     this.far = options?.far ?? 100;
+    const s = options?.softness ?? 0;
+    if (s !== 0 && s !== 1 && s !== 2) {
+      throw new Error(`ShadowMap: softness 必须为 0、1 或 2，收到 ${s}`);
+    }
+    this.softness = s;
     this.renderTarget = new RenderTarget({
-      width: this.resolution,
-      height: this.resolution,
+      width: w,
+      height: h,
       depthBuffer: true,
     });
+  }
+
+  /** 返回片元着色器声明代码（根据 softness 决定是否含 u_shadowMapSize） */
+  getFragmentParsCode(): string {
+    if (this.softness === 0) return SHADOW_FRAGMENT_PARS;
+    return `${SHADOW_FRAGMENT_PARS}\nuniform vec2 u_shadowMapSize;`;
+  }
+
+  /** 返回片元着色器阴影计算代码（softness=0 硬阴影，1=3x3 PCF，2=5x5 PCF） */
+  getFragmentCode(): string {
+    if (this.softness === 0) return SHADOW_FRAGMENT_CODE;
+    return this.softness === 1 ? PCF_3X3_FRAGMENT_CODE : PCF_5X5_FRAGMENT_CODE;
   }
 
   /**
@@ -140,4 +167,60 @@ vec2 shadowUV = shadowNDC.xy * 0.5 + 0.5;
 float shadowDepth = texture2D(u_shadowMap, shadowUV).r;
 float bias = u_shadowBias;
 float shadow = (shadowNDC.z * 0.5 + 0.5 - bias > shadowDepth) ? 0.5 : 1.0;
+`.trim();
+
+/** 3x3 PCF 展开式，9 次采样（WebGL 1.0 兼容，无 for 循环） */
+export const PCF_3X3_FRAGMENT_CODE = `
+vec3 shadowNDC = v_shadowCoord.xyz / v_shadowCoord.w;
+vec2 shadowUV = shadowNDC.xy * 0.5 + 0.5;
+float bias = u_shadowBias;
+float depth = shadowNDC.z * 0.5 + 0.5 - bias;
+vec2 texelSize = 1.0 / u_shadowMapSize;
+float shadow = 0.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-1.0, -1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 0.0, -1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 1.0, -1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-1.0,  0.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 0.0,  0.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 1.0,  0.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-1.0,  1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 0.0,  1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 1.0,  1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow /= 9.0;
+`.trim();
+
+/** 5x5 PCF 展开式，25 次采样（WebGL 1.0 兼容，无 for 循环） */
+export const PCF_5X5_FRAGMENT_CODE = `
+vec3 shadowNDC = v_shadowCoord.xyz / v_shadowCoord.w;
+vec2 shadowUV = shadowNDC.xy * 0.5 + 0.5;
+float bias = u_shadowBias;
+float depth = shadowNDC.z * 0.5 + 0.5 - bias;
+vec2 texelSize = 1.0 / u_shadowMapSize;
+float shadow = 0.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-2.0, -2.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-1.0, -2.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 0.0, -2.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 1.0, -2.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 2.0, -2.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-2.0, -1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-1.0, -1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 0.0, -1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 1.0, -1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 2.0, -1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-2.0,  0.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-1.0,  0.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 0.0,  0.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 1.0,  0.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 2.0,  0.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-2.0,  1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-1.0,  1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 0.0,  1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 1.0,  1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 2.0,  1.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-2.0,  2.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2(-1.0,  2.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 0.0,  2.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 1.0,  2.0) * texelSize).r) ? 0.5 : 1.0;
+shadow += (depth > texture2D(u_shadowMap, shadowUV + vec2( 2.0,  2.0) * texelSize).r) ? 0.5 : 1.0;
+shadow /= 25.0;
 `.trim();

--- a/test/unit/renderer/shadow-pcf.test.ts
+++ b/test/unit/renderer/shadow-pcf.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { ShadowMap, SHADOW_FRAGMENT_CODE } from '../../../src/renderer/shadow-map';
+
+describe('ShadowMap PCF Soft Shadow', () => {
+  it('softness=0 默认硬阴影，单次 texture2D 采样', () => {
+    const sm = new ShadowMap({ width: 1024, height: 1024 });
+    expect(sm.softness).toBe(0);
+    const code = sm.getFragmentCode();
+    const matches = code.match(/texture2D\(u_shadowMap/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it('softness=1 启用 3x3 PCF，9 次采样', () => {
+    const sm = new ShadowMap({ width: 1024, height: 1024, softness: 1 });
+    expect(sm.softness).toBe(1);
+    const code = sm.getFragmentCode();
+    const matches = code.match(/texture2D\(u_shadowMap/g) ?? [];
+    expect(matches.length).toBe(9);
+    expect(code).toMatch(/shadow\s*\/=\s*9\.0/);
+  });
+
+  it('softness=2 启用 5x5 PCF，25 次采样', () => {
+    const sm = new ShadowMap({ width: 1024, height: 1024, softness: 2 });
+    expect(sm.softness).toBe(2);
+    const code = sm.getFragmentCode();
+    const matches = code.match(/texture2D\(u_shadowMap/g) ?? [];
+    expect(matches.length).toBe(25);
+    expect(code).toMatch(/shadow\s*\/=\s*25\.0/);
+  });
+
+  it('softness 大于 2 抛错', () => {
+    expect(() => new ShadowMap({ width: 1024, height: 1024, softness: 3 as any })).toThrow();
+  });
+
+  it('softness>0 时片段代码包含 u_shadowMapSize uniform', () => {
+    const sm = new ShadowMap({ width: 1024, height: 1024, softness: 1 });
+    expect(sm.getFragmentParsCode()).toMatch(/uniform\s+vec2\s+u_shadowMapSize/);
+  });
+
+  it('softness=0 时片段代码不包含 u_shadowMapSize uniform', () => {
+    const sm = new ShadowMap({ width: 1024, height: 1024, softness: 0 });
+    expect(sm.getFragmentParsCode()).not.toMatch(/u_shadowMapSize/);
+  });
+
+  it('原有静态导出 SHADOW_FRAGMENT_CODE 保持向后兼容（硬阴影）', () => {
+    const matches = SHADOW_FRAGMENT_CODE.match(/texture2D\(u_shadowMap/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it('softness=2 GLSL 不含动态 for 循环（WebGL 1.0 兼容性）', () => {
+    const sm = new ShadowMap({ width: 1024, height: 1024, softness: 2 });
+    const code = sm.getFragmentCode();
+    expect(code).not.toMatch(/for\s*\(\s*int\s+\w+\s*=\s*-?\w+\s*;\s*\w+\s*<\s*\w+\s*;/);
+  });
+});


### PR DESCRIPTION
## 变更摘要

- `ShadowMapOptions` 新增 `softness` 字段（`0` = 硬阴影，`1` = 3×3 PCF，`2` = 5×5 PCF）
- `ShadowMapOptions` 新增 `width`/`height` 字段，与原有 `resolution` 兼容
- `ShadowMap` 新增 `softness` 只读属性
- 新增 `getFragmentCode()` — 根据 softness 返回对应 GLSL 阴影计算代码
- 新增 `getFragmentParsCode()` — softness>0 时附加 `uniform vec2 u_shadowMapSize`
- PCF GLSL 全部展开式（unrolled），无 `for` 循环，确保 WebGL 1.0 兼容性
- 保留原有 `SHADOW_FRAGMENT_CODE` 静态导出（硬阴影，单次采样），向后兼容

## 测试

- 新增 `test/unit/renderer/shadow-pcf.test.ts`，覆盖 8 个测试用例
- 全量单元测试：113 文件 / 1630 用例全部通过

close #284