### PR TITLE
feat: 实现 FXAAPass 快速近似抗锯齿后处理 (Phase 39)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -708,3 +708,112 @@ void main() {
     if (uPixelSize) gl.uniform1f(uPixelSize, this.pixelSize);
   }
 }
+
+/* ── FXAAOptions ── */
+
+export interface FXAAOptions {
+  /** 像素亮度对比阈值，默认 0.0625（建议 0.0313-0.0833） */
+  edgeThreshold?: number;
+  /** 最小边缘对比度阈值（绝对值），默认 0.0312 */
+  edgeThresholdMin?: number;
+  /** 子像素抗锯齿强度 [0, 1]，默认 0.75 */
+  subpixelQuality?: number;
+}
+
+/** 快速近似抗锯齿（Timothy Lottes FXAA 3.11 简化版）：基于亮度对比消除锯齿边缘 */
+export class FXAAPass implements EffectPass {
+  readonly name = 'fxaa';
+  enabled = true;
+  edgeThreshold: number;
+  edgeThresholdMin: number;
+  subpixelQuality: number;
+  texelSize: [number, number] = [0, 0];
+
+  constructor(options?: FXAAOptions) {
+    const edgeThreshold = options?.edgeThreshold ?? 0.0625;
+    const edgeThresholdMin = options?.edgeThresholdMin ?? 0.0312;
+    const subpixelQuality = options?.subpixelQuality ?? 0.75;
+
+    if (edgeThreshold < 0 || edgeThreshold > 1) {
+      throw new Error(`FXAAPass: edgeThreshold (${edgeThreshold}) 必须在 [0, 1] 范围内`);
+    }
+    if (edgeThresholdMin < 0) {
+      throw new Error(`FXAAPass: edgeThresholdMin (${edgeThresholdMin}) 不能为负数`);
+    }
+    if (subpixelQuality < 0 || subpixelQuality > 1) {
+      throw new Error(`FXAAPass: subpixelQuality (${subpixelQuality}) 必须在 [0, 1] 范围内`);
+    }
+
+    this.edgeThreshold = edgeThreshold;
+    this.edgeThresholdMin = edgeThresholdMin;
+    this.subpixelQuality = subpixelQuality;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform vec2 u_texelSize;
+uniform float u_edgeThreshold;
+uniform float u_edgeThresholdMin;
+uniform float u_subpixelQuality;
+varying vec2 v_texCoord;
+
+float luma(vec3 rgb) {
+  return dot(rgb, vec3(0.299, 0.587, 0.114));
+}
+
+void main() {
+  vec2 uv = v_texCoord;
+  vec3 colorC = texture2D(u_texture, uv).rgb;
+  float lumaC = luma(colorC);
+
+  float lumaN = luma(texture2D(u_texture, uv + vec2( 0.0,  u_texelSize.y)).rgb);
+  float lumaS = luma(texture2D(u_texture, uv + vec2( 0.0, -u_texelSize.y)).rgb);
+  float lumaE = luma(texture2D(u_texture, uv + vec2( u_texelSize.x,  0.0)).rgb);
+  float lumaW = luma(texture2D(u_texture, uv + vec2(-u_texelSize.x,  0.0)).rgb);
+
+  float lumaMax = max(max(lumaN, lumaS), max(lumaE, max(lumaW, lumaC)));
+  float lumaMin = min(min(lumaN, lumaS), min(lumaE, min(lumaW, lumaC)));
+  float lumaRange = lumaMax - lumaMin;
+
+  // 未达到阈值，直接输出原色
+  if (lumaRange < max(u_edgeThresholdMin, lumaMax * u_edgeThreshold)) {
+    gl_FragColor = vec4(colorC, 1.0);
+    return;
+  }
+
+  // 水平 / 垂直梯度判断主方向
+  float gradH = abs(lumaN - lumaS);
+  float gradV = abs(lumaE - lumaW);
+  bool isHorizontal = gradH >= gradV;
+
+  vec2 stepDir = isHorizontal ? vec2(0.0, u_texelSize.y) : vec2(u_texelSize.x, 0.0);
+  float lumaA = isHorizontal ? lumaN : lumaE;
+  float lumaB = isHorizontal ? lumaS : lumaW;
+  float gradA = abs(lumaA - lumaC);
+  float gradB = abs(lumaB - lumaC);
+  if (gradA < gradB) stepDir = -stepDir;
+
+  // 子像素混合
+  float lumaAvg = (lumaN + lumaS + lumaE + lumaW) * 0.25;
+  float subpixelBlend = clamp(abs(lumaAvg - lumaC) / lumaRange, 0.0, 1.0);
+  subpixelBlend = subpixelBlend * subpixelBlend * u_subpixelQuality;
+
+  vec3 colorBlend = texture2D(u_texture, uv + stepDir * 0.5).rgb;
+  gl_FragColor = vec4(mix(colorC, colorBlend, subpixelBlend), 1.0);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uEdgeThreshold = gl.getUniformLocation(program, 'u_edgeThreshold');
+    if (uEdgeThreshold) gl.uniform1f(uEdgeThreshold, this.edgeThreshold);
+    const uEdgeThresholdMin = gl.getUniformLocation(program, 'u_edgeThresholdMin');
+    if (uEdgeThresholdMin) gl.uniform1f(uEdgeThresholdMin, this.edgeThresholdMin);
+    const uSubpixelQuality = gl.getUniformLocation(program, 'u_subpixelQuality');
+    if (uSubpixelQuality) gl.uniform1f(uSubpixelQuality, this.subpixelQuality);
+    const uTexelSize = gl.getUniformLocation(program, 'u_texelSize');
+    if (uTexelSize) gl.uniform2f(uTexelSize, this.texelSize[0], this.texelSize[1]);
+  }
+}

--- a/test/unit/renderer/fxaa-pass.test.ts
+++ b/test/unit/renderer/fxaa-pass.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { FXAAPass } from '../../../src/renderer/post-process';
+
+describe('FXAAPass', () => {
+  describe('constructor', () => {
+    it('should default edgeThreshold to 0.0625, edgeThresholdMin to 0.0312, subpixelQuality to 0.75', () => {
+      const pass = new FXAAPass();
+      expect(pass.edgeThreshold).toBe(0.0625);
+      expect(pass.edgeThresholdMin).toBe(0.0312);
+      expect(pass.subpixelQuality).toBe(0.75);
+    });
+
+    it('should accept custom options', () => {
+      const pass = new FXAAPass({ edgeThreshold: 0.125, edgeThresholdMin: 0.05, subpixelQuality: 1.0 });
+      expect(pass.edgeThreshold).toBe(0.125);
+      expect(pass.edgeThresholdMin).toBe(0.05);
+      expect(pass.subpixelQuality).toBe(1.0);
+    });
+
+    it('should throw on edgeThreshold out of [0, 1]', () => {
+      expect(() => new FXAAPass({ edgeThreshold: -0.1 })).toThrow(/edgeThreshold/);
+      expect(() => new FXAAPass({ edgeThreshold: 1.5 })).toThrow(/edgeThreshold/);
+    });
+
+    it('should throw on subpixelQuality out of [0, 1]', () => {
+      expect(() => new FXAAPass({ subpixelQuality: -0.1 })).toThrow(/subpixelQuality/);
+      expect(() => new FXAAPass({ subpixelQuality: 1.5 })).toThrow(/subpixelQuality/);
+    });
+
+    it('should throw on edgeThresholdMin negative', () => {
+      expect(() => new FXAAPass({ edgeThresholdMin: -0.1 })).toThrow(/edgeThresholdMin/);
+    });
+  });
+
+  describe('identity', () => {
+    it('should have name "fxaa" and enabled=true by default', () => {
+      const pass = new FXAAPass();
+      expect(pass.name).toBe('fxaa');
+      expect(pass.enabled).toBe(true);
+    });
+  });
+
+  describe('getFragmentShader', () => {
+    it('should return non-empty GLSL string', () => {
+      const pass = new FXAAPass();
+      const shader = pass.getFragmentShader();
+      expect(shader.length).toBeGreaterThan(0);
+    });
+
+    it('should reference u_texture, u_texelSize and v_texCoord', () => {
+      const pass = new FXAAPass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('u_texture');
+      expect(shader).toContain('u_texelSize');
+      expect(shader).toContain('v_texCoord');
+    });
+
+    it('should compute luma via dot product with 0.299/0.587/0.114', () => {
+      const pass = new FXAAPass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toMatch(/0\.299|0\.587|0\.114/);
+    });
+  });
+
+  describe('texelSize', () => {
+    it('should default to [0, 0] and allow external mutation', () => {
+      const pass = new FXAAPass();
+      expect(pass.texelSize).toEqual([0, 0]);
+      pass.texelSize = [1 / 800, 1 / 600];
+      expect(pass.texelSize).toEqual([1 / 800, 1 / 600]);
+    });
+  });
+});


### PR DESCRIPTION
## 概述

在 `src/renderer/post-process.ts` 中新增 **FXAAPass**，基于 Timothy Lottes FXAA 3.11 简化版实现快速近似抗锯齿后处理。

## 变更内容

- `src/renderer/post-process.ts` — 新增 `FXAAOptions` 接口 + `FXAAPass` 类
- `test/unit/renderer/fxaa-pass.test.ts` — 10 个单元测试（Type B，随分支提交）

## 实现细节

- **luma 计算**：`dot(rgb, vec3(0.299, 0.587, 0.114))`
- **边缘检测**：采样 N/S/E/W 4 方向邻居，计算 luma range 与阈值对比
- **方向判断**：水平/垂直梯度比较决定混合方向
- **子像素混合**：基于 subpixelQuality 控制抗锯齿强度
- **texelSize**：公开字段，由 PostProcessor 外部注入（参照 BloomPass 约定）

## 测试结果

```
✓ test/unit/renderer/fxaa-pass.test.ts (10 tests)
Test Files: 119 passed | Tests: 1692 passed
```

close #296