### PR TITLE
feat: 实现 SaturationPass 饱和度调整后处理 (#303)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1004,3 +1004,48 @@ void main() {
     if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
   }
 }
+
+/* ── SaturationOptions ── */
+
+export interface SaturationOptions {
+  /** 饱和度乘子 [0, 3]，0=灰度，1=原色（默认），2=过饱和 */
+  saturation?: number;
+}
+
+/** 饱和度调整后处理：Rec. 709 luma-based desaturation，支持 0=灰度 / 1=原色 / 2=过饱和 */
+export class SaturationPass implements EffectPass {
+  readonly name = 'saturation';
+  enabled = true;
+  saturation: number;
+
+  constructor(options?: SaturationOptions) {
+    const saturation = options?.saturation ?? 1.0;
+
+    if (saturation < 0 || saturation > 3) {
+      throw new Error(`SaturationPass: saturation (${saturation}) 必须在 [0, 3] 范围内`);
+    }
+
+    this.saturation = saturation;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_saturation;
+varying vec2 v_texCoord;
+void main() {
+  vec4 col = texture2D(u_texture, v_texCoord);
+  float luma = dot(col.rgb, vec3(0.2126, 0.7152, 0.0722));
+  vec3 gray = vec3(luma);
+  vec3 final = mix(gray, col.rgb, u_saturation);
+  gl_FragColor = vec4(final, col.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uSaturation = gl.getUniformLocation(program, 'u_saturation');
+    if (uSaturation) gl.uniform1f(uSaturation, this.saturation);
+  }
+}

--- a/test/unit/renderer/saturation-pass.test.ts
+++ b/test/unit/renderer/saturation-pass.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { SaturationPass } from '../../../src/renderer/post-process';
+
+describe('SaturationPass', () => {
+  it('默认构造 saturation=1.0, enabled=true, name=saturation', () => {
+    const pass = new SaturationPass();
+    expect(pass.saturation).toBe(1.0);
+    expect(pass.enabled).toBe(true);
+    expect(pass.name).toBe('saturation');
+  });
+
+  it('构造器可传入自定义 saturation', () => {
+    const pass = new SaturationPass({ saturation: 0.5 });
+    expect(pass.saturation).toBe(0.5);
+  });
+
+  it('saturation < 0 抛错', () => {
+    expect(() => new SaturationPass({ saturation: -0.1 })).toThrow();
+  });
+
+  it('saturation > 3 抛错', () => {
+    expect(() => new SaturationPass({ saturation: 3.5 })).toThrow();
+  });
+
+  it('saturation = 0 合法（灰度）', () => {
+    expect(() => new SaturationPass({ saturation: 0 })).not.toThrow();
+  });
+
+  it('saturation = 2 合法（过饱和）', () => {
+    expect(() => new SaturationPass({ saturation: 2 })).not.toThrow();
+  });
+
+  it('getFragmentShader 返回包含 Rec. 709 luma 权重的 GLSL', () => {
+    const pass = new SaturationPass();
+    const shader = pass.getFragmentShader();
+    expect(shader).toContain('0.2126');
+    expect(shader).toContain('0.7152');
+    expect(shader).toContain('0.0722');
+    expect(shader).toContain('u_saturation');
+    expect(shader).toContain('mix');
+  });
+
+  it('enabled 可切换为 false', () => {
+    const pass = new SaturationPass();
+    pass.enabled = false;
+    expect(pass.enabled).toBe(false);
+  });
+});


### PR DESCRIPTION
close #303

## 实现概要

基于 Rec. 709 luma 权重的饱和度调整后处理 Pass（Phase 40 色彩分级三件套第二件）：

- **SaturationOptions** 接口：`saturation?: number`（默认 1.0）
- **参数语义**：saturation ∈ [0, 3]
  - 0 = 完全灰度
  - 1 = 原色（默认）
  - 2-3 = 过饱和外推
- **GLSL**：
  ```glsl
  float luma = dot(col.rgb, vec3(0.2126, 0.7152, 0.0722));
  vec3 gray = vec3(luma);
  vec3 final = mix(gray, col.rgb, u_saturation);
  ```
- **构造期校验**：saturation < 0 或 > 3 抛错
- **单元测试**：8 个（默认值/边界/越界/颜色断言）

## 测试结果

- SaturationPass 专项：8/8 ✅
- renderer 全量回归：637/637 ✅（Phase 40 两个 Pass 共存验证）

## Architect 接力说明

Forge-1 完整写出 SaturationPass 实现 + 测试，但因 framework CWD invalidation bug 被卡死（shell cwd 指向已清理的 issue-302 worktree，Bash 工具全部被拒）。延续 Phase 38 Pixelate / Phase 39 Sharpen 既定救援路径：Architect 切换到 worktree active/lucid-3d--issue-303，验证代码 + 跑测试 + rebase（解决 post-process.ts 与 main 中 Sepia 的文件级 conflict，保留 Sepia 不变 + 追加 Saturation）+ force-push + 开 PR。

Co-authored-by: Forge <forge@lucid-3d>