### PR TITLE
feat: 实现 ContrastPass 对比度调整后处理 (#304)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1049,3 +1049,57 @@ void main() {
     if (uSaturation) gl.uniform1f(uSaturation, this.saturation);
   }
 }
+
+/* ── ContrastOptions ── */
+
+export interface ContrastOptions {
+  /** 对比度乘子 [0, 3]，1=原图（默认），<1 降低对比，>1 增加对比 */
+  contrast?: number;
+  /** 对比度中心（灰度参考点）[0, 1]，默认 0.5 */
+  midpoint?: number;
+}
+
+/** 围绕 midpoint 缩放的对比度调整后处理 */
+export class ContrastPass implements EffectPass {
+  readonly name = 'contrast';
+  enabled = true;
+  contrast: number;
+  midpoint: number;
+
+  constructor(options?: ContrastOptions) {
+    const contrast = options?.contrast ?? 1.0;
+    const midpoint = options?.midpoint ?? 0.5;
+
+    if (contrast < 0 || contrast > 3) {
+      throw new Error(`ContrastPass: contrast (${contrast}) 必须在 [0, 3] 范围内`);
+    }
+    if (midpoint < 0 || midpoint > 1) {
+      throw new Error(`ContrastPass: midpoint (${midpoint}) 必须在 [0, 1] 范围内`);
+    }
+
+    this.contrast = contrast;
+    this.midpoint = midpoint;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_contrast;
+uniform float u_midpoint;
+varying vec2 v_texCoord;
+void main() {
+  vec4 col = texture2D(u_texture, v_texCoord);
+  vec3 adjusted = (col.rgb - vec3(u_midpoint)) * u_contrast + vec3(u_midpoint);
+  gl_FragColor = vec4(clamp(adjusted, 0.0, 1.0), col.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uContrast = gl.getUniformLocation(program, 'u_contrast');
+    if (uContrast) gl.uniform1f(uContrast, this.contrast);
+    const uMidpoint = gl.getUniformLocation(program, 'u_midpoint');
+    if (uMidpoint) gl.uniform1f(uMidpoint, this.midpoint);
+  }
+}

--- a/test/unit/renderer/contrast-pass.test.ts
+++ b/test/unit/renderer/contrast-pass.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { ContrastPass } from '../../../src/renderer/post-process';
+
+describe('ContrastPass', () => {
+  it('默认构造 contrast=1.0, midpoint=0.5, enabled=true, name=contrast', () => {
+    const pass = new ContrastPass();
+    expect(pass.contrast).toBe(1.0);
+    expect(pass.midpoint).toBe(0.5);
+    expect(pass.enabled).toBe(true);
+    expect(pass.name).toBe('contrast');
+  });
+
+  it('构造器可传入自定义 contrast', () => {
+    const pass = new ContrastPass({ contrast: 1.5 });
+    expect(pass.contrast).toBe(1.5);
+  });
+
+  it('构造器可传入自定义 midpoint', () => {
+    const pass = new ContrastPass({ midpoint: 0.3 });
+    expect(pass.midpoint).toBe(0.3);
+  });
+
+  it('contrast < 0 抛错', () => {
+    expect(() => new ContrastPass({ contrast: -0.1 })).toThrow();
+  });
+
+  it('contrast > 3 抛错', () => {
+    expect(() => new ContrastPass({ contrast: 3.5 })).toThrow();
+  });
+
+  it('midpoint < 0 抛错', () => {
+    expect(() => new ContrastPass({ midpoint: -0.1 })).toThrow();
+  });
+
+  it('midpoint > 1 抛错', () => {
+    expect(() => new ContrastPass({ midpoint: 1.5 })).toThrow();
+  });
+
+  it('contrast 边界 0 和 3 合法', () => {
+    expect(() => new ContrastPass({ contrast: 0 })).not.toThrow();
+    expect(() => new ContrastPass({ contrast: 3 })).not.toThrow();
+  });
+
+  it('midpoint 边界 0 和 1 合法', () => {
+    expect(() => new ContrastPass({ midpoint: 0 })).not.toThrow();
+    expect(() => new ContrastPass({ midpoint: 1 })).not.toThrow();
+  });
+
+  it('getFragmentShader 返回包含 contrast/midpoint 公式的 GLSL', () => {
+    const pass = new ContrastPass();
+    const shader = pass.getFragmentShader();
+    expect(shader).toContain('u_contrast');
+    expect(shader).toContain('u_midpoint');
+    expect(shader).toContain('u_texture');
+    expect(shader).toContain('v_texCoord');
+    expect(shader).toContain('clamp');
+  });
+});


### PR DESCRIPTION
## 变更内容

在 `src/renderer/post-process.ts` 新增 **ContrastPass** — 对比度调整后处理。

### 实现细节

- `ContrastOptions` 接口：`contrast ∈ [0,3]`（默认 1.0），`midpoint ∈ [0,1]`（默认 0.5）
- GLSL 公式：`(color - midpoint) * contrast + midpoint`，contrast=1 时恒等
- 构造器边界校验，越界抛出描述性错误
- 参照 SharpenPass 模式实现 `EffectPass` 接口

## 测试

- 10 个单元测试全绿
- `pnpm exec vitest run test/unit/renderer/` 631 个测试全绿，零回归

close #304