### PR TITLE
feat: 实现 OutlinePass Sobel 边缘检测描边后处理 (Phase 39)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -817,3 +817,90 @@ void main() {
     if (uTexelSize) gl.uniform2f(uTexelSize, this.texelSize[0], this.texelSize[1]);
   }
 }
+
+/* ── OutlineOptions ── */
+
+export interface OutlineOptions {
+  /** 描边颜色 RGB，默认 [0, 0, 0]（黑色） */
+  color?: [number, number, number];
+  /** 描边粗细（采样步长倍数），范围 [0.5, 3]，默认 1.0 */
+  thickness?: number;
+  /** 亮度差异阈值 [0, 1]，超过该阈值判定为边缘，默认 0.1 */
+  threshold?: number;
+}
+
+/** Sobel 边缘检测描边后处理：基于亮度梯度识别边缘并叠加描边色 */
+export class OutlinePass implements EffectPass {
+  readonly name = 'outline';
+  enabled = true;
+  color: [number, number, number];
+  thickness: number;
+  threshold: number;
+  texelSize: [number, number] = [0, 0];
+
+  constructor(options?: OutlineOptions) {
+    const color = options?.color ?? [0, 0, 0];
+    const thickness = options?.thickness ?? 1.0;
+    const threshold = options?.threshold ?? 0.1;
+
+    if (color.length !== 3) {
+      throw new Error(`OutlinePass: color 必须是长度为 3 的数组`);
+    }
+    if (thickness < 0.5 || thickness > 3) {
+      throw new Error(`OutlinePass: thickness (${thickness}) 必须在 [0.5, 3] 范围内`);
+    }
+    if (threshold < 0 || threshold > 1) {
+      throw new Error(`OutlinePass: threshold (${threshold}) 必须在 [0, 1] 范围内`);
+    }
+
+    this.color = color;
+    this.thickness = thickness;
+    this.threshold = threshold;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform vec2 u_texelSize;
+uniform vec3 u_outlineColor;
+uniform float u_thickness;
+uniform float u_threshold;
+varying vec2 v_texCoord;
+float luma(vec3 c) {
+  return dot(c, vec3(0.299, 0.587, 0.114));
+}
+void main() {
+  vec2 step = u_texelSize * u_thickness;
+  float tl = luma(texture2D(u_texture, v_texCoord + vec2(-step.x,  step.y)).rgb);
+  float tc = luma(texture2D(u_texture, v_texCoord + vec2(     0.0,  step.y)).rgb);
+  float tr = luma(texture2D(u_texture, v_texCoord + vec2( step.x,  step.y)).rgb);
+  float ml = luma(texture2D(u_texture, v_texCoord + vec2(-step.x,      0.0)).rgb);
+  float mr = luma(texture2D(u_texture, v_texCoord + vec2( step.x,      0.0)).rgb);
+  float bl = luma(texture2D(u_texture, v_texCoord + vec2(-step.x, -step.y)).rgb);
+  float bc = luma(texture2D(u_texture, v_texCoord + vec2(     0.0, -step.y)).rgb);
+  float br = luma(texture2D(u_texture, v_texCoord + vec2( step.x, -step.y)).rgb);
+  float gx = -tl - 2.0 * ml - bl + tr + 2.0 * mr + br;
+  float gy = -tl - 2.0 * tc - tr + bl + 2.0 * bc + br;
+  float gradient = sqrt(gx * gx + gy * gy);
+  vec4 base = texture2D(u_texture, v_texCoord);
+  if (gradient > u_threshold) {
+    gl_FragColor = vec4(u_outlineColor, base.a);
+  } else {
+    gl_FragColor = base;
+  }
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uColor = gl.getUniformLocation(program, 'u_outlineColor');
+    if (uColor) gl.uniform3f(uColor, this.color[0], this.color[1], this.color[2]);
+    const uThickness = gl.getUniformLocation(program, 'u_thickness');
+    if (uThickness) gl.uniform1f(uThickness, this.thickness);
+    const uThreshold = gl.getUniformLocation(program, 'u_threshold');
+    if (uThreshold) gl.uniform1f(uThreshold, this.threshold);
+    const uTexelSize = gl.getUniformLocation(program, 'u_texelSize');
+    if (uTexelSize) gl.uniform2f(uTexelSize, this.texelSize[0], this.texelSize[1]);
+  }
+}

--- a/test/unit/renderer/outline-pass.test.ts
+++ b/test/unit/renderer/outline-pass.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { OutlinePass } from '../../../src/renderer/post-process';
+
+describe('OutlinePass', () => {
+  describe('constructor', () => {
+    it('should default color to [0,0,0], thickness to 1.0, threshold to 0.1', () => {
+      const pass = new OutlinePass();
+      expect(pass.color).toEqual([0, 0, 0]);
+      expect(pass.thickness).toBe(1.0);
+      expect(pass.threshold).toBe(0.1);
+    });
+
+    it('should accept custom options', () => {
+      const pass = new OutlinePass({ color: [1, 0.5, 0], thickness: 2.0, threshold: 0.3 });
+      expect(pass.color).toEqual([1, 0.5, 0]);
+      expect(pass.thickness).toBe(2.0);
+      expect(pass.threshold).toBe(0.3);
+    });
+
+    it('should throw on thickness out of [0.5, 3]', () => {
+      expect(() => new OutlinePass({ thickness: 0.1 })).toThrow(/thickness/);
+      expect(() => new OutlinePass({ thickness: 5 })).toThrow(/thickness/);
+    });
+
+    it('should throw on threshold out of [0, 1]', () => {
+      expect(() => new OutlinePass({ threshold: -0.1 })).toThrow(/threshold/);
+      expect(() => new OutlinePass({ threshold: 1.5 })).toThrow(/threshold/);
+    });
+
+    it('should throw on color not length 3', () => {
+      expect(() => new OutlinePass({ color: [1, 0] as any })).toThrow(/color/);
+    });
+  });
+
+  describe('identity', () => {
+    it('should have name "outline" and enabled=true by default', () => {
+      const pass = new OutlinePass();
+      expect(pass.name).toBe('outline');
+      expect(pass.enabled).toBe(true);
+    });
+  });
+
+  describe('getFragmentShader', () => {
+    it('should return non-empty GLSL string', () => {
+      const pass = new OutlinePass();
+      const shader = pass.getFragmentShader();
+      expect(shader.length).toBeGreaterThan(0);
+    });
+
+    it('should reference u_texture, u_texelSize, u_outlineColor, u_thickness, u_threshold', () => {
+      const pass = new OutlinePass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('u_texture');
+      expect(shader).toContain('u_texelSize');
+      expect(shader).toContain('u_outlineColor');
+      expect(shader).toContain('u_thickness');
+      expect(shader).toContain('u_threshold');
+    });
+
+    it('should compute luma via dot with 0.299/0.587/0.114 (for edge detection)', () => {
+      const pass = new OutlinePass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toMatch(/0\.299|0\.587|0\.114/);
+    });
+  });
+
+  describe('texelSize', () => {
+    it('should default to [0, 0] and allow external mutation', () => {
+      const pass = new OutlinePass();
+      expect(pass.texelSize).toEqual([0, 0]);
+      pass.texelSize = [1 / 640, 1 / 480];
+      expect(pass.texelSize).toEqual([1 / 640, 1 / 480]);
+    });
+  });
+});


### PR DESCRIPTION
## 概述

实现 `OutlinePass` — 基于 Sobel 算子的屏幕空间边缘检测描边后处理，新增至 `src/renderer/post-process.ts`。

## 实现要点

- **Sobel 3×3 kernel**：对亮度图（`dot(rgb, vec3(0.299, 0.587, 0.114))`）计算 Gx/Gy 梯度
- **边缘判断**：`gradient = sqrt(Gx² + Gy²) > threshold` → 输出 `u_outlineColor`；否则透传原色
- **采样步长**：`u_texelSize * u_thickness`，支持粗细调节
- **参数校验**：`thickness ∈ [0.5, 3]`，`threshold ∈ [0, 1]`，`color` 长度必须为 3

## 测试结果

- `test/unit/renderer/outline-pass.test.ts`：**10/10 通过**
- 全量单元测试：**1692/1692 通过**（119 个文件）

## 变更文件

- `src/renderer/post-process.ts` — 新增 `OutlineOptions` 接口 + `OutlinePass` 类
- `test/unit/renderer/outline-pass.test.ts` — 新增 10 个测试用例（类型 B，从 Issue body 复制）

close #297