### PR TITLE
feat: 实现 FunnelSmooth Simple Stupid Funnel 路径平滑算法 (#345)

### DIFF
--- a/src/navigation/funnel.ts
+++ b/src/navigation/funnel.ts
@@ -16,15 +16,92 @@
  * @see test/unit/navigation/funnel.test.ts
  */
 
-export const __STUB__ = true;
-
 import type { Vec3 } from '../math/vec3';
 
+// XZ-plane signed area: (c-a)×(b-a) — positive means c is on the right of a→b
+function triArea2D(a: Vec3, b: Vec3, c: Vec3): number {
+  return (c[0] - a[0]) * (b[2] - a[2]) - (b[0] - a[0]) * (c[2] - a[2]);
+}
+
+function vEqual(a: Vec3, b: Vec3): boolean {
+  const dx = a[0] - b[0], dy = a[1] - b[1], dz = a[2] - b[2];
+  return dx * dx + dy * dy + dz * dz < 1e-10;
+}
+
 export function funnelSmooth(
-  _start: Vec3,
-  _end: Vec3,
-  _portalsLeft: Vec3[],
-  _portalsRight: Vec3[],
+  start: Vec3,
+  end: Vec3,
+  portalsLeft: Vec3[],
+  portalsRight: Vec3[],
 ): Vec3[] {
-  throw new Error('funnelSmooth: Not implemented (stub)');
+  if (portalsLeft.length !== portalsRight.length) {
+    throw new Error('funnelSmooth: portalsLeft and portalsRight must have the same length');
+  }
+
+  if (portalsLeft.length === 0) {
+    return [start, end];
+  }
+
+  const n = portalsLeft.length;
+  // Extended portal arrays: degenerate start portal at index 0, end portal at index n+1
+  const allLeft: Vec3[] = [start, ...portalsLeft, end];
+  const allRight: Vec3[] = [start, ...portalsRight, end];
+
+  const path: Vec3[] = [start];
+
+  let apex = start;
+  let apexIndex = 0;
+  let left = allLeft[1];
+  let right = allRight[1];
+  let leftIndex = 1;
+  let rightIndex = 1;
+
+  for (let i = 2; i <= n + 1; i++) {
+    const newLeft = allLeft[i];
+    const newRight = allRight[i];
+
+    // Try to tighten right side of funnel
+    if (triArea2D(apex, right, newRight) <= 0) {
+      if (vEqual(apex, right) || triArea2D(apex, left, newRight) > 0) {
+        right = newRight;
+        rightIndex = i;
+      } else {
+        // New right crosses left boundary — advance apex to left
+        path.push(left);
+        apex = left;
+        apexIndex = leftIndex;
+        left = apex;
+        right = apex;
+        leftIndex = apexIndex;
+        rightIndex = apexIndex;
+        i = apexIndex;
+        continue;
+      }
+    }
+
+    // Try to tighten left side of funnel
+    if (triArea2D(apex, left, newLeft) >= 0) {
+      if (vEqual(apex, left) || triArea2D(apex, right, newLeft) < 0) {
+        left = newLeft;
+        leftIndex = i;
+      } else {
+        // New left crosses right boundary — advance apex to right
+        path.push(right);
+        apex = right;
+        apexIndex = rightIndex;
+        left = apex;
+        right = apex;
+        leftIndex = apexIndex;
+        rightIndex = apexIndex;
+        i = apexIndex;
+        continue;
+      }
+    }
+  }
+
+  if (!vEqual(path[path.length - 1], end)) {
+    path.push(end);
+  }
+
+  return path;
 }


### PR DESCRIPTION
## 概述

实现 Phase 47.2 的 **Simple Stupid Funnel Algorithm**（Mikko Mononen 2010），将 NavMesh portal 边序列平滑为 string-pulled 路径。

## 实现要点

- **纯函数**：无类、无状态，单文件 `src/navigation/funnel.ts`
- **XZ 平面判定**：用 `triArea2D` 做 2D cross product 判断 funnel 收紧/穿越
- **apex 推进**：当新 portal 顶点越过对侧边界时，推进 apex 并记录路径点
- **Y 坐标保留**：XZ 仅用于几何判断，waypoint 的 Y 来自 portal 顶点本身
- **边界处理**：0 portals → [start, end]；portal 数组长度不匹配 → throw

## 验收结果

- [x] 9 个预写测试全部 pass
- [x] `npx vitest run test/unit/navigation/` 全绿（零回归）
- [x] 单元测试总计 1943 passed | 22 skipped，0 失败
- [x] 纯函数实现，无类/无状态

close #345