### PR TITLE
feat: 实现 HueRotatePass YIQ 色相旋转后处理 (#310)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1050,6 +1050,73 @@ void main() {
   }
 }
 
+/* ── HueRotateOptions ── */
+
+export interface HueRotateOptions {
+  /** 色相旋转角度（弧度），-2π 到 2π，0 = 无变化。默认 0 */
+  angle?: number;
+  /** 饱和度保留因子 [0, 1]，控制旋转后是否保持饱和度。默认 1 */
+  saturation?: number;
+}
+
+/** HSV 色相旋转后处理：通过 YIQ 色彩空间旋转矩阵实现快速色相偏移 */
+export class HueRotatePass implements EffectPass {
+  readonly name = 'hueRotate';
+  enabled = true;
+  angle: number;
+  saturation: number;
+
+  constructor(options?: HueRotateOptions) {
+    const angle = options?.angle ?? 0;
+    const saturation = options?.saturation ?? 1;
+
+    if (angle < -Math.PI * 2 || angle > Math.PI * 2) {
+      throw new Error(`HueRotatePass: angle (${angle}) 必须在 [-2π, 2π] 范围内`);
+    }
+    if (saturation < 0 || saturation > 1) {
+      throw new Error(`HueRotatePass: saturation (${saturation}) 必须在 [0, 1] 范围内`);
+    }
+
+    this.angle = angle;
+    this.saturation = saturation;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_angle;
+uniform float u_saturation;
+varying vec2 v_texCoord;
+void main() {
+  vec4 col = texture2D(u_texture, v_texCoord);
+  float y = dot(col.rgb, vec3(0.299, 0.587, 0.114));
+  float i = dot(col.rgb, vec3(0.596, -0.274, -0.322));
+  float q = dot(col.rgb, vec3(0.211, -0.523, 0.312));
+  float c = cos(u_angle);
+  float s = sin(u_angle);
+  float iRot = c * i - s * q;
+  float qRot = s * i + c * q;
+  iRot *= u_saturation;
+  qRot *= u_saturation;
+  vec3 rgb = vec3(
+    y + 0.956 * iRot + 0.621 * qRot,
+    y - 0.272 * iRot - 0.647 * qRot,
+    y - 1.106 * iRot + 1.703 * qRot
+  );
+  gl_FragColor = vec4(clamp(rgb, 0.0, 1.0), col.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uAngle = gl.getUniformLocation(program, 'u_angle');
+    if (uAngle) gl.uniform1f(uAngle, this.angle);
+    const uSaturation = gl.getUniformLocation(program, 'u_saturation');
+    if (uSaturation) gl.uniform1f(uSaturation, this.saturation);
+  }
+}
+
 /* ── ContrastOptions ── */
 
 export interface ContrastOptions {

--- a/test/unit/renderer/hue-rotate-pass.test.ts
+++ b/test/unit/renderer/hue-rotate-pass.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { HueRotatePass } from '../../../src/renderer/post-process';
+
+describe('HueRotatePass', () => {
+  it('默认参数构造', () => {
+    const pass = new HueRotatePass();
+    expect(pass.name).toBe('hueRotate');
+    expect(pass.enabled).toBe(true);
+    expect(pass.angle).toBe(0);
+    expect(pass.saturation).toBe(1);
+  });
+
+  it('自定义参数构造', () => {
+    const pass = new HueRotatePass({ angle: Math.PI, saturation: 0.5 });
+    expect(pass.angle).toBeCloseTo(Math.PI, 5);
+    expect(pass.saturation).toBe(0.5);
+  });
+
+  it('angle 超出 [-2π, 2π] 抛错', () => {
+    expect(() => new HueRotatePass({ angle: -7 })).toThrow();
+    expect(() => new HueRotatePass({ angle: 7 })).toThrow();
+  });
+
+  it('angle 边界值通过', () => {
+    expect(() => new HueRotatePass({ angle: -Math.PI * 2 })).not.toThrow();
+    expect(() => new HueRotatePass({ angle: Math.PI * 2 })).not.toThrow();
+  });
+
+  it('saturation 超出 [0, 1] 抛错', () => {
+    expect(() => new HueRotatePass({ saturation: -0.1 })).toThrow();
+    expect(() => new HueRotatePass({ saturation: 1.1 })).toThrow();
+  });
+
+  it('saturation 边界值通过', () => {
+    expect(() => new HueRotatePass({ saturation: 0 })).not.toThrow();
+    expect(() => new HueRotatePass({ saturation: 1 })).not.toThrow();
+  });
+
+  it('getFragmentShader 返回包含关键 uniform 的 GLSL', () => {
+    const pass = new HueRotatePass();
+    const shader = pass.getFragmentShader();
+    expect(shader).toContain('u_angle');
+    expect(shader).toContain('u_saturation');
+    expect(shader).toContain('u_texture');
+    // YIQ 转换关键系数
+    expect(shader).toContain('0.299');
+    expect(shader).toContain('0.587');
+  });
+
+  it('可写属性被修改后生效', () => {
+    const pass = new HueRotatePass();
+    pass.angle = Math.PI / 2;
+    pass.saturation = 0.3;
+    expect(pass.angle).toBeCloseTo(Math.PI / 2, 5);
+    expect(pass.saturation).toBe(0.3);
+  });
+
+  it('setUniforms 无 program 时不抛错', () => {
+    const pass = new HueRotatePass();
+    const mockGl = {
+      getUniformLocation: () => null,
+      uniform1f: () => {},
+    } as unknown as WebGLRenderingContext;
+    expect(() => pass.setUniforms(mockGl, {} as WebGLProgram)).not.toThrow();
+  });
+
+  it('支持 enabled 切换', () => {
+    const pass = new HueRotatePass();
+    pass.enabled = false;
+    expect(pass.enabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概述

实现 HueRotatePass — 基于 YIQ 色彩空间旋转矩阵的快速色相旋转后处理。

## 变更内容

- `src/renderer/post-process.ts`：新增 `HueRotateOptions` 接口和 `HueRotatePass` 类
- `test/unit/renderer/hue-rotate-pass.test.ts`：新增 10 个单元测试

## 算法说明

通过 YIQ 色彩空间实现色相旋转，避免完整 RGB→HSV→RGB 转换：
1. RGB → YIQ（luma/chroma 分离）
2. 在 IQ 平面旋转 angle 角度
3. 应用 saturation 饱和度因子
4. YIQ → RGB + clamp

## 测试结果

- HueRotatePass 专项测试：10/10 全绿
- 全量单元测试：1749/1749 通过，零回归

close #310