### PR TITLE
feat: 实现 DebugDraw immediate-mode 调试绘制 API (#326)

### DIFF
--- a/src/debug/debug-draw.ts
+++ b/src/debug/debug-draw.ts
@@ -5,11 +5,7 @@
  * 自动累积到 buffer，flush() 后清空。供 AI Agent 调试运行时几何/路径/碰撞用。
  *
  * @see test/unit/debug/debug-draw.test.ts
- *
- * STUB — Phase 44 Architect 预写
  */
-
-export const __STUB__ = true;
 
 import type { Vec3 } from '../math/vec3';
 
@@ -41,44 +37,55 @@ export interface DebugArrow {
   headSize: number;
 }
 
+const WHITE: Vec3 = [1, 1, 1];
+
 export class DebugDraw {
-  drawLine(_start: Vec3, _end: Vec3, _color?: Vec3, _thickness?: number): void {
-    throw new Error('Not implemented');
+  private _lines: DebugLine[] = [];
+  private _spheres: DebugSphere[] = [];
+  private _boxes: DebugBox[] = [];
+  private _arrows: DebugArrow[] = [];
+
+  drawLine(start: Vec3, end: Vec3, color: Vec3 = WHITE, thickness: number = 1): void {
+    this._lines.push({ start, end, color, thickness });
   }
 
-  drawSphere(_center: Vec3, _radius: number, _color?: Vec3, _segments?: number): void {
-    throw new Error('Not implemented');
+  drawSphere(center: Vec3, radius: number, color: Vec3 = WHITE, segments: number = 16): void {
+    if (radius <= 0) throw new Error(`drawSphere: radius 必须大于 0，收到 ${radius}`);
+    this._spheres.push({ center, radius, color, segments });
   }
 
-  drawBox(_min: Vec3, _max: Vec3, _color?: Vec3): void {
-    throw new Error('Not implemented');
+  drawBox(min: Vec3, max: Vec3, color: Vec3 = WHITE): void {
+    this._boxes.push({ min, max, color });
   }
 
-  drawArrow(_origin: Vec3, _direction: Vec3, _length: number, _color?: Vec3, _headSize?: number): void {
-    throw new Error('Not implemented');
+  drawArrow(origin: Vec3, direction: Vec3, length: number, color: Vec3 = WHITE, headSize?: number): void {
+    this._arrows.push({ origin, direction, length, color, headSize: headSize ?? 0.2 * length });
   }
 
   getLines(): readonly DebugLine[] {
-    throw new Error('Not implemented');
+    return this._lines;
   }
 
   getSpheres(): readonly DebugSphere[] {
-    throw new Error('Not implemented');
+    return this._spheres;
   }
 
   getBoxes(): readonly DebugBox[] {
-    throw new Error('Not implemented');
+    return this._boxes;
   }
 
   getArrows(): readonly DebugArrow[] {
-    throw new Error('Not implemented');
+    return this._arrows;
   }
 
   flush(): void {
-    throw new Error('Not implemented');
+    this._lines = [];
+    this._spheres = [];
+    this._boxes = [];
+    this._arrows = [];
   }
 
   get count(): number {
-    throw new Error('Not implemented');
+    return this._lines.length + this._spheres.length + this._boxes.length + this._arrows.length;
   }
 }


### PR DESCRIPTION
## 实现内容

实现 `DebugDraw` immediate-mode 调试绘制数据层 API。

- 内部用 4 个数组（`_lines` / `_spheres` / `_boxes` / `_arrows`）累积绘制命令
- 默认颜色白色 `[1,1,1]`，thickness 默认 1，sphere segments 默认 16，headSize 默认 `0.2 * length`
- `drawSphere` 对 `radius <= 0` 抛出 Error
- `getXxx()` 返回 readonly 引用，`count` 返回四个 buffer 总长度
- `flush()` 清空所有 buffer，删除 `__STUB__` 标记

## 测试

14 个预写测试全部通过，全量单元测试 1852 通过。

close #326