### PR TITLE
feat: 实现 UIDropdown 下拉选择组件 (#340)

### DIFF
--- a/src/ui/ui-dropdown.ts
+++ b/src/ui/ui-dropdown.ts
@@ -1,35 +1,117 @@
 /**
- * UIDropdown — 下拉选择 UI 元素（STUB）。
+ * UIDropdown — 下拉选择 UI 元素。
  * 用于难度 / 角色 / 分辨率 / 语言等离散选项选择。
  * 核心能力：options 数组 + selectedIndex + open/close 展开状态 + 选中触发 onChange 回调。
  * @see test/unit/ui/ui-dropdown.test.ts
  */
 
-export const __STUB__ = true;
+import { vec3, type Vec3 } from '../math/vec3';
+import type { BitmapFontData } from '../renderer/bitmap-font';
+import { UIElement, type UIElementOptions } from './ui-element';
 
 export interface UIDropdownOption {
   label: string;
   value: string;
 }
 
-export interface UIDropdownOptions {
-  x?: number;
-  y?: number;
-  width?: number;
-  height?: number;
-  options?: UIDropdownOption[];
+export interface UIDropdownOptions extends UIElementOptions {
+  options: UIDropdownOption[];
   selectedIndex?: number;
   fontSize?: number;
-  textColor?: unknown;
-  backgroundColor?: unknown;
-  hoverColor?: unknown;
+  textColor?: Vec3;
+  backgroundColor?: Vec3;
+  hoverColor?: Vec3;
+  font?: BitmapFontData;
   onChange?: (option: UIDropdownOption, index: number) => void;
   disabled?: boolean;
   maxVisibleItems?: number;
 }
 
-export class UIDropdown {
-  constructor(_options?: UIDropdownOptions) {
-    throw new Error('UIDropdown is a stub — implement in Phase 46 #<issue>');
+export class UIDropdown extends UIElement {
+  options: UIDropdownOption[];
+  selectedIndex: number;
+  fontSize: number;
+  textColor: Vec3;
+  backgroundColor: Vec3;
+  hoverColor: Vec3;
+  font: BitmapFontData | null;
+  onChange: ((option: UIDropdownOption, index: number) => void) | null;
+  disabled: boolean;
+  isOpen: boolean;
+  maxVisibleItems: number;
+
+  constructor(options: UIDropdownOptions) {
+    super({ interactive: true, ...options });
+
+    if (!options.options || options.options.length === 0) {
+      throw new Error('UIDropdown requires at least one option');
+    }
+
+    const selectedIndex = options.selectedIndex ?? 0;
+    if (selectedIndex < 0 || selectedIndex >= options.options.length) {
+      throw new Error(`UIDropdown selectedIndex ${selectedIndex} out of range [0, ${options.options.length - 1}]`);
+    }
+
+    this.options = options.options;
+    this.selectedIndex = selectedIndex;
+    this.fontSize = options.fontSize ?? 16;
+    this.textColor = options.textColor ?? vec3(1, 1, 1);
+    this.backgroundColor = options.backgroundColor ?? vec3(0.2, 0.2, 0.2);
+    this.hoverColor = options.hoverColor ?? vec3(0.3, 0.3, 0.3);
+    this.font = options.font ?? null;
+    this.onChange = options.onChange ?? null;
+    this.disabled = options.disabled ?? false;
+    this.isOpen = false;
+    this.maxVisibleItems = options.maxVisibleItems ?? this.options.length;
+  }
+
+  open(): void {
+    if (this.disabled) return;
+    this.isOpen = true;
+  }
+
+  close(): void {
+    this.isOpen = false;
+  }
+
+  toggle(): void {
+    if (this.isOpen) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  selectByIndex(index: number): void {
+    if (index < 0 || index >= this.options.length) {
+      throw new Error(`UIDropdown selectByIndex ${index} out of range [0, ${this.options.length - 1}]`);
+    }
+    const changed = index !== this.selectedIndex;
+    this.selectedIndex = index;
+    this.isOpen = false;
+    if (changed) {
+      this.onChange?.(this.options[index], index);
+    }
+  }
+
+  getSelected(): UIDropdownOption {
+    return this.options[this.selectedIndex];
+  }
+
+  getVertices(): Float32Array {
+    const b = this.getScreenBounds();
+    const x0 = b.x;
+    const y0 = b.y;
+    const x1 = b.x + b.width;
+    const y1 = b.y + b.height;
+
+    return new Float32Array([
+      x0, y0, 0, 0,
+      x0, y1, 0, 1,
+      x1, y0, 1, 0,
+      x0, y1, 0, 1,
+      x1, y1, 1, 1,
+      x1, y0, 1, 0,
+    ]);
   }
 }


### PR DESCRIPTION
## 概述

实现 `src/ui/ui-dropdown.ts` UIDropdown 类，用于难度 / 角色 / 分辨率 / 语言等离散选项选择。

## 实现要点

- 继承 `UIElement`，构造时强制 `interactive: true`
- 构造期校验：`options` 为空或 `selectedIndex` 越界均抛错
- `open()` 在 `disabled` 时早退，`close()` 永远生效，`toggle()` 翻转状态
- `selectByIndex()` 越界抛错，仅 `selectedIndex` 实际变化时触发 `onChange`，选中后自动关闭
- `getSelected()` 返回当前选中项引用
- `getVertices()` 返回折叠态矩形顶点（6 顶点 × 4 float）

## 测试结果

- 12/12 UIDropdown 测试通过
- 1913 全量单元测试通过，零回归

closes #340