### PR TITLE
feat: 实现 LatheGeometry (#351)

### DIFF
--- a/src/renderer/lathe-geometry.ts
+++ b/src/renderer/lathe-geometry.ts
@@ -1,16 +1,9 @@
 /**
  * LatheGeometry — 2D profile 绕 Y 轴旋转成型几何体。
  * 用于生成花瓶、酒杯、陶罐、灯罩等旋转对称模型。
- *
- * 实现思路：
- * 1. points 是 2D (x, y) 坐标数组，x 代表距 Y 轴半径，y 代表沿 Y 轴高度
- * 2. 绕 Y 轴旋转 segments 次，每个 profile 点产生 segments+1 个顶点环
- * 3. 相邻两环展开为四边形带
  */
 
-import type { Geometry } from './geometry';
-
-export const __STUB__ = true;
+import { Geometry } from './geometry';
 
 export interface LatheGeometryOptions {
   points: Array<[number, number]>; // (x=半径, y=高度) 沿 Y 轴从下到上
@@ -19,6 +12,88 @@ export interface LatheGeometryOptions {
   phiLength?: number;  // 角度跨度（弧度），默认 2π
 }
 
-export function createLatheGeometry(_opts: LatheGeometryOptions): Geometry {
-  throw new Error('Not implemented');
+export function createLatheGeometry(opts: LatheGeometryOptions): Geometry {
+  const {
+    points,
+    segments = 12,
+    phiStart = 0,
+    phiLength = Math.PI * 2,
+  } = opts;
+
+  if (points.length < 2) throw new Error('LatheGeometry: points 至少需要 2 个');
+  if (segments < 3) throw new Error('LatheGeometry: segments 必须 >= 3');
+  if (phiLength <= 0) throw new Error('LatheGeometry: phiLength 必须 > 0');
+
+  const n = points.length;
+  const rings = segments + 1;
+  const vertexCount = n * rings;
+
+  const positions = new Float32Array(vertexCount * 3);
+  const normals = new Float32Array(vertexCount * 3);
+  const uvs = new Float32Array(vertexCount * 2);
+
+  // 用有限差分计算每个 profile 点的切线 (dr, dy)
+  // 外法线 = 将切线旋转 -90°: (dy, -dr)，即 radial 分量=dy，y 分量=-dr
+  for (let i = 0; i < n; i++) {
+    let dr: number, dy: number;
+    if (i === 0) {
+      dr = points[1][0] - points[0][0];
+      dy = points[1][1] - points[0][1];
+    } else if (i === n - 1) {
+      dr = points[n - 1][0] - points[n - 2][0];
+      dy = points[n - 1][1] - points[n - 2][1];
+    } else {
+      dr = points[i + 1][0] - points[i - 1][0];
+      dy = points[i + 1][1] - points[i - 1][1];
+    }
+
+    const len = Math.sqrt(dr * dr + dy * dy);
+    // 外法线 2D: (dy, -dr) 归一化 → radial 分量 nr, y 分量 ny
+    const nr = len > 1e-8 ? dy / len : 1;
+    const ny = len > 1e-8 ? -dr / len : 0;
+
+    const radius = points[i][0];
+    const y = points[i][1];
+    const v = i / (n - 1);
+
+    for (let j = 0; j <= segments; j++) {
+      const phi = phiStart + (j / segments) * phiLength;
+      const cosP = Math.cos(phi);
+      const sinP = Math.sin(phi);
+
+      const vi = (i * rings + j) * 3;
+      positions[vi]     = radius * cosP;
+      positions[vi + 1] = y;
+      positions[vi + 2] = radius * sinP;
+
+      normals[vi]     = nr * cosP;
+      normals[vi + 1] = ny;
+      normals[vi + 2] = nr * sinP;
+
+      const ui = (i * rings + j) * 2;
+      uvs[ui]     = j / segments;
+      uvs[ui + 1] = v;
+    }
+  }
+
+  // 每对相邻 profile 环之间生成四边形带 (2 个三角形 / 四边形)
+  const indexCount = (n - 1) * segments * 6;
+  const indices = new Uint16Array(indexCount);
+  let idx = 0;
+  for (let i = 0; i < n - 1; i++) {
+    for (let j = 0; j < segments; j++) {
+      const a = i * rings + j;
+      const b = i * rings + j + 1;
+      const c = (i + 1) * rings + j + 1;
+      const d = (i + 1) * rings + j;
+      indices[idx++] = a;
+      indices[idx++] = b;
+      indices[idx++] = d;
+      indices[idx++] = b;
+      indices[idx++] = c;
+      indices[idx++] = d;
+    }
+  }
+
+  return new Geometry({ positions, normals, uvs, indices });
 }


### PR DESCRIPTION
## 变更说明

实现 `LatheGeometry` — 2D profile 绕 Y 轴旋转成型几何体，用于生成花瓶、酒杯、陶罐、灯罩等旋转对称模型。

## 核心算法

- **顶点生成**：`points.length × (segments+1)` 个顶点，首尾不合并保证 UV 连续
- **法线计算**：用有限差分求 profile 切线 `(dr, dy)`，将切线旋转 -90° 得到 2D 外法线 `(dy, -dr)`，再展开到 3D `(nr*cos(phi), ny, nr*sin(phi))` — 长度天然为 1
- **UV**：u = j/segments（绕轴），v = i/(n-1)（沿 profile）
- **索引**：`(n-1) × segments` 个四边形，每个 2 个三角形

## 验收

- [x] 9/9 tests passing
- [x] 全量单元测试 1974/1974 通过
- [x] LatheGeometry 无类型错误

close #351