### PR TITLE
feat: 实现 SepiaPass 复古棕褐色调色后处理

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -957,3 +957,50 @@ void main() {
     if (uTexelSize) gl.uniform2f(uTexelSize, this.texelSize[0], this.texelSize[1]);
   }
 }
+
+/* ── SepiaOptions ── */
+
+export interface SepiaOptions {
+  /** 强度 [0, 1]，0 = 原色, 1 = 完全 sepia，默认 1.0 */
+  intensity?: number;
+}
+
+/** 复古棕褐色调色后处理：经典 sepia 矩阵变换，用 mix 融合原色与 sepia 色 */
+export class SepiaPass implements EffectPass {
+  readonly name = 'sepia';
+  enabled = true;
+  intensity: number;
+
+  constructor(options?: SepiaOptions) {
+    const intensity = options?.intensity ?? 1.0;
+
+    if (intensity < 0 || intensity > 1) {
+      throw new Error(`SepiaPass: intensity (${intensity}) 必须在 [0, 1] 范围内`);
+    }
+
+    this.intensity = intensity;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_intensity;
+varying vec2 v_texCoord;
+void main() {
+  vec4 col = texture2D(u_texture, v_texCoord);
+  float r = dot(col.rgb, vec3(0.393, 0.769, 0.189));
+  float g = dot(col.rgb, vec3(0.349, 0.686, 0.168));
+  float b = dot(col.rgb, vec3(0.272, 0.534, 0.131));
+  vec3 sepia = vec3(r, g, b);
+  vec3 final = mix(col.rgb, sepia, u_intensity);
+  gl_FragColor = vec4(final, col.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uIntensity = gl.getUniformLocation(program, 'u_intensity');
+    if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
+  }
+}

--- a/test/unit/renderer/sepia-pass.test.ts
+++ b/test/unit/renderer/sepia-pass.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { SepiaPass } from '../../../src/renderer/post-process';
+
+describe('SepiaPass', () => {
+  it('默认构造 intensity=1.0, enabled=true, name=sepia', () => {
+    const pass = new SepiaPass();
+    expect(pass.intensity).toBe(1.0);
+    expect(pass.enabled).toBe(true);
+    expect(pass.name).toBe('sepia');
+  });
+
+  it('构造器可传入自定义 intensity', () => {
+    const pass = new SepiaPass({ intensity: 0.5 });
+    expect(pass.intensity).toBe(0.5);
+  });
+
+  it('intensity < 0 抛错', () => {
+    expect(() => new SepiaPass({ intensity: -0.1 })).toThrow();
+  });
+
+  it('intensity > 1 抛错', () => {
+    expect(() => new SepiaPass({ intensity: 1.5 })).toThrow();
+  });
+
+  it('intensity 边界 0 和 1 合法', () => {
+    expect(() => new SepiaPass({ intensity: 0 })).not.toThrow();
+    expect(() => new SepiaPass({ intensity: 1 })).not.toThrow();
+  });
+
+  it('getFragmentShader 返回包含 sepia 矩阵常量的 GLSL', () => {
+    const pass = new SepiaPass();
+    const shader = pass.getFragmentShader();
+    expect(shader).toContain('0.393');
+    expect(shader).toContain('0.769');
+    expect(shader).toContain('u_intensity');
+    expect(shader).toContain('u_texture');
+    expect(shader).toContain('v_texCoord');
+  });
+
+  it('getFragmentShader 用 mix 融合原色和 sepia', () => {
+    const pass = new SepiaPass();
+    expect(pass.getFragmentShader()).toContain('mix');
+  });
+
+  it('enabled 可切换为 false', () => {
+    const pass = new SepiaPass();
+    pass.enabled = false;
+    expect(pass.enabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概述

实现 Issue #302 要求的 SepiaPass 后处理效果。

- 新增 `SepiaOptions` 接口（`intensity?: number`）
- 新增 `SepiaPass implements EffectPass`，使用标准 sepia 矩阵变换
- `intensity` 范围 [0, 1] 边界校验，越界抛错
- `mix(col.rgb, sepia, u_intensity)` 融合原色与 sepia 色

## 测试

8 个单元测试全绿，renderer 目录 629 个测试零回归：

```
pnpm exec vitest run test/unit/renderer/sepia-pass.test.ts  → 8/8 passed
pnpm exec vitest run test/unit/renderer/                    → 629/629 passed
```

close #302