### PR TITLE
feat: 实现 SceneTreeDumper 场景图 JSON 序列化 (#327)

### DIFF
--- a/src/core/node3d.ts
+++ b/src/core/node3d.ts
@@ -37,6 +37,9 @@ export class Node3D {
   }
 
   /** Add a child node, removing it from its previous parent first. */
+  add(child: Node3D): void { this.addChild(child); }
+
+  /** Add a child node, removing it from its previous parent first. */
   addChild(child: Node3D): void {
     if (child.parent) {
       child.parent.removeChild(child);

--- a/src/debug/scene-dumper.ts
+++ b/src/debug/scene-dumper.ts
@@ -5,11 +5,7 @@
  * 用于调试运行时场景状态、对比快照、AI Agent 自查场景结构。
  *
  * @see test/unit/debug/scene-dumper.test.ts
- *
- * STUB — Phase 44 Architect 预写
  */
-
-export const __STUB__ = true;
 
 import type { Node3D } from '../core/node3d';
 
@@ -32,10 +28,49 @@ export interface DumpOptions {
   maxDepth?: number;
 }
 
-export function dumpScene(_root: Node3D, _options?: DumpOptions): SerializedNode {
-  throw new Error('Not implemented');
+export function dumpScene(root: Node3D, options?: DumpOptions): SerializedNode {
+  const maxDepth = options?.maxDepth ?? Infinity;
+  const includeMesh = options?.includeMesh !== false;
+
+  function serialize(node: Node3D, depth: number): SerializedNode {
+    const p = node.position;
+    const r = node.rotation;
+    const s = node.scale;
+
+    const result: SerializedNode = {
+      name: node.name,
+      type: node.constructor.name,
+      position: [p[0], p[1], p[2]],
+      rotation: [r[0], r[1], r[2]],
+      scale: [s[0], s[1], s[2]],
+      visible: node.visible,
+      children: depth < maxDepth
+        ? node.children.map(child => serialize(child, depth + 1))
+        : [],
+    };
+
+    if (includeMesh && isMesh(node)) {
+      result.meshInfo = {
+        geometryType: (node as MeshLike).geometry?.constructor.name ?? 'unknown',
+        materialType: (node as MeshLike).material?.constructor.name ?? 'unknown',
+      };
+    }
+
+    return result;
+  }
+
+  return serialize(root, 0);
 }
 
-export function dumpSceneJSON(_root: Node3D, _options?: DumpOptions, _indent?: number): string {
-  throw new Error('Not implemented');
+export function dumpSceneJSON(root: Node3D, options?: DumpOptions, indent?: number): string {
+  return JSON.stringify(dumpScene(root, options), null, indent);
+}
+
+interface MeshLike {
+  geometry?: object;
+  material?: object;
+}
+
+function isMesh(node: Node3D): node is Node3D & MeshLike {
+  return node.constructor.name === 'Mesh' && 'geometry' in node && 'material' in node;
 }


### PR DESCRIPTION
## 概述

实现 `SceneTreeDumper`（Phase 44） — 把 Node3D 场景图序列化为 JSON 友好的纯数据结构。

## 改动

- `src/debug/scene-dumper.ts`: 实现 `dumpScene` 和 `dumpSceneJSON`，删除 `__STUB__`
- `src/core/node3d.ts`: 新增 `add()` 别名（`addChild` 的快捷方式），与预写测试约定一致

## 实现细节

- `dumpScene` 递归遍历子树，`type` 取 `node.constructor.name`
- `maxDepth` 控制递归深度，默认 `Infinity`（全部遍历）
- `meshInfo` 仅在 `node.constructor.name === 'Mesh'` 且 `includeMesh !== false` 时输出
- `dumpSceneJSON` 包装 `JSON.stringify`，`indent` 默认 `undefined`（紧凑格式）

## 测试

10/10 单元测试通过，全量单元测试 134 passed。

close #327