### PR TITLE
feat: 实现 HighlightShadowPass 高光/阴影分区调整后处理 (#321)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1462,3 +1462,58 @@ void main() {
   }
 }
 
+/* ── HighlightShadowPass ── */
+
+export interface HighlightShadowOptions {
+  /** 高光调整，[-1, 1]。正值提亮高光，负值压暗。默认 0 */
+  highlights?: number;
+  /** 阴影调整，[-1, 1]。正值提亮阴影，负值压暗。默认 0 */
+  shadows?: number;
+}
+
+/** 高光/阴影分区调整：基于 Rec.709 luma mask 独立控制亮区和暗区 */
+export class HighlightShadowPass implements EffectPass {
+  readonly name = 'highlightShadow';
+  enabled = true;
+  highlights: number;
+  shadows: number;
+
+  constructor(options?: HighlightShadowOptions) {
+    this.highlights = options?.highlights ?? 0;
+    this.shadows = options?.shadows ?? 0;
+    if (!isFinite(this.highlights) || this.highlights < -1 || this.highlights > 1) {
+      throw new Error(`HighlightShadowPass: highlights must be in [-1, 1], got ${this.highlights}`);
+    }
+    if (!isFinite(this.shadows) || this.shadows < -1 || this.shadows > 1) {
+      throw new Error(`HighlightShadowPass: shadows must be in [-1, 1], got ${this.shadows}`);
+    }
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_highlights;
+uniform float u_shadows;
+varying vec2 v_texCoord;
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  vec3 rgb = color.rgb;
+  float luma = dot(rgb, vec3(0.2126, 0.7152, 0.0722));
+  float shadowMask = smoothstep(0.5, 0.0, luma);
+  float highlightMask = smoothstep(0.5, 1.0, luma);
+  rgb += u_shadows * shadowMask * 0.3;
+  rgb += u_highlights * highlightMask * 0.3;
+  gl_FragColor = vec4(clamp(rgb, 0.0, 1.0), color.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const hlLoc = gl.getUniformLocation(program, 'u_highlights');
+    if (hlLoc) gl.uniform1f(hlLoc, this.highlights);
+    const shLoc = gl.getUniformLocation(program, 'u_shadows');
+    if (shLoc) gl.uniform1f(shLoc, this.shadows);
+  }
+}
+

--- a/test/unit/renderer/highlight-shadow-pass.test.ts
+++ b/test/unit/renderer/highlight-shadow-pass.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { HighlightShadowPass } from '../../../src/renderer/post-process';
+
+describe('HighlightShadowPass', () => {
+  describe('constructor defaults', () => {
+    it('should default highlights to 0', () => {
+      const pass = new HighlightShadowPass();
+      expect(pass.highlights).toBe(0);
+    });
+
+    it('should default shadows to 0', () => {
+      const pass = new HighlightShadowPass();
+      expect(pass.shadows).toBe(0);
+    });
+
+    it('should have name "highlightShadow" and enabled=true', () => {
+      const pass = new HighlightShadowPass();
+      expect(pass.name).toBe('highlightShadow');
+      expect(pass.enabled).toBe(true);
+    });
+  });
+
+  describe('custom options', () => {
+    it('should accept custom highlights/shadows', () => {
+      const pass = new HighlightShadowPass({ highlights: 0.3, shadows: -0.2 });
+      expect(pass.highlights).toBe(0.3);
+      expect(pass.shadows).toBe(-0.2);
+    });
+
+    it('should accept boundary values', () => {
+      const pass1 = new HighlightShadowPass({ highlights: 1, shadows: -1 });
+      expect(pass1.highlights).toBe(1);
+      expect(pass1.shadows).toBe(-1);
+      const pass2 = new HighlightShadowPass({ highlights: -1, shadows: 1 });
+      expect(pass2.highlights).toBe(-1);
+      expect(pass2.shadows).toBe(1);
+    });
+  });
+
+  describe('parameter validation', () => {
+    it('should throw when highlights out of [-1, 1]', () => {
+      expect(() => new HighlightShadowPass({ highlights: 1.5 })).toThrow();
+      expect(() => new HighlightShadowPass({ highlights: -1.5 })).toThrow();
+    });
+
+    it('should throw when shadows out of [-1, 1]', () => {
+      expect(() => new HighlightShadowPass({ shadows: 1.5 })).toThrow();
+      expect(() => new HighlightShadowPass({ shadows: -1.5 })).toThrow();
+    });
+
+    it('should throw on NaN', () => {
+      expect(() => new HighlightShadowPass({ highlights: NaN })).toThrow();
+      expect(() => new HighlightShadowPass({ shadows: NaN })).toThrow();
+    });
+  });
+
+  describe('getFragmentShader', () => {
+    it('should return GLSL containing u_highlights and u_shadows uniforms', () => {
+      const pass = new HighlightShadowPass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('u_highlights');
+      expect(shader).toContain('u_shadows');
+      expect(shader).toContain('u_texture');
+    });
+
+    it('should use luminance calculation (Rec.709 weights)', () => {
+      const pass = new HighlightShadowPass();
+      const shader = pass.getFragmentShader();
+      // 验证出现 luma 计算或关键系数
+      expect(shader).toMatch(/0\.2126|luma|dot/);
+    });
+  });
+
+  describe('setUniforms', () => {
+    it('should call uniform1f for highlights and shadows', () => {
+      const pass = new HighlightShadowPass({ highlights: 0.4, shadows: -0.3 });
+      const calls: Array<[string, number]> = [];
+      const gl = {
+        getUniformLocation: (_: any, name: string) => ({ name }),
+        uniform1f: (loc: any, value: number) => calls.push([loc.name, value]),
+      } as any;
+      pass.setUniforms(gl, {} as any);
+      expect(calls.find(c => c[0] === 'u_highlights')?.[1]).toBeCloseTo(0.4);
+      expect(calls.find(c => c[0] === 'u_shadows')?.[1]).toBeCloseTo(-0.3);
+    });
+  });
+
+  describe('mutation', () => {
+    it('should allow runtime highlights/shadows mutation', () => {
+      const pass = new HighlightShadowPass();
+      pass.highlights = 0.5;
+      pass.shadows = -0.5;
+      expect(pass.highlights).toBe(0.5);
+      expect(pass.shadows).toBe(-0.5);
+    });
+  });
+});


### PR DESCRIPTION
## 概述

实现 `HighlightShadowPass`，基于 Rec.709 luma mask 对高光区和阴影区进行独立亮度调整。

## 变更

- `src/renderer/post-process.ts`：在末尾新增 `HighlightShadowPass` 及 `HighlightShadowOptions` 接口
- `test/unit/renderer/highlight-shadow-pass.test.ts`：新增 12 个单元测试

## 核心实现

- Rec.709 luma 权重（0.2126 / 0.7152 / 0.0722）计算亮度
- `smoothstep` 柔和 mask 分离高光/阴影区域
- 0.3 缩放系数让 `[-1, 1]` 范围对应合理视觉强度
- 参数校验：`highlights`、`shadows` 越界或 NaN 时 throw

## 测试结果

- HighlightShadowPass：12/12 ✅
- 全量 `test/unit/renderer/`：721/721 ✅（61 个文件，零回归）

close #321