### PR TITLE
feat: 实现 CameraSwitcher 多相机注册与切换管理器 (#334)

### DIFF
--- a/src/core/camera-switcher.ts
+++ b/src/core/camera-switcher.ts
@@ -7,18 +7,72 @@
 
 import type { Camera } from './camera';
 
-export const __STUB__ = true;
-
 export class CameraSwitcher {
-  constructor() { throw new Error('Not implemented'); }
-  register(_name: string, _camera: Camera): void { throw new Error('Not implemented'); }
-  unregister(_name: string): void { throw new Error('Not implemented'); }
-  switchTo(_name: string): void { throw new Error('Not implemented'); }
-  push(_name: string): void { throw new Error('Not implemented'); }
-  pop(): string | null { throw new Error('Not implemented'); }
-  get active(): Camera | null { throw new Error('Not implemented'); }
-  get activeName(): string | null { throw new Error('Not implemented'); }
-  has(_name: string): boolean { throw new Error('Not implemented'); }
-  get names(): string[] { throw new Error('Not implemented'); }
-  get stackDepth(): number { throw new Error('Not implemented'); }
+  private _cameras: Map<string, Camera> = new Map();
+  private _activeName: string | null = null;
+  private _stack: string[] = [];
+
+  constructor() {}
+
+  register(name: string, camera: Camera): void {
+    if (this._cameras.has(name)) {
+      throw new Error(`camera name already registered: ${name}`);
+    }
+    this._cameras.set(name, camera);
+    // 首次注册自动激活
+    if (this._activeName === null) {
+      this._activeName = name;
+    }
+  }
+
+  unregister(name: string): void {
+    this._cameras.delete(name);
+    if (this._activeName === name) {
+      this._activeName = null;
+    }
+    // 从堆栈中移除同名条目
+    this._stack = this._stack.filter(n => n !== name);
+  }
+
+  switchTo(name: string): void {
+    if (!this._cameras.has(name)) {
+      throw new Error(`camera not registered: ${name}`);
+    }
+    this._activeName = name;
+  }
+
+  push(name: string): void {
+    if (this._activeName !== null) {
+      this._stack.push(this._activeName);
+    }
+    this.switchTo(name);
+  }
+
+  pop(): string | null {
+    if (this._stack.length === 0) return null;
+    const prev = this._stack.pop()!;
+    this.switchTo(prev);
+    return prev;
+  }
+
+  get active(): Camera | null {
+    if (this._activeName === null) return null;
+    return this._cameras.get(this._activeName) ?? null;
+  }
+
+  get activeName(): string | null {
+    return this._activeName;
+  }
+
+  has(name: string): boolean {
+    return this._cameras.has(name);
+  }
+
+  get names(): string[] {
+    return Array.from(this._cameras.keys());
+  }
+
+  get stackDepth(): number {
+    return this._stack.length;
+  }
 }


### PR DESCRIPTION
## 概述

实现多相机注册与切换管理器，支持：
- 命名注册 / 注销
- 按名字切换 (switchTo)
- 堆栈式 push/pop 历史导航
- 首次注册自动激活
- 重名 / 未知名抛错

## 验收结果

- [x] 10/10 预写测试全部通过
- [x] 全 core 318 tests 无回归
- [x] 零 TypeScript 错误

## 介入说明

代码由 Forge-1 完整实现。Architect 代为 commit + rebase origin/main + push + 开 PR
（Forge-1 shell CWD 失效无法自行完成 git 操作，标准化救援路径第 N+1 次）。

Fixes #334