### PR TITLE
feat(renderer): 实现 ChromaticAberrationPass RGB 通道色差后处理 (#290)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -591,3 +591,74 @@ void main() {
     if (uTime) gl.uniform1f(uTime, this.time);
   }
 }
+
+/* ── ChromaticAberrationOptions ── */
+
+export interface ChromaticAberrationOptions {
+  /** R 通道水平偏移像素，默认 2.0 */
+  redOffset?: number;
+  /** B 通道水平偏移像素，默认 -2.0 */
+  blueOffset?: number;
+  /** 整体强度 [0, 1]，默认 1.0 */
+  intensity?: number;
+}
+
+/** RGB 通道色差效果：模拟镜头色散，常用于赛博朋克 / 恐怖 / 动作风格 */
+export class ChromaticAberrationPass implements EffectPass {
+  readonly name = 'chromatic-aberration';
+  enabled = true;
+  redOffset: number;
+  blueOffset: number;
+  intensity: number;
+
+  constructor(options?: ChromaticAberrationOptions) {
+    const redOffset = options?.redOffset ?? 2.0;
+    const blueOffset = options?.blueOffset ?? -2.0;
+    const intensity = options?.intensity ?? 1.0;
+
+    if (!Number.isFinite(redOffset)) {
+      throw new Error(`ChromaticAberrationPass: redOffset (${redOffset}) 必须是有限数值`);
+    }
+    if (!Number.isFinite(blueOffset)) {
+      throw new Error(`ChromaticAberrationPass: blueOffset (${blueOffset}) 必须是有限数值`);
+    }
+    if (!Number.isFinite(intensity) || intensity < 0 || intensity > 1) {
+      throw new Error(`ChromaticAberrationPass: intensity (${intensity}) 必须在 [0, 1] 范围内`);
+    }
+
+    this.redOffset = redOffset;
+    this.blueOffset = blueOffset;
+    this.intensity = intensity;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_redOffset;
+uniform float u_blueOffset;
+uniform float u_intensity;
+uniform vec2 u_texelSize;
+varying vec2 v_texCoord;
+void main() {
+  vec2 redCoord = v_texCoord + vec2(u_redOffset * u_texelSize.x, 0.0);
+  vec2 blueCoord = v_texCoord + vec2(u_blueOffset * u_texelSize.x, 0.0);
+  float r = texture2D(u_texture, redCoord).r;
+  vec4 base = texture2D(u_texture, v_texCoord);
+  float g = base.g;
+  float b = texture2D(u_texture, blueCoord).b;
+  vec3 aberrated = vec3(r, g, b);
+  gl_FragColor = vec4(mix(base.rgb, aberrated, u_intensity), base.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uRedOffset = gl.getUniformLocation(program, 'u_redOffset');
+    if (uRedOffset) gl.uniform1f(uRedOffset, this.redOffset);
+    const uBlueOffset = gl.getUniformLocation(program, 'u_blueOffset');
+    if (uBlueOffset) gl.uniform1f(uBlueOffset, this.blueOffset);
+    const uIntensity = gl.getUniformLocation(program, 'u_intensity');
+    if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
+  }
+}

--- a/test/unit/renderer/chromatic-aberration-pass.test.ts
+++ b/test/unit/renderer/chromatic-aberration-pass.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { ChromaticAberrationPass, PostProcessor } from '../../../src/renderer/post-process';
+
+describe('ChromaticAberrationPass', () => {
+  it('默认参数：redOffset=2, blueOffset=-2, intensity=1', () => {
+    const p = new ChromaticAberrationPass();
+    expect(p.redOffset).toBe(2.0);
+    expect(p.blueOffset).toBe(-2.0);
+    expect(p.intensity).toBe(1.0);
+  });
+
+  it('可自定义三参数', () => {
+    const p = new ChromaticAberrationPass({ redOffset: 5, blueOffset: -5, intensity: 0.5 });
+    expect(p.redOffset).toBe(5);
+    expect(p.blueOffset).toBe(-5);
+    expect(p.intensity).toBe(0.5);
+  });
+
+  it('name 固定为 chromatic-aberration', () => {
+    expect(new ChromaticAberrationPass().name).toBe('chromatic-aberration');
+  });
+
+  it('enabled 默认 true，可设置', () => {
+    const p = new ChromaticAberrationPass();
+    expect(p.enabled).toBe(true);
+    p.enabled = false;
+    expect(p.enabled).toBe(false);
+  });
+
+  it('intensity 超出 [0, 1] 抛错', () => {
+    expect(() => new ChromaticAberrationPass({ intensity: -0.1 })).toThrow();
+    expect(() => new ChromaticAberrationPass({ intensity: 1.5 })).toThrow();
+  });
+
+  it('intensity=0 / intensity=1 边界值合法', () => {
+    expect(() => new ChromaticAberrationPass({ intensity: 0 })).not.toThrow();
+    expect(() => new ChromaticAberrationPass({ intensity: 1 })).not.toThrow();
+  });
+
+  it('非 finite 参数抛错', () => {
+    expect(() => new ChromaticAberrationPass({ redOffset: Number.NaN })).toThrow();
+    expect(() => new ChromaticAberrationPass({ blueOffset: Number.POSITIVE_INFINITY })).toThrow();
+    expect(() => new ChromaticAberrationPass({ intensity: Number.NaN })).toThrow();
+  });
+
+  it('三参数运行时可写', () => {
+    const p = new ChromaticAberrationPass();
+    p.redOffset = 3;
+    p.blueOffset = -3;
+    p.intensity = 0.8;
+    expect(p.redOffset).toBe(3);
+    expect(p.blueOffset).toBe(-3);
+    expect(p.intensity).toBe(0.8);
+  });
+
+  it('getFragmentShader 返回含 u_texture/u_redOffset/u_blueOffset/u_intensity/u_texelSize 的 GLSL', () => {
+    const src = new ChromaticAberrationPass().getFragmentShader();
+    expect(src).toContain('u_texture');
+    expect(src).toContain('u_redOffset');
+    expect(src).toContain('u_blueOffset');
+    expect(src).toContain('u_intensity');
+    expect(src).toContain('u_texelSize');
+    expect(src).toContain('varying vec2 v_texCoord');
+    expect(src).toMatch(/texture2D\s*\(/);
+  });
+
+  it('R 通道和 B 通道 GLSL 采样偏移正负相反', () => {
+    const src = new ChromaticAberrationPass().getFragmentShader();
+    // R 通道必须用 u_redOffset 采样，B 通道必须用 u_blueOffset 采样
+    expect(src.match(/u_redOffset/g)?.length ?? 0).toBeGreaterThanOrEqual(1);
+    expect(src.match(/u_blueOffset/g)?.length ?? 0).toBeGreaterThanOrEqual(1);
+  });
+
+  it('可接入 PostProcessor', () => {
+    const pp = new PostProcessor({ width: 256, height: 256 });
+    const pass = new ChromaticAberrationPass();
+    pp.addPass(pass);
+    expect(pp.passes).toContain(pass);
+    expect(pp.passes.find(p => p.name === 'chromatic-aberration')).toBe(pass);
+  });
+});


### PR DESCRIPTION
## 概要

- 在 `src/renderer/post-process.ts` 新增 `ChromaticAberrationPass` 类（实现 `EffectPass` 接口）
- 模拟镜头透镜 RGB 通道分离效果，常用于赛博朋克 / 恐怖 / 动作风格游戏
- 创建测试文件 `test/unit/renderer/chromatic-aberration-pass.test.ts`（11 个测试全绿）

## 实现细节

- `redOffset`：R 通道水平偏移像素，默认 2.0
- `blueOffset`：B 通道水平偏移像素，默认 -2.0（方向与 R 相反）
- `intensity`：整体强度 [0, 1]，默认 1.0
- 非 finite 参数或 intensity 越界 [0, 1] 时构造器抛错
- GLSL 着色器通过 `u_texelSize` uniform 将偏移量转为纹素单位
- `setUniforms` 注入三个运行时可变参数

## 测试结果

- `chromatic-aberration-pass.test.ts`：11/11 通过
- 全量单元测试：1661/1661 通过（116 个测试文件）
- Vignette / Tonemap / Bloom 三个已有 Pass 测试无回归
- 视觉回归测试：12/12 通过（0 px diff）

close #290