### PR TITLE
feat: 实现 LiftGammaGainPass 三段调色后处理

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1517,3 +1517,79 @@ void main() {
   }
 }
 
+/* ── LiftGammaGainPass ── */
+
+export interface LiftGammaGainOptions {
+  /** 阴影偏移 (lift)，每通道 [-1, 1]。默认 [0, 0, 0]（无偏移） */
+  lift?: [number, number, number];
+  /** 中间调曲线 (gamma)，每通道 [0.1, 5]。默认 [1, 1, 1]（线性） */
+  gamma?: [number, number, number];
+  /** 高光倍数 (gain)，每通道 [0, 5]。默认 [1, 1, 1]（恒等） */
+  gain?: [number, number, number];
+}
+
+/** 三段调色后处理：分别控制阴影 lift、中间调 gamma、高光 gain（DaVinci Resolve 标准公式） */
+export class LiftGammaGainPass implements EffectPass {
+  readonly name = 'liftGammaGain';
+  enabled = true;
+  lift: [number, number, number];
+  gamma: [number, number, number];
+  gain: [number, number, number];
+
+  constructor(options?: LiftGammaGainOptions) {
+    this.lift = options?.lift ?? [0, 0, 0];
+    this.gamma = options?.gamma ?? [1, 1, 1];
+    this.gain = options?.gain ?? [1, 1, 1];
+
+    for (let i = 0; i < 3; i++) {
+      if (!isFinite(this.lift[i])) {
+        throw new Error(`LiftGammaGainPass: lift[${i}] must be finite, got ${this.lift[i]}`);
+      }
+      if (this.lift[i] < -1 || this.lift[i] > 1) {
+        throw new Error(`LiftGammaGainPass: lift[${i}] must be in [-1, 1], got ${this.lift[i]}`);
+      }
+      if (!isFinite(this.gamma[i])) {
+        throw new Error(`LiftGammaGainPass: gamma[${i}] must be finite, got ${this.gamma[i]}`);
+      }
+      if (this.gamma[i] < 0.1 || this.gamma[i] > 5) {
+        throw new Error(`LiftGammaGainPass: gamma[${i}] must be in [0.1, 5], got ${this.gamma[i]}`);
+      }
+      if (!isFinite(this.gain[i])) {
+        throw new Error(`LiftGammaGainPass: gain[${i}] must be finite, got ${this.gain[i]}`);
+      }
+      if (this.gain[i] < 0 || this.gain[i] > 5) {
+        throw new Error(`LiftGammaGainPass: gain[${i}] must be in [0, 5], got ${this.gain[i]}`);
+      }
+    }
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+varying vec2 v_texCoord;
+uniform sampler2D u_texture;
+uniform vec3 u_lift;
+uniform vec3 u_gamma;
+uniform vec3 u_gain;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  vec3 rgb = color.rgb;
+  rgb = rgb + u_lift * (vec3(1.0) - rgb);
+  rgb = rgb * u_gain;
+  rgb = pow(max(rgb, vec3(0.0)), vec3(1.0) / max(u_gamma, vec3(0.01)));
+  gl_FragColor = vec4(clamp(rgb, 0.0, 1.0), color.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const liftLoc = gl.getUniformLocation(program, 'u_lift');
+    if (liftLoc) gl.uniform3fv(liftLoc, this.lift);
+    const gammaLoc = gl.getUniformLocation(program, 'u_gamma');
+    if (gammaLoc) gl.uniform3fv(gammaLoc, this.gamma);
+    const gainLoc = gl.getUniformLocation(program, 'u_gain');
+    if (gainLoc) gl.uniform3fv(gainLoc, this.gain);
+  }
+}
+

--- a/test/unit/renderer/lift-gamma-gain-pass.test.ts
+++ b/test/unit/renderer/lift-gamma-gain-pass.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { LiftGammaGainPass } from '../../../src/renderer/post-process';
+
+describe('LiftGammaGainPass', () => {
+  describe('constructor defaults', () => {
+    it('should default lift to [0, 0, 0]', () => {
+      const pass = new LiftGammaGainPass();
+      expect(pass.lift).toEqual([0, 0, 0]);
+    });
+
+    it('should default gamma to [1, 1, 1]', () => {
+      const pass = new LiftGammaGainPass();
+      expect(pass.gamma).toEqual([1, 1, 1]);
+    });
+
+    it('should default gain to [1, 1, 1]', () => {
+      const pass = new LiftGammaGainPass();
+      expect(pass.gain).toEqual([1, 1, 1]);
+    });
+
+    it('should have name "liftGammaGain" and enabled=true', () => {
+      const pass = new LiftGammaGainPass();
+      expect(pass.name).toBe('liftGammaGain');
+      expect(pass.enabled).toBe(true);
+    });
+  });
+
+  describe('custom options', () => {
+    it('should accept custom lift/gamma/gain', () => {
+      const pass = new LiftGammaGainPass({
+        lift: [0.1, 0.0, -0.1],
+        gamma: [1.2, 1.0, 0.8],
+        gain: [1.1, 1.0, 0.9],
+      });
+      expect(pass.lift).toEqual([0.1, 0.0, -0.1]);
+      expect(pass.gamma).toEqual([1.2, 1.0, 0.8]);
+      expect(pass.gain).toEqual([1.1, 1.0, 0.9]);
+    });
+  });
+
+  describe('parameter validation', () => {
+    it('should throw when lift out of [-1, 1]', () => {
+      expect(() => new LiftGammaGainPass({ lift: [1.5, 0, 0] })).toThrow();
+      expect(() => new LiftGammaGainPass({ lift: [-1.5, 0, 0] })).toThrow();
+    });
+
+    it('should throw when gamma out of [0.1, 5]', () => {
+      expect(() => new LiftGammaGainPass({ gamma: [0.05, 1, 1] })).toThrow();
+      expect(() => new LiftGammaGainPass({ gamma: [5.5, 1, 1] })).toThrow();
+      expect(() => new LiftGammaGainPass({ gamma: [0, 1, 1] })).toThrow();
+    });
+
+    it('should throw when gain out of [0, 5]', () => {
+      expect(() => new LiftGammaGainPass({ gain: [-0.1, 1, 1] })).toThrow();
+      expect(() => new LiftGammaGainPass({ gain: [5.5, 1, 1] })).toThrow();
+    });
+
+    it('should throw on NaN', () => {
+      expect(() => new LiftGammaGainPass({ lift: [NaN, 0, 0] })).toThrow();
+      expect(() => new LiftGammaGainPass({ gamma: [NaN, 1, 1] })).toThrow();
+      expect(() => new LiftGammaGainPass({ gain: [NaN, 1, 1] })).toThrow();
+    });
+  });
+
+  describe('getFragmentShader', () => {
+    it('should return GLSL string containing u_lift/u_gamma/u_gain uniforms', () => {
+      const pass = new LiftGammaGainPass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('u_lift');
+      expect(shader).toContain('u_gamma');
+      expect(shader).toContain('u_gain');
+      expect(shader).toContain('u_texture');
+    });
+  });
+
+  describe('setUniforms', () => {
+    it('should call uniform3fv for lift/gamma/gain', () => {
+      const pass = new LiftGammaGainPass({
+        lift: [0.1, 0.2, 0.3],
+        gamma: [1.1, 1.2, 1.3],
+        gain: [1.5, 1.5, 1.5],
+      });
+      const calls: Array<[string, Float32Array | number[]]> = [];
+      const gl = {
+        getUniformLocation: (_: any, name: string) => ({ name }),
+        uniform3fv: (loc: any, value: any) => {
+          calls.push([loc.name, Array.from(value)]);
+        },
+      } as any;
+      pass.setUniforms(gl, {} as any);
+      const liftCall = calls.find(c => c[0] === 'u_lift');
+      const gammaCall = calls.find(c => c[0] === 'u_gamma');
+      const gainCall = calls.find(c => c[0] === 'u_gain');
+      expect(liftCall?.[1]).toEqual([0.1, 0.2, 0.3]);
+      expect(gammaCall?.[1]).toEqual([1.1, 1.2, 1.3]);
+      expect(gainCall?.[1]).toEqual([1.5, 1.5, 1.5]);
+    });
+  });
+
+  describe('mutation', () => {
+    it('should allow runtime lift/gamma/gain mutation', () => {
+      const pass = new LiftGammaGainPass();
+      pass.lift = [0.2, 0.2, 0.2];
+      pass.gamma = [1.5, 1.5, 1.5];
+      pass.gain = [1.2, 1.2, 1.2];
+      expect(pass.lift).toEqual([0.2, 0.2, 0.2]);
+      expect(pass.gamma).toEqual([1.5, 1.5, 1.5]);
+      expect(pass.gain).toEqual([1.2, 1.2, 1.2]);
+    });
+  });
+});


### PR DESCRIPTION
## 概述

实现 Phase 43 第一个 KR — `LiftGammaGainPass`，AAA 级三段调色（阴影 lift + 中间调 gamma + 高光 gain）。

## 变更

- `src/renderer/post-process.ts`：追加 `LiftGammaGainPass` 类及 `LiftGammaGainOptions` 接口
- `test/unit/renderer/lift-gamma-gain-pass.test.ts`：新增 12 个单元测试

## 核心公式（DaVinci Resolve 标准）

```
output = pow((input + lift*(1-input)) * gain, 1/gamma)
```

## 验收结果

- [x] 12/12 目标测试全绿
- [x] 全量 renderer 测试 721/721 零回归
- [x] 默认 lift=[0,0,0]/gamma=[1,1,1]/gain=[1,1,1] 是恒等变换

close #320