### PR TITLE
feat: 实现 GammaPass sRGB gamma 校正后处理 (#315)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1320,3 +1320,43 @@ void main() {
   }
 }
 
+/* ── GammaPass ── */
+
+/** sRGB gamma 校正后处理：线性空间转显示器空间（pre-display encoding）*/
+export class GammaPass implements EffectPass {
+  readonly name = 'gamma';
+  enabled = true;
+  /** Gamma 值。默认 2.2（sRGB 标准）。范围 [0.1, 5.0] */
+  gamma: number;
+
+  constructor(gammaOrOpts: number | { gamma?: number } = 2.2) {
+    if (typeof gammaOrOpts === 'object') {
+      this.gamma = gammaOrOpts.gamma ?? 2.2;
+    } else {
+      this.gamma = gammaOrOpts;
+    }
+    if (!isFinite(this.gamma) || this.gamma < 0.1 || this.gamma > 5.0) {
+      throw new Error(`GammaPass: gamma must be in [0.1, 5.0], got ${this.gamma}`);
+    }
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_invGamma;
+varying vec2 v_texCoord;
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  vec3 corrected = pow(max(color.rgb, vec3(0.0)), vec3(u_invGamma));
+  gl_FragColor = vec4(corrected, color.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const loc = gl.getUniformLocation(program, 'u_invGamma');
+    if (loc) gl.uniform1f(loc, 1.0 / this.gamma);
+  }
+}
+

--- a/test/unit/renderer/gamma-pass.test.ts
+++ b/test/unit/renderer/gamma-pass.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { GammaPass } from '../../../src/renderer/post-process';
+
+describe('GammaPass', () => {
+  describe('构造器', () => {
+    it('默认 gamma=2.2', () => {
+      const pass = new GammaPass();
+      expect(pass.gamma).toBeCloseTo(2.2, 6);
+    });
+
+    it('数字参数形式', () => {
+      const pass = new GammaPass(2.4);
+      expect(pass.gamma).toBeCloseTo(2.4, 6);
+    });
+
+    it('对象参数形式', () => {
+      const pass = new GammaPass({ gamma: 1.8 });
+      expect(pass.gamma).toBeCloseTo(1.8, 6);
+    });
+
+    it('gamma=1.0 有效（禁用校正）', () => {
+      expect(() => new GammaPass(1.0)).not.toThrow();
+    });
+
+    it('gamma 范围校验：正越界抛错', () => {
+      expect(() => new GammaPass(5.1)).toThrow();
+    });
+
+    it('gamma 范围校验：太小抛错', () => {
+      expect(() => new GammaPass(0.05)).toThrow();
+    });
+
+    it('gamma 范围校验：负值抛错', () => {
+      expect(() => new GammaPass(-1)).toThrow();
+    });
+
+    it('NaN 抛错', () => {
+      expect(() => new GammaPass(NaN)).toThrow();
+    });
+  });
+
+  describe('EffectPass 接口', () => {
+    it('name 为 gamma', () => {
+      expect(new GammaPass().name).toBe('gamma');
+    });
+
+    it('默认 enabled', () => {
+      expect(new GammaPass().enabled).toBe(true);
+    });
+
+    it('片元着色器使用 pow 做 gamma 校正', () => {
+      const pass = new GammaPass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('pow');
+      expect(shader).toContain('u_invGamma');
+      expect(shader).toContain('u_texture');
+    });
+  });
+});


### PR DESCRIPTION
## 概述

实现 `GammaPass`——sRGB gamma 校正后处理 Pass，作为相机成像管线的最后一步（pre-display encoding）。

## 变更

- `src/renderer/post-process.ts`：末端追加 `GammaPass` 类
- `test/unit/renderer/gamma-pass.test.ts`：新增 11 个单元测试

## 实现要点

- 支持数字参数 `new GammaPass(2.4)` 和对象参数 `new GammaPass({ gamma: 1.8 })` 两种构造形式
- gamma 范围校验 [0.1, 5.0]，越界/NaN 抛错
- CPU 侧预计算 `1/gamma`（`u_invGamma`），避免 GPU 除法
- GLSL 用 `max(color.rgb, vec3(0.0))` 保护负色值再做 `pow`
- alpha 通道保持线性不变

## 测试

```
✓ test/unit/renderer/gamma-pass.test.ts (11 tests)
✓ test/unit/renderer/ 全量 688 tests 零回归
```

close #315