### PR TITLE
feat: 实现 PixelatePass 像素化后处理 (#292)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -662,3 +662,49 @@ void main() {
     if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
   }
 }
+/* ── PixelateOptions ── */
+
+export interface PixelateOptions {
+  /** 像素块大小（单位：屏幕像素），默认 8，最小 1 */
+  pixelSize?: number;
+}
+
+/** 像素化后处理：将屏幕划分为像素网格，每格统一采样，模拟复古像素游戏视觉 */
+export class PixelatePass implements EffectPass {
+  readonly name = 'pixelate';
+  enabled = true;
+  pixelSize: number;
+
+  constructor(options?: PixelateOptions) {
+    const pixelSize = options?.pixelSize ?? 8;
+
+    if (!Number.isFinite(pixelSize)) {
+      throw new Error(`PixelatePass: pixelSize (${pixelSize}) 必须是有限数值`);
+    }
+    if (pixelSize < 1) {
+      throw new Error(`PixelatePass: pixelSize (${pixelSize}) 必须 >= 1`);
+    }
+
+    this.pixelSize = pixelSize;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_pixelSize;
+uniform vec2 u_texelSize;
+varying vec2 v_texCoord;
+void main() {
+  vec2 g = u_pixelSize * u_texelSize;
+  vec2 q = floor(v_texCoord / g) * g + g * 0.5;
+  gl_FragColor = texture2D(u_texture, q);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uPixelSize = gl.getUniformLocation(program, 'u_pixelSize');
+    if (uPixelSize) gl.uniform1f(uPixelSize, this.pixelSize);
+  }
+}

--- a/test/unit/renderer/pixelate-pass.test.ts
+++ b/test/unit/renderer/pixelate-pass.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { PixelatePass, PostProcessor } from '../../../src/renderer/post-process';
+
+describe('PixelatePass', () => {
+  it('默认参数：pixelSize=8', () => {
+    const p = new PixelatePass();
+    expect(p.pixelSize).toBe(8);
+  });
+
+  it('可自定义 pixelSize', () => {
+    const p = new PixelatePass({ pixelSize: 16 });
+    expect(p.pixelSize).toBe(16);
+  });
+
+  it('name 固定为 pixelate', () => {
+    expect(new PixelatePass().name).toBe('pixelate');
+  });
+
+  it('enabled 默认 true，可设置', () => {
+    const p = new PixelatePass();
+    expect(p.enabled).toBe(true);
+    p.enabled = false;
+    expect(p.enabled).toBe(false);
+  });
+
+  it('pixelSize < 1 抛错', () => {
+    expect(() => new PixelatePass({ pixelSize: 0 })).toThrow();
+    expect(() => new PixelatePass({ pixelSize: 0.5 })).toThrow();
+    expect(() => new PixelatePass({ pixelSize: -5 })).toThrow();
+  });
+
+  it('pixelSize=1 边界值合法', () => {
+    expect(() => new PixelatePass({ pixelSize: 1 })).not.toThrow();
+  });
+
+  it('非 finite 参数抛错', () => {
+    expect(() => new PixelatePass({ pixelSize: Number.NaN })).toThrow();
+    expect(() => new PixelatePass({ pixelSize: Number.POSITIVE_INFINITY })).toThrow();
+  });
+
+  it('pixelSize 运行时可写', () => {
+    const p = new PixelatePass();
+    p.pixelSize = 32;
+    expect(p.pixelSize).toBe(32);
+  });
+
+  it('getFragmentShader 返回含 u_texture/u_pixelSize/u_texelSize 的 GLSL', () => {
+    const src = new PixelatePass().getFragmentShader();
+    expect(src).toContain('u_texture');
+    expect(src).toContain('u_pixelSize');
+    expect(src).toContain('u_texelSize');
+    expect(src).toContain('varying vec2 v_texCoord');
+    expect(src).toMatch(/texture2D\s*\(/);
+    // 量化必须用 floor
+    expect(src).toMatch(/floor/);
+  });
+
+  it('可接入 PostProcessor', () => {
+    const pp = new PostProcessor({ width: 256, height: 256 });
+    const pass = new PixelatePass();
+    pp.addPass(pass);
+    expect(pp.passes).toContain(pass);
+    expect(pp.passes.find(p => p.name === 'pixelate')).toBe(pass);
+  });
+});


### PR DESCRIPTION
## 变更内容

在 `src/renderer/post-process.ts` 中新增 `PixelatePass`，实现像素化后处理效果。

## 实现要点

- 沿用 EffectPass 接口 + options 风格（与 VignettePass / FilmGrainPass 一致）
- GLSL `floor(uv / (pixelSize * texelSize)) * pixelSize * texelSize + 0.5 * pixelSize * texelSize` 量化 UV 到像素网格中心
- 构造器校验：非 finite 值、pixelSize < 1 均抛错
- `u_texelSize` 由 PostProcessor 每帧注入（与 BloomPass / ChromaticAberrationPass / VignettePass 约定一致）

## 背景

**Architect 补救说明**：Forge-2 已完成 PixelatePass 的实现与测试文件创建，但其会话 shell 进程 cwd 指向已清理的 #291 worktree，无法执行 commit/push/开 PR。Architect 介入验证代码（10/10 pixelate tests pass + 590/590 renderer tests 全绿）、手工 rebase 解决 post-process.ts 冲突（保留 FilmGrainPass + ChromaticAberrationPass + PixelatePass 三者）、push + 开 PR。

## 测试

- 10/10 `test/unit/renderer/pixelate-pass.test.ts` 通过
- 590/590 `test/unit/renderer/` 全回归通过

Fixes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)