### PR TITLE
feat: 实现 VignettePass 屏幕暗角后处理 (#286)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -38,6 +38,11 @@ export class PostProcessor {
   private _width = 0;
   private _height = 0;
 
+  constructor(options?: { width?: number; height?: number }) {
+    if (options?.width) this._width = options.width;
+    if (options?.height) this._height = options.height;
+  }
+
   // ping-pong 双缓冲 FBO
   private _fbos: (WebGLFramebuffer | null)[] = [null, null];
   private _textures: (WebGLTexture | null)[] = [null, null];
@@ -365,5 +370,75 @@ void main() {
     if (uThreshold) gl.uniform1f(uThreshold, this.threshold);
     const uIntensity = gl.getUniformLocation(program, 'u_intensity');
     if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
+  }
+}
+
+/* ── VignetteOptions ── */
+
+export interface VignetteOptions {
+  /** 内半径：dist <= 此值时不变暗。默认 0.4 */
+  innerRadius?: number;
+  /** 外半径：dist >= 此值时变最暗。默认 0.8 */
+  outerRadius?: number;
+  /** 暗角强度：0=无, 1=四角全黑。默认 0.6 */
+  intensity?: number;
+}
+
+/** 屏幕暗角效果：径向 smoothstep 衰减，营造电影感聚焦中心 */
+export class VignettePass implements EffectPass {
+  readonly name = 'vignette';
+  enabled = true;
+  innerRadius: number;
+  outerRadius: number;
+  intensity: number;
+
+  constructor(options?: VignetteOptions) {
+    const inner = options?.innerRadius ?? 0.4;
+    const outer = options?.outerRadius ?? 0.8;
+    const intensity = options?.intensity ?? 0.6;
+
+    if (inner >= outer) {
+      throw new Error(`VignettePass: innerRadius (${inner}) 必须小于 outerRadius (${outer})`);
+    }
+    if (intensity < 0 || intensity > 1) {
+      throw new Error(`VignettePass: intensity (${intensity}) 必须在 [0, 1] 范围内`);
+    }
+
+    this.innerRadius = inner;
+    this.outerRadius = outer;
+    this.intensity = intensity;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_innerRadius;
+uniform float u_outerRadius;
+uniform float u_intensity;
+varying vec2 v_texCoord;
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  vec2 center = vec2(0.5);
+  float dist = distance(v_texCoord, center);
+  float vignette = 1.0 - smoothstep(u_innerRadius, u_outerRadius, dist) * u_intensity;
+  gl_FragColor = vec4(color.rgb * vignette, color.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uInner = gl.getUniformLocation(program, 'u_innerRadius');
+    if (uInner) gl.uniform1f(uInner, this.innerRadius);
+    const uOuter = gl.getUniformLocation(program, 'u_outerRadius');
+    if (uOuter) gl.uniform1f(uOuter, this.outerRadius);
+    const uIntensity = gl.getUniformLocation(program, 'u_intensity');
+    if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
+  }
+
+  apply(gl: WebGLRenderingContext, _input: WebGLTexture, _output: WebGLFramebuffer | null): void {
+    // apply 由外部 PostProcessor 调用时会走 render 路径
+    // 此方法提供 duck-typing 兼容
+    void gl;
   }
 }

--- a/test/unit/renderer/vignette-pass.test.ts
+++ b/test/unit/renderer/vignette-pass.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { VignettePass, PostProcessor, BloomPass } from '../../../src/renderer/post-process';
+
+describe('VignettePass', () => {
+  it('默认参数：inner=0.4, outer=0.8, intensity=0.6', () => {
+    const p = new VignettePass();
+    expect(p.innerRadius).toBe(0.4);
+    expect(p.outerRadius).toBe(0.8);
+    expect(p.intensity).toBe(0.6);
+  });
+
+  it('可自定义三参数', () => {
+    const p = new VignettePass({ innerRadius: 0.2, outerRadius: 0.9, intensity: 1.0 });
+    expect(p.innerRadius).toBe(0.2);
+    expect(p.outerRadius).toBe(0.9);
+    expect(p.intensity).toBe(1.0);
+  });
+
+  it('innerRadius >= outerRadius 抛错', () => {
+    expect(() => new VignettePass({ innerRadius: 0.8, outerRadius: 0.4 })).toThrow();
+    expect(() => new VignettePass({ innerRadius: 0.5, outerRadius: 0.5 })).toThrow();
+  });
+
+  it('intensity 超出 [0, 1] 抛错', () => {
+    expect(() => new VignettePass({ intensity: -0.1 })).toThrow();
+    expect(() => new VignettePass({ intensity: 1.5 })).toThrow();
+  });
+
+  it('intensity=0 / intensity=1 边界值合法', () => {
+    expect(() => new VignettePass({ intensity: 0 })).not.toThrow();
+    expect(() => new VignettePass({ intensity: 1 })).not.toThrow();
+  });
+
+  it('三参数运行时可写', () => {
+    const p = new VignettePass();
+    p.innerRadius = 0.3;
+    p.outerRadius = 0.7;
+    p.intensity = 0.8;
+    expect(p.innerRadius).toBe(0.3);
+    expect(p.outerRadius).toBe(0.7);
+    expect(p.intensity).toBe(0.8);
+  });
+
+  it('fragment shader 包含必需 uniforms', () => {
+    const p = new VignettePass();
+    const fs = p.getFragmentShader();
+    expect(fs).toMatch(/uniform\s+float\s+u_innerRadius/);
+    expect(fs).toMatch(/uniform\s+float\s+u_outerRadius/);
+    expect(fs).toMatch(/uniform\s+float\s+u_intensity/);
+  });
+
+  it('fragment shader 使用 smoothstep + distance 数学', () => {
+    const p = new VignettePass();
+    const fs = p.getFragmentShader();
+    expect(fs).toMatch(/distance\s*\(/);
+    expect(fs).toMatch(/smoothstep\s*\(/);
+  });
+
+  it('VignettePass 实现 EffectPass 接口（duck typing）', () => {
+    const p = new VignettePass();
+    expect(typeof p.apply).toBe('function');
+  });
+
+  it('PostProcessor 可串联 Bloom + Vignette 链', () => {
+    const proc = new PostProcessor({ width: 800, height: 600 });
+    proc.addPass(new BloomPass());
+    proc.addPass(new VignettePass({ intensity: 0.7 }));
+    expect(proc.passes.length).toBe(2);
+    expect(proc.passes[1]).toBeInstanceOf(VignettePass);
+  });
+});


### PR DESCRIPTION
## Summary

- 在 `src/renderer/post-process.ts` 追加 `VignettePass` 类，实现 `EffectPass` 接口
- 基于 UV 距中心的径向 `distance` + `smoothstep` 衰减计算暗角
- 支持 `innerRadius`（默认 0.4）、`outerRadius`（默认 0.8）、`intensity`（默认 0.6）三参数
- 构造时验证：`innerRadius >= outerRadius` 或 `intensity` 越界均抛错
- `PostProcessor` 构造函数增加可选 `{ width, height }` 参数，支持串联场景
- 新增测试文件 `test/unit/renderer/vignette-pass.test.ts`（10 个测试全部通过）

## Test plan

- [x] `pnpm run test` — 113 个测试文件，1632 个测试，0 失败
- [x] VignettePass 默认参数验证
- [x] 自定义三参数验证
- [x] innerRadius >= outerRadius 抛错
- [x] intensity 越界抛错
- [x] 边界值 intensity=0/1 合法
- [x] 三参数运行时可写
- [x] fragment shader 包含 u_innerRadius / u_outerRadius / u_intensity
- [x] fragment shader 使用 distance + smoothstep
- [x] duck typing apply 方法存在
- [x] PostProcessor 可串联 Bloom + Vignette 链

close #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)