### PR TITLE
feat: 实现 WhiteBalancePass 色温白平衡后处理 (#316)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1398,3 +1398,67 @@ void main() {
   }
 }
 
+/* ── WhiteBalancePass ── */
+
+/** 色温白平衡后处理：补偿光源色温偏差，营造时段/天气氛围 */
+export class WhiteBalancePass implements EffectPass {
+  readonly name = 'whitebalance';
+  enabled = true;
+  /** 色温 Kelvin。默认 6500（中性）。范围 [1000, 20000] */
+  temperature: number;
+  /** 色调。负值偏绿/洋红，默认 0。范围 [-1, 1] */
+  tint: number;
+
+  constructor(opts: { temperature?: number; tint?: number } = {}) {
+    this.temperature = opts.temperature ?? 6500;
+    this.tint = opts.tint ?? 0;
+    if (!isFinite(this.temperature) || this.temperature < 1000 || this.temperature > 20000) {
+      throw new Error(`WhiteBalancePass: temperature must be in [1000, 20000], got ${this.temperature}`);
+    }
+    if (!isFinite(this.tint) || this.tint < -1 || this.tint > 1) {
+      throw new Error(`WhiteBalancePass: tint must be in [-1, 1], got ${this.tint}`);
+    }
+  }
+
+  private computeRGBMultiplier(): [number, number, number] {
+    const t = this.temperature / 100;
+    let r: number, g: number, b: number;
+    if (t <= 66) {
+      r = 1.0;
+      g = Math.max(0, Math.min(1, (99.4708025861 * Math.log(t) - 161.1195681661) / 255));
+      b = t <= 19 ? 0 : Math.max(0, Math.min(1, (138.5177312231 * Math.log(t - 10) - 305.0447927307) / 255));
+    } else {
+      r = Math.max(0, Math.min(1, (329.698727446 * Math.pow(t - 60, -0.1332047592)) / 255));
+      g = Math.max(0, Math.min(1, (288.1221695283 * Math.pow(t - 60, -0.0755148492)) / 255));
+      b = 1.0;
+    }
+    return [r, g, b];
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform vec3 u_balanceMul;
+uniform float u_tint;
+varying vec2 v_texCoord;
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  vec3 balanced = color.rgb * u_balanceMul;
+  balanced.g += u_tint * 0.1;
+  balanced.r -= u_tint * 0.05;
+  balanced.b -= u_tint * 0.05;
+  gl_FragColor = vec4(clamp(balanced, 0.0, 1.0), color.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const [r, g, b] = this.computeRGBMultiplier();
+    const mulLoc = gl.getUniformLocation(program, 'u_balanceMul');
+    if (mulLoc) gl.uniform3f(mulLoc, r, g, b);
+    const tintLoc = gl.getUniformLocation(program, 'u_tint');
+    if (tintLoc) gl.uniform1f(tintLoc, this.tint);
+  }
+}
+

--- a/test/unit/renderer/whitebalance-pass.test.ts
+++ b/test/unit/renderer/whitebalance-pass.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { WhiteBalancePass } from '../../../src/renderer/post-process';
+
+describe('WhiteBalancePass', () => {
+  describe('构造器', () => {
+    it('默认 temperature=6500, tint=0', () => {
+      const pass = new WhiteBalancePass();
+      expect(pass.temperature).toBe(6500);
+      expect(pass.tint).toBe(0);
+    });
+
+    it('对象参数形式', () => {
+      const pass = new WhiteBalancePass({ temperature: 3500, tint: 0.2 });
+      expect(pass.temperature).toBe(3500);
+      expect(pass.tint).toBeCloseTo(0.2, 6);
+    });
+
+    it('temperature 范围校验：正越界抛错', () => {
+      expect(() => new WhiteBalancePass({ temperature: 25000 })).toThrow();
+    });
+
+    it('temperature 范围校验：太小抛错', () => {
+      expect(() => new WhiteBalancePass({ temperature: 500 })).toThrow();
+    });
+
+    it('tint 范围校验：正越界抛错', () => {
+      expect(() => new WhiteBalancePass({ tint: 1.5 })).toThrow();
+    });
+
+    it('tint 范围校验：负越界抛错', () => {
+      expect(() => new WhiteBalancePass({ tint: -1.5 })).toThrow();
+    });
+
+    it('temperature 或 tint 为 NaN 抛错', () => {
+      expect(() => new WhiteBalancePass({ temperature: NaN })).toThrow();
+      expect(() => new WhiteBalancePass({ tint: NaN })).toThrow();
+    });
+
+    it('边界值有效', () => {
+      expect(() => new WhiteBalancePass({ temperature: 1000, tint: -1 })).not.toThrow();
+      expect(() => new WhiteBalancePass({ temperature: 20000, tint: 1 })).not.toThrow();
+    });
+  });
+
+  describe('EffectPass 接口', () => {
+    it('name 为 whitebalance', () => {
+      expect(new WhiteBalancePass().name).toBe('whitebalance');
+    });
+
+    it('默认 enabled', () => {
+      expect(new WhiteBalancePass().enabled).toBe(true);
+    });
+
+    it('片元着色器包含 u_balanceMul + u_tint', () => {
+      const pass = new WhiteBalancePass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('u_balanceMul');
+      expect(shader).toContain('u_tint');
+      expect(shader).toContain('u_texture');
+    });
+  });
+});


### PR DESCRIPTION
## 概述

实现 Phase 42 相机成像管线补全的第三个 Pass：WhiteBalancePass — 色温白平衡后处理。

闭合 issue #316。

## 实现要点

- **temperature** ∈ [1000, 20000] Kelvin，默认 6500（中性）
- **tint** ∈ [-1, 1]，默认 0（无色调偏移）
- CPU 预计算 Robertson 色温→RGB 转换（computeRGBMultiplier 基于经典 Tanner Helland 近似）
- GLSL shader 纯 RGB 乘法 + 色调偏移 O(1)（r/b 减 tint×0.05、g 加 tint×0.1）
- 构造器参数边界校验 + NaN/越界抛错
- 输出 clamp 到 [0, 1] 防溢

## 测试

- 11 个单元测试全绿
- 全量 699 renderer tests 零回归（含 GammaPass 22 测试）

## Architect 介入说明

Forge-2 实现 WhiteBalancePass 代码完整，但遭遇 **CWD 失效 bug**（shell cwd 指向已被清理的 lucid-3d--issue-315 worktree，Bash 工具被运行时拒绝）。Architect 接力完成：
1. 切到 active/lucid-3d--issue-316 worktree 验证代码
2. 11/11 whitebalance tests ✅ + 699/699 renderer tests ✅ 零回归
3. git commit + rebase origin/main（解 post-process.ts file-level conflict，保留 HEAD GammaPass + append WhiteBalancePass）
4. push feat/issue-316 + 开 PR

这是 Phase 38/39/40/41/42 CWD 失效 bug 连续第 6 次复现，建议 framework 增强 watchdog。

Co-Authored-By: Claude Sonnet 4.6 (Forge-2)
Co-Authored-By: Claude Opus 4.7 (Architect)