### PR TITLE
feat: 实现 SharpenPass Laplacian 锐化后处理 (Phase 39)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -904,3 +904,56 @@ void main() {
     if (uTexelSize) gl.uniform2f(uTexelSize, this.texelSize[0], this.texelSize[1]);
   }
 }
+
+/* ── SharpenOptions ── */
+
+export interface SharpenOptions {
+  /** 锐化强度 [0, 1]，默认 0.5。0 = 无锐化（原图），1 = 强锐化 */
+  intensity?: number;
+}
+
+/** Laplacian 5-tap cross kernel 锐化后处理：提升图像细节清晰度 */
+export class SharpenPass implements EffectPass {
+  readonly name = 'sharpen';
+  enabled = true;
+  intensity: number;
+  texelSize: [number, number] = [0, 0];
+
+  constructor(options?: SharpenOptions) {
+    const intensity = options?.intensity ?? 0.5;
+
+    if (intensity < 0 || intensity > 1) {
+      throw new Error(`SharpenPass: intensity (${intensity}) 必须在 [0, 1] 范围内`);
+    }
+
+    this.intensity = intensity;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform vec2 u_texelSize;
+uniform float u_intensity;
+varying vec2 v_texCoord;
+void main() {
+  vec4 center = texture2D(u_texture, v_texCoord);
+  vec4 north  = texture2D(u_texture, v_texCoord + vec2( 0.0,  u_texelSize.y));
+  vec4 south  = texture2D(u_texture, v_texCoord + vec2( 0.0, -u_texelSize.y));
+  vec4 east   = texture2D(u_texture, v_texCoord + vec2( u_texelSize.x,  0.0));
+  vec4 west   = texture2D(u_texture, v_texCoord + vec2(-u_texelSize.x,  0.0));
+  // Laplacian 5-tap cross kernel: center + intensity * (5.0*center - N - S - E - W)
+  vec4 laplacian = 5.0 * center - north - south - east - west;
+  vec4 sharpened = center + u_intensity * laplacian;
+  gl_FragColor = vec4(clamp(sharpened.rgb, 0.0, 1.0), center.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uIntensity = gl.getUniformLocation(program, 'u_intensity');
+    if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
+    const uTexelSize = gl.getUniformLocation(program, 'u_texelSize');
+    if (uTexelSize) gl.uniform2f(uTexelSize, this.texelSize[0], this.texelSize[1]);
+  }
+}

--- a/test/unit/renderer/sharpen-pass.test.ts
+++ b/test/unit/renderer/sharpen-pass.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { SharpenPass } from '../../../src/renderer/post-process';
+
+describe('SharpenPass', () => {
+  describe('constructor', () => {
+    it('should default intensity to 0.5', () => {
+      const pass = new SharpenPass();
+      expect(pass.intensity).toBe(0.5);
+    });
+
+    it('should accept custom intensity option', () => {
+      const pass = new SharpenPass({ intensity: 0.8 });
+      expect(pass.intensity).toBe(0.8);
+    });
+
+    it('should accept intensity=0 (no sharpen)', () => {
+      const pass = new SharpenPass({ intensity: 0 });
+      expect(pass.intensity).toBe(0);
+    });
+
+    it('should accept intensity=1 (max sharpen)', () => {
+      const pass = new SharpenPass({ intensity: 1 });
+      expect(pass.intensity).toBe(1);
+    });
+
+    it('should throw on intensity negative', () => {
+      expect(() => new SharpenPass({ intensity: -0.1 })).toThrow(/intensity/);
+    });
+
+    it('should throw on intensity > 1', () => {
+      expect(() => new SharpenPass({ intensity: 1.5 })).toThrow(/intensity/);
+    });
+  });
+
+  describe('identity', () => {
+    it('should have name "sharpen" and enabled=true by default', () => {
+      const pass = new SharpenPass();
+      expect(pass.name).toBe('sharpen');
+      expect(pass.enabled).toBe(true);
+    });
+  });
+
+  describe('getFragmentShader', () => {
+    it('should return non-empty GLSL string', () => {
+      const pass = new SharpenPass();
+      const shader = pass.getFragmentShader();
+      expect(shader.length).toBeGreaterThan(0);
+    });
+
+    it('should reference u_texture, u_texelSize, u_intensity and v_texCoord', () => {
+      const pass = new SharpenPass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('u_texture');
+      expect(shader).toContain('u_texelSize');
+      expect(shader).toContain('u_intensity');
+      expect(shader).toContain('v_texCoord');
+    });
+
+    it('should contain Laplacian kernel (5.0 center + 4 neighbors subtraction)', () => {
+      const pass = new SharpenPass();
+      const shader = pass.getFragmentShader();
+      // 5-tap cross kernel 应含 5.0 系数或等价形式
+      expect(shader).toMatch(/5\.0|4\.0/);
+    });
+  });
+
+  describe('texelSize', () => {
+    it('should default to [0, 0] and allow external mutation', () => {
+      const pass = new SharpenPass();
+      expect(pass.texelSize).toEqual([0, 0]);
+      pass.texelSize = [1 / 1920, 1 / 1080];
+      expect(pass.texelSize).toEqual([1 / 1920, 1 / 1080]);
+    });
+  });
+});


### PR DESCRIPTION
## 摘要

Phase 39 第三个 KR — **SharpenPass** Laplacian 锐化后处理。

基于 5-tap cross kernel Laplacian 算法实现屏幕空间锐化：

```glsl
vec3 center = texture2D(u_tex, v_uv).rgb;
vec3 north  = texture2D(u_tex, v_uv + vec2(0.0, u_texelSize.y)).rgb;
vec3 south  = texture2D(u_tex, v_uv - vec2(0.0, u_texelSize.y)).rgb;
vec3 east   = texture2D(u_tex, v_uv + vec2(u_texelSize.x, 0.0)).rgb;
vec3 west   = texture2D(u_tex, v_uv - vec2(u_texelSize.x, 0.0)).rgb;
vec3 result = center + u_intensity * (5.0 * center - north - south - east - west);
```

## API

\`\`\`ts
new SharpenPass({ intensity: 0.5 })
\`\`\`

- **intensity** [0, 1]: 锐化强度，0=无效果，1=最强
- 构造器对 intensity 越界抛错
- u_texelSize uniform 由 PostProcessor 外部注入（约定已在 BloomPass 建立）

## 测试

- ✅ 11 tests passed (\`test/unit/renderer/sharpen-pass.test.ts\`)
- ✅ 601/601 renderer regression tests passed
- ✅ 零回归

## ⚠️ 介入说明

本 PR 由 **Architect 代 Forge-1 push 提交**。Forge-1 已在 worktree 完整写出 SharpenPass 实现
（src/renderer/post-process.ts +53 行）+ 测试文件（test/unit/renderer/sharpen-pass.test.ts），
代码质量 OK，但 tmux session 的 shell cwd 指向已清理的 issue-296 worktree
（Phase 38 known framework CWD invalidation bug），所有 Bash 命令被拦截 "Working directory no longer exists"。

Architect 按 Phase 38 PR #295 介入模式接力：
1. 切换到 worktree \`active/lucid-3d--issue-298\`
2. \`pnpm exec vitest run test/unit/renderer/sharpen-pass.test.ts\` → 11/11 ✅
3. \`pnpm exec vitest run test/unit/renderer/\` → 601/601 ✅
4. 代 Forge-1 commit + push + 开 PR

代码完全为 Forge-1 原作，Architect 仅做 merge 调解。

Closes #298