### PR TITLE
feat: 实现 ExposurePass EV stops 曝光补偿后处理 (#314)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1360,3 +1360,41 @@ void main() {
   }
 }
 
+/* ── ExposurePass ── */
+
+/** EV stops 曝光补偿后处理：+1 stop = ×2 亮度，-1 stop = ÷2 亮度，CPU 侧预计算 pow(2, ev) */
+export class ExposurePass implements EffectPass {
+  readonly name = 'exposure';
+  enabled = true;
+  ev: number;
+
+  constructor(evOrOpts: number | { ev?: number } = 0) {
+    if (typeof evOrOpts === 'object') {
+      this.ev = evOrOpts.ev ?? 0;
+    } else {
+      this.ev = evOrOpts;
+    }
+    if (!isFinite(this.ev) || this.ev < -5 || this.ev > 5) {
+      throw new Error(`ExposurePass: ev must be in [-5, 5], got ${this.ev}`);
+    }
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_exposure;
+varying vec2 v_texCoord;
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  gl_FragColor = vec4(color.rgb * u_exposure, color.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const loc = gl.getUniformLocation(program, 'u_exposure');
+    if (loc) gl.uniform1f(loc, Math.pow(2.0, this.ev));
+  }
+}
+

--- a/test/unit/renderer/exposure-pass.test.ts
+++ b/test/unit/renderer/exposure-pass.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { ExposurePass } from '../../../src/renderer/post-process';
+
+describe('ExposurePass', () => {
+  describe('构造器', () => {
+    it('默认 ev=0', () => {
+      const pass = new ExposurePass();
+      expect(pass.ev).toBe(0);
+    });
+
+    it('数字参数形式', () => {
+      const pass = new ExposurePass(1.5);
+      expect(pass.ev).toBe(1.5);
+    });
+
+    it('对象参数形式', () => {
+      const pass = new ExposurePass({ ev: -2 });
+      expect(pass.ev).toBe(-2);
+    });
+
+    it('ev 范围校验：正越界抛错', () => {
+      expect(() => new ExposurePass(6)).toThrow();
+    });
+
+    it('ev 范围校验：负越界抛错', () => {
+      expect(() => new ExposurePass(-6)).toThrow();
+    });
+
+    it('ev 范围校验：边界值有效', () => {
+      expect(() => new ExposurePass(-5)).not.toThrow();
+      expect(() => new ExposurePass(5)).not.toThrow();
+    });
+
+    it('NaN 抛错', () => {
+      expect(() => new ExposurePass(NaN)).toThrow();
+    });
+  });
+
+  describe('EffectPass 接口', () => {
+    it('name 为 exposure', () => {
+      expect(new ExposurePass().name).toBe('exposure');
+    });
+
+    it('默认 enabled', () => {
+      expect(new ExposurePass().enabled).toBe(true);
+    });
+
+    it('片元着色器包含 u_exposure', () => {
+      const pass = new ExposurePass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('u_exposure');
+      expect(shader).toContain('u_texture');
+      expect(shader).toContain('v_texCoord');
+    });
+  });
+});


### PR DESCRIPTION
## 概述

实现 `ExposurePass`，为引擎后处理管线新增物理相机曝光补偿能力（EV stops）。

## 变更内容

- `src/renderer/post-process.ts`：末端追加 `ExposurePass` 类
- `test/unit/renderer/exposure-pass.test.ts`：10 个单元测试（新增）

## 实现要点

- 支持数字和对象两种构造器形式：`new ExposurePass(1.5)` / `new ExposurePass({ ev: -2 })`
- EV stops 范围 `[-5, 5]`，越界（含 NaN）抛错
- CPU 侧预计算 `pow(2, ev)`，GPU 直接乘法 O(1)
- 片元着色器统一变量 `u_exposure = pow(2, ev)`，对 RGB 通道乘法，Alpha 不变

## 测试结果

```
✓ test/unit/renderer/exposure-pass.test.ts (10 tests)
renderer/ 全套：58 passed, 687 tests, 零回归
```

close #314