### PR TITLE
feat: 实现 UITextInput 文本输入框组件 (#339)

### DIFF
--- a/src/ui/ui-text-input.ts
+++ b/src/ui/ui-text-input.ts
@@ -1,31 +1,104 @@
 /**
- * UITextInput — 文本输入框 UI 元素（STUB）。
+ * UITextInput — 文本输入框 UI 元素。
  * 用于玩家名 / 聊天 / 搜索 / 作弊码等输入场景。
- * 核心能力：value 字符串 + focus 状态 + handleKeyDown + onChange + onSubmit 回调 + maxLength + placeholder。
- * @see test/unit/ui/ui-text-input.test.ts
  */
 
-export const __STUB__ = true;
+import { UIElement, type UIElementOptions } from './ui-element';
+import { vec3, type Vec3 } from '../math/vec3';
+import type { BitmapFontData } from '../renderer/bitmap-font';
 
-export interface UITextInputOptions {
-  x?: number;
-  y?: number;
-  width?: number;
-  height?: number;
+export interface UITextInputOptions extends UIElementOptions {
   value?: string;
   placeholder?: string;
   maxLength?: number;
   fontSize?: number;
-  textColor?: unknown;
-  backgroundColor?: unknown;
-  focusedColor?: unknown;
+  textColor?: Vec3;
+  placeholderColor?: Vec3;
+  backgroundColor?: Vec3;
+  focusedColor?: Vec3;
+  font?: BitmapFontData;
   onChange?: (value: string) => void;
   onSubmit?: (value: string) => void;
   disabled?: boolean;
 }
 
-export class UITextInput {
-  constructor(_options?: UITextInputOptions) {
-    throw new Error('UITextInput is a stub — implement in Phase 46 #<issue>');
+export class UITextInput extends UIElement {
+  value: string;
+  placeholder: string;
+  maxLength: number;
+  fontSize: number;
+  textColor: Vec3;
+  placeholderColor: Vec3;
+  backgroundColor: Vec3;
+  focusedColor: Vec3;
+  font: BitmapFontData | null;
+  onChange: ((value: string) => void) | null;
+  onSubmit: ((value: string) => void) | null;
+  disabled: boolean;
+  focused: boolean;
+
+  constructor(options?: UITextInputOptions) {
+    super({ ...options, interactive: true });
+    this.value = options?.value ?? '';
+    this.placeholder = options?.placeholder ?? '';
+    this.maxLength = options?.maxLength ?? Infinity;
+    this.fontSize = options?.fontSize ?? 16;
+    this.textColor = options?.textColor ?? vec3(1, 1, 1);
+    this.placeholderColor = options?.placeholderColor ?? vec3(0.5, 0.5, 0.5);
+    this.backgroundColor = options?.backgroundColor ?? vec3(0.2, 0.2, 0.2);
+    this.focusedColor = options?.focusedColor ?? vec3(0.3, 0.3, 0.3);
+    this.font = options?.font ?? null;
+    this.onChange = options?.onChange ?? null;
+    this.onSubmit = options?.onSubmit ?? null;
+    this.disabled = options?.disabled ?? false;
+    this.focused = false;
+  }
+
+  focus(): void {
+    if (this.disabled) return;
+    this.focused = true;
+  }
+
+  blur(): void {
+    this.focused = false;
+  }
+
+  setValue(value: string): void {
+    const prev = this.value;
+    this.value = value;
+    if (this.value !== prev) {
+      this.onChange?.(this.value);
+    }
+  }
+
+  handleKeyDown(key: string): void {
+    if (!this.focused || this.disabled) return;
+
+    if (key === 'Backspace') {
+      const prev = this.value;
+      this.value = this.value.slice(0, -1);
+      if (this.value !== prev) {
+        this.onChange?.(this.value);
+      }
+    } else if (key === 'Enter') {
+      this.onSubmit?.(this.value);
+    } else if (key === 'Escape') {
+      this.blur();
+    } else if (key.length === 1) {
+      if (this.value.length < this.maxLength) {
+        this.value += key;
+        this.onChange?.(this.value);
+      }
+    }
+  }
+
+  getVertices(): Float32Array {
+    const { x, y, width, height } = this;
+    return new Float32Array([
+      x,         y,
+      x + width, y,
+      x + width, y + height,
+      x,         y + height,
+    ]);
   }
 }


### PR DESCRIPTION
## 概述

实现 `src/ui/ui-text-input.ts` UITextInput 类，作为玩家名 / 聊天 / 搜索 / 作弊码输入的标准组件。

## 变更内容

- 移除 `__STUB__` 标记，实现完整 `UITextInput` 类
- 继承 `UIElement`，构造器传入 `interactive: true`
- 支持 `focus()` / `blur()` 状态管理（disabled 时 focus 不生效）
- `handleKeyDown` 处理 Backspace / Enter / Escape / 单字符追加
- `maxLength` 限制字符追加（默认 Infinity）
- `onChange` 仅在 value 实际改变时触发
- `onSubmit` 在 Enter 时触发，保留 value 不清空
- `getVertices()` 返回背景矩形四顶点

## 测试结果

- ✅ 11/11 UITextInput 单元测试通过
- ✅ 1912 单元测试全量零回归

close #339