### PR TITLE
feat: 实现 ScanlinePass CRT 扫描线复古后处理 (#308)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1103,3 +1103,76 @@ void main() {
     if (uMidpoint) gl.uniform1f(uMidpoint, this.midpoint);
   }
 }
+
+/* ── ScanlineOptions ── */
+
+export interface ScanlineOptions {
+  /** 扫描线强度 [0, 1]，0=无效果，1=最强。默认 0.3 */
+  intensity?: number;
+  /** 扫描线密度（每像素几条线）[0.1, 10]，默认 1.0 */
+  density?: number;
+  /** 扫描线移动速度（时间相关），单位 px/s。默认 0 = 静态 */
+  speed?: number;
+  /** 当前时间（由 GameLoop 注入，用于动画）。默认 0 */
+  time?: number;
+}
+
+/** CRT 扫描线复古后处理：模拟 CRT 显示器水平扫描线，适用于复古/retro wave 风格 */
+export class ScanlinePass implements EffectPass {
+  readonly name = 'scanline';
+  enabled = true;
+  intensity: number;
+  density: number;
+  speed: number;
+  time: number;
+
+  constructor(options?: ScanlineOptions) {
+    const intensity = options?.intensity ?? 0.3;
+    const density = options?.density ?? 1.0;
+    const speed = options?.speed ?? 0;
+    const time = options?.time ?? 0;
+
+    if (intensity < 0 || intensity > 1) {
+      throw new Error(`ScanlinePass: intensity (${intensity}) 必须在 [0, 1] 范围内`);
+    }
+    if (density < 0.1 || density > 10) {
+      throw new Error(`ScanlinePass: density (${density}) 必须在 [0.1, 10] 范围内`);
+    }
+
+    this.intensity = intensity;
+    this.density = density;
+    this.speed = speed;
+    this.time = time;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_intensity;
+uniform float u_density;
+uniform float u_speed;
+uniform float u_time;
+uniform vec2 u_resolution;
+varying vec2 v_texCoord;
+void main() {
+  vec4 col = texture2D(u_texture, v_texCoord);
+  float y = gl_FragCoord.y + u_time * u_speed;
+  float line = sin(y * u_density * 3.14159265) * 0.5 + 0.5;
+  float dark = mix(1.0, line, u_intensity);
+  gl_FragColor = vec4(col.rgb * dark, col.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uIntensity = gl.getUniformLocation(program, 'u_intensity');
+    if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
+    const uDensity = gl.getUniformLocation(program, 'u_density');
+    if (uDensity) gl.uniform1f(uDensity, this.density);
+    const uSpeed = gl.getUniformLocation(program, 'u_speed');
+    if (uSpeed) gl.uniform1f(uSpeed, this.speed);
+    const uTime = gl.getUniformLocation(program, 'u_time');
+    if (uTime) gl.uniform1f(uTime, this.time);
+  }
+}

--- a/test/unit/renderer/scanline-pass.test.ts
+++ b/test/unit/renderer/scanline-pass.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { ScanlinePass } from '../../../src/renderer/post-process';
+
+describe('ScanlinePass', () => {
+  it('默认参数构造', () => {
+    const pass = new ScanlinePass();
+    expect(pass.name).toBe('scanline');
+    expect(pass.enabled).toBe(true);
+    expect(pass.intensity).toBe(0.3);
+    expect(pass.density).toBe(1.0);
+    expect(pass.speed).toBe(0);
+    expect(pass.time).toBe(0);
+  });
+
+  it('自定义参数构造', () => {
+    const pass = new ScanlinePass({ intensity: 0.5, density: 2, speed: 10, time: 1.5 });
+    expect(pass.intensity).toBe(0.5);
+    expect(pass.density).toBe(2);
+    expect(pass.speed).toBe(10);
+    expect(pass.time).toBe(1.5);
+  });
+
+  it('intensity 超出 [0, 1] 抛错', () => {
+    expect(() => new ScanlinePass({ intensity: -0.1 })).toThrow();
+    expect(() => new ScanlinePass({ intensity: 1.1 })).toThrow();
+  });
+
+  it('intensity 边界值通过', () => {
+    expect(() => new ScanlinePass({ intensity: 0 })).not.toThrow();
+    expect(() => new ScanlinePass({ intensity: 1 })).not.toThrow();
+  });
+
+  it('density 超出 [0.1, 10] 抛错', () => {
+    expect(() => new ScanlinePass({ density: 0.05 })).toThrow();
+    expect(() => new ScanlinePass({ density: 10.1 })).toThrow();
+  });
+
+  it('density 边界值通过', () => {
+    expect(() => new ScanlinePass({ density: 0.1 })).not.toThrow();
+    expect(() => new ScanlinePass({ density: 10 })).not.toThrow();
+  });
+
+  it('getFragmentShader 返回 GLSL 字符串', () => {
+    const pass = new ScanlinePass();
+    const shader = pass.getFragmentShader();
+    expect(shader).toContain('precision mediump float');
+    expect(shader).toContain('u_texture');
+    expect(shader).toContain('u_intensity');
+    expect(shader).toContain('u_density');
+    expect(shader).toContain('u_speed');
+    expect(shader).toContain('u_time');
+  });
+
+  it('可写属性被修改后生效', () => {
+    const pass = new ScanlinePass();
+    pass.intensity = 0.8;
+    pass.density = 3;
+    pass.time = 2.0;
+    expect(pass.intensity).toBe(0.8);
+    expect(pass.density).toBe(3);
+    expect(pass.time).toBe(2.0);
+  });
+
+  it('setUniforms 无 program 时不抛错', () => {
+    const pass = new ScanlinePass();
+    const mockGl = {
+      getUniformLocation: () => null,
+      uniform1f: () => {},
+    } as unknown as WebGLRenderingContext;
+    expect(() => pass.setUniforms(mockGl, {} as WebGLProgram)).not.toThrow();
+  });
+
+  it('支持 enabled 切换', () => {
+    const pass = new ScanlinePass();
+    pass.enabled = false;
+    expect(pass.enabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

新增 `ScanlinePass` — CRT 扫描线复古后处理效果。

- 在 fragment shader 中用 `sin(gl_FragCoord.y * density)` 生成水平扫描线
- 支持 `intensity` / `density` / `speed` / `time` 四参数控制外观与动画
- 构造器校验：`intensity ∈ [0, 1]`、`density ∈ [0.1, 10]`，越界抛 `Error`
- 适用于复古、retro wave、CRT 显示器、游戏机模拟器等风格化游戏

## 测试结果

- `test/unit/renderer/scanline-pass.test.ts` 10/10 全绿 ✅
- 全量测试 1749/1749 通过，零回归 ✅

close #308