### PR TITLE
feat: 实现 FilmGrainPass 胶片颗粒噪声后处理 (#291)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -530,3 +530,64 @@ void main() {
     void gl;
   }
 }
+
+/* ── FilmGrainOptions ── */
+
+export interface FilmGrainOptions {
+  /** 颗粒强度 [0, 1]，默认 0.15 */
+  intensity?: number;
+  /** 时间种子，默认 0，每帧外部递增以避免颗粒图案静止 */
+  time?: number;
+}
+
+/** 胶片颗粒噪声后处理：在最终输出上叠加伪随机噪声，模拟电影胶片颗粒感 */
+export class FilmGrainPass implements EffectPass {
+  readonly name = 'film-grain';
+  enabled = true;
+  intensity: number;
+  time: number;
+
+  constructor(options?: FilmGrainOptions) {
+    const intensity = options?.intensity ?? 0.15;
+    const time = options?.time ?? 0;
+
+    if (!Number.isFinite(intensity)) {
+      throw new Error(`FilmGrainPass: intensity (${intensity}) 必须是有限数值`);
+    }
+    if (intensity < 0 || intensity > 1) {
+      throw new Error(`FilmGrainPass: intensity (${intensity}) 必须在 [0, 1] 范围内`);
+    }
+    if (!Number.isFinite(time)) {
+      throw new Error(`FilmGrainPass: time (${time}) 必须是有限数值`);
+    }
+    if (time < 0) {
+      throw new Error(`FilmGrainPass: time (${time}) 不能为负数`);
+    }
+
+    this.intensity = intensity;
+    this.time = time;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_intensity;
+uniform float u_time;
+varying vec2 v_texCoord;
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  float noise = fract(sin(dot(v_texCoord + u_time, vec2(12.9898, 78.233))) * 43758.5453);
+  vec3 grain = color.rgb + (noise - 0.5) * 2.0 * u_intensity;
+  gl_FragColor = vec4(clamp(grain, 0.0, 1.0), color.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uIntensity = gl.getUniformLocation(program, 'u_intensity');
+    if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
+    const uTime = gl.getUniformLocation(program, 'u_time');
+    if (uTime) gl.uniform1f(uTime, this.time);
+  }
+}

--- a/test/unit/renderer/film-grain-pass.test.ts
+++ b/test/unit/renderer/film-grain-pass.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { FilmGrainPass, PostProcessor } from '../../../src/renderer/post-process';
+
+describe('FilmGrainPass', () => {
+  it('默认参数：intensity=0.15, time=0', () => {
+    const p = new FilmGrainPass();
+    expect(p.intensity).toBe(0.15);
+    expect(p.time).toBe(0);
+  });
+
+  it('可自定义两参数', () => {
+    const p = new FilmGrainPass({ intensity: 0.3, time: 5.0 });
+    expect(p.intensity).toBe(0.3);
+    expect(p.time).toBe(5.0);
+  });
+
+  it('name 固定为 film-grain', () => {
+    expect(new FilmGrainPass().name).toBe('film-grain');
+  });
+
+  it('enabled 默认 true，可设置', () => {
+    const p = new FilmGrainPass();
+    expect(p.enabled).toBe(true);
+    p.enabled = false;
+    expect(p.enabled).toBe(false);
+  });
+
+  it('intensity 超出 [0, 1] 抛错', () => {
+    expect(() => new FilmGrainPass({ intensity: -0.1 })).toThrow();
+    expect(() => new FilmGrainPass({ intensity: 1.5 })).toThrow();
+  });
+
+  it('time < 0 抛错', () => {
+    expect(() => new FilmGrainPass({ time: -1 })).toThrow();
+  });
+
+  it('intensity=0 / intensity=1 / time=0 边界值合法', () => {
+    expect(() => new FilmGrainPass({ intensity: 0, time: 0 })).not.toThrow();
+    expect(() => new FilmGrainPass({ intensity: 1, time: 0 })).not.toThrow();
+  });
+
+  it('非 finite 参数抛错', () => {
+    expect(() => new FilmGrainPass({ intensity: Number.NaN })).toThrow();
+    expect(() => new FilmGrainPass({ time: Number.POSITIVE_INFINITY })).toThrow();
+  });
+
+  it('两参数运行时可写', () => {
+    const p = new FilmGrainPass();
+    p.intensity = 0.5;
+    p.time = 10.0;
+    expect(p.intensity).toBe(0.5);
+    expect(p.time).toBe(10.0);
+  });
+
+  it('getFragmentShader 返回含 u_texture/u_intensity/u_time 的 GLSL', () => {
+    const src = new FilmGrainPass().getFragmentShader();
+    expect(src).toContain('u_texture');
+    expect(src).toContain('u_intensity');
+    expect(src).toContain('u_time');
+    expect(src).toContain('varying vec2 v_texCoord');
+    expect(src).toMatch(/texture2D\s*\(/);
+    // 伪随机：应含 fract + sin + dot
+    expect(src).toMatch(/fract/);
+  });
+
+  it('可接入 PostProcessor', () => {
+    const pp = new PostProcessor({ width: 256, height: 256 });
+    const pass = new FilmGrainPass();
+    pp.addPass(pass);
+    expect(pp.passes).toContain(pass);
+    expect(pp.passes.find(p => p.name === 'film-grain')).toBe(pass);
+  });
+});


### PR DESCRIPTION
## 变更内容

在 `src/renderer/post-process.ts` 中新增 `FilmGrainPass`，实现胶片颗粒噪声后处理效果。

## 实现要点

- 沿用 `VignettePass` 的 EffectPass 接口 + options 风格
- GLSL 使用 `fract(sin(dot(v_texCoord + u_time, vec2(12.9898, 78.233))) * 43758.5453)` 生成伪随机噪声
- 输出 = 采样色 + (噪声 - 0.5) * 2 * intensity，clamp 到 [0, 1]
- 构造器校验：非 finite 值、intensity 越界 [0, 1]、time < 0 均抛错
- `time` 参数支持外部每帧累加 dt，避免颗粒图案静止

## 测试结果

- `film-grain-pass.test.ts`: 11/11 全绿
- 全量单元测试：116 文件，1661 测试，0 失败

close #291