### PR TITLE
feat: 实现 VibrancePass 自然饱和度后处理 (#322)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1593,3 +1593,58 @@ void main() {
   }
 }
 
+/* ── VibrancePass ── */
+
+export interface VibranceOptions {
+  /** 自然饱和度调整，[-1, 1]。正值提升未饱和色，负值降低饱和。默认 0 */
+  vibrance?: number;
+}
+
+/** 自然饱和度后处理：对未饱和色影响大、对已饱和色影响小（Lightroom Vibrance 业界标准） */
+export class VibrancePass implements EffectPass {
+  readonly name = 'vibrance';
+  enabled = true;
+  vibrance: number;
+
+  constructor(options?: VibranceOptions) {
+    this.vibrance = options?.vibrance ?? 0;
+    if (!isFinite(this.vibrance)) {
+      throw new Error(`VibrancePass: vibrance must be finite, got ${this.vibrance}`);
+    }
+    if (this.vibrance < -1 || this.vibrance > 1) {
+      throw new Error(`VibrancePass: vibrance must be in [-1, 1], got ${this.vibrance}`);
+    }
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+varying vec2 v_texCoord;
+uniform sampler2D u_texture;
+uniform float u_vibrance;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  vec3 rgb = color.rgb;
+
+  float maxC = max(max(rgb.r, rgb.g), rgb.b);
+  float minC = min(min(rgb.r, rgb.g), rgb.b);
+  float currentSat = maxC - minC;
+
+  float luma = dot(rgb, vec3(0.2126, 0.7152, 0.0722));
+
+  float weight = 1.0 - currentSat;
+
+  vec3 adjusted = mix(vec3(luma), rgb, 1.0 + u_vibrance * weight);
+
+  gl_FragColor = vec4(clamp(adjusted, 0.0, 1.0), color.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const loc = gl.getUniformLocation(program, 'u_vibrance');
+    if (loc) gl.uniform1f(loc, this.vibrance);
+  }
+}
+

--- a/test/unit/renderer/vibrance-pass.test.ts
+++ b/test/unit/renderer/vibrance-pass.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { VibrancePass } from '../../../src/renderer/post-process';
+
+describe('VibrancePass', () => {
+  describe('constructor defaults', () => {
+    it('should default vibrance to 0', () => {
+      const pass = new VibrancePass();
+      expect(pass.vibrance).toBe(0);
+    });
+
+    it('should have name "vibrance" and enabled=true', () => {
+      const pass = new VibrancePass();
+      expect(pass.name).toBe('vibrance');
+      expect(pass.enabled).toBe(true);
+    });
+  });
+
+  describe('custom options', () => {
+    it('should accept custom vibrance', () => {
+      const pass = new VibrancePass({ vibrance: 0.5 });
+      expect(pass.vibrance).toBe(0.5);
+    });
+
+    it('should accept boundary values', () => {
+      const pass1 = new VibrancePass({ vibrance: 1 });
+      expect(pass1.vibrance).toBe(1);
+      const pass2 = new VibrancePass({ vibrance: -1 });
+      expect(pass2.vibrance).toBe(-1);
+      const pass3 = new VibrancePass({ vibrance: 0 });
+      expect(pass3.vibrance).toBe(0);
+    });
+  });
+
+  describe('parameter validation', () => {
+    it('should throw when vibrance out of [-1, 1]', () => {
+      expect(() => new VibrancePass({ vibrance: 1.5 })).toThrow();
+      expect(() => new VibrancePass({ vibrance: -1.5 })).toThrow();
+      expect(() => new VibrancePass({ vibrance: 2 })).toThrow();
+    });
+
+    it('should throw on NaN', () => {
+      expect(() => new VibrancePass({ vibrance: NaN })).toThrow();
+    });
+
+    it('should throw on Infinity', () => {
+      expect(() => new VibrancePass({ vibrance: Infinity })).toThrow();
+    });
+  });
+
+  describe('getFragmentShader', () => {
+    it('should return GLSL containing u_vibrance uniform', () => {
+      const pass = new VibrancePass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('u_vibrance');
+      expect(shader).toContain('u_texture');
+    });
+
+    it('should include luma calculation (Rec.709 weights)', () => {
+      const pass = new VibrancePass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toMatch(/0\.2126|luma/);
+    });
+
+    it('should include saturation weight (1 - currentSat)', () => {
+      const pass = new VibrancePass();
+      const shader = pass.getFragmentShader();
+      // 验证 max - min 结构（HSV saturation 近似）
+      expect(shader).toMatch(/max\(.*max\(|min\(.*min\(/);
+    });
+  });
+
+  describe('setUniforms', () => {
+    it('should call uniform1f for vibrance', () => {
+      const pass = new VibrancePass({ vibrance: 0.3 });
+      const calls: Array<[string, number]> = [];
+      const gl = {
+        getUniformLocation: (_: any, name: string) => ({ name }),
+        uniform1f: (loc: any, value: number) => calls.push([loc.name, value]),
+      } as any;
+      pass.setUniforms(gl, {} as any);
+      expect(calls.find(c => c[0] === 'u_vibrance')?.[1]).toBeCloseTo(0.3);
+    });
+  });
+
+  describe('mutation', () => {
+    it('should allow runtime vibrance mutation', () => {
+      const pass = new VibrancePass();
+      pass.vibrance = 0.7;
+      expect(pass.vibrance).toBe(0.7);
+      pass.vibrance = -0.3;
+      expect(pass.vibrance).toBe(-0.3);
+    });
+  });
+
+  describe('integration', () => {
+    it('should coexist with SaturationPass (both exported)', async () => {
+      const mod = await import('../../../src/renderer/post-process');
+      expect(mod.VibrancePass).toBeDefined();
+      expect(mod.SaturationPass).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 43 KR3 — 自然饱和度（Vibrance）后处理滤镜。

## 实现细节

与 SaturationPass 不同，Vibrance 对**已饱和色保护性更强** (weight = 1 - currentSat)，是 Lightroom/Capture One 业界标准做法。

**公式**：
```
currentSat = max(rgb) - min(rgb)
weight = 1 - currentSat  // 已饱和色 weight 小 → 影响小
luma = dot(rgb, vec3(0.2126, 0.7152, 0.0722))  // Rec.709
adjusted = mix(vec3(luma), rgb, 1 + vibrance * weight)
```

## API

```ts
import { VibrancePass } from 'lucid-3d';
pipeline.addPass(new VibrancePass({ vibrance: 0.5 }));  // [-1, 1], 默认 0
```

## 测试

- 13 vitest (vibrance-pass.test.ts) — 构造/边界/参数校验/shader 结构 全绿
- 全 renderer 测试 746/746 零回归

## Architect 代表 Forge-1 介入说明

Forge-1 在 10:34:26Z 开工 #322，tmux session 于 10:58:07Z 终止（worker-states status=stopped），**本地代码完整但未 commit/未 push/未开 PR**。
Architect 验证 Forge-1 的 VibrancePass 实现+测试后：
1. 代 Forge-1 commit（Co-authored-by Forge-1 + Architect）
2. rebase origin/main 解 3 处 post-process.ts conflict（HighlightShadow + LiftGammaGain + VibrancePass 三 Pass 共存）
3. 全 renderer 746/746 零回归
4. push + 开 PR

Closes #322