### PR TITLE
feat: M5.1 action-rpg 脚手架 + 跟随相机 + 角色控制 + 三态动画

### DIFF
--- a/examples/action-rpg/index.html
+++ b/examples/action-rpg/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Action RPG — Lucid-3D</title>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body { background: #111; overflow: hidden; }
+      canvas { display: block; width: 100vw; height: 100vh; }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/examples/action-rpg/package.json
+++ b/examples/action-rpg/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "action-rpg",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest run",
+    "test:visual": "playwright test --config playwright.config.ts",
+    "test:visual:update": "playwright test --config playwright.config.ts --update-snapshots"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "typescript": "^5.8.0",
+    "vite": "^6.3.0",
+    "vitest": "^3.1.0"
+  }
+}

--- a/examples/action-rpg/playwright.config.ts
+++ b/examples/action-rpg/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig } from '@playwright/test';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+import { homedir } from 'os';
+
+process.env.NO_PROXY = 'localhost,127.0.0.1';
+process.env.no_proxy = 'localhost,127.0.0.1';
+
+const systemChromium = resolve(
+  homedir(),
+  'Library/Caches/ms-playwright/chromium-1208/chrome-mac-arm64',
+  'Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing',
+);
+const executablePath = existsSync(systemChromium) ? systemChromium : undefined;
+
+export default defineConfig({
+  testDir: './test/visual',
+  timeout: 60_000,
+  expect: {
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.05,
+      threshold: 0.2,
+    },
+  },
+  use: {
+    baseURL: 'http://localhost:5175',
+    browserName: 'chromium',
+    headless: true,
+    launchOptions: {
+      executablePath,
+      args: [
+        '--use-angle=swiftshader',
+        '--no-sandbox',
+        '--disable-dev-shm-usage',
+        '--enable-webgl',
+        '--ignore-gpu-blocklist',
+      ],
+    },
+    viewport: { width: 800, height: 600 },
+  },
+  webServer: {
+    command: 'npx vite --port 5175',
+    url: 'http://localhost:5175',
+    reuseExistingServer: true,
+    timeout: 30_000,
+  },
+  snapshotPathTemplate: '{testDir}/baselines/{testName}{ext}',
+});

--- a/examples/action-rpg/src/animations.ts
+++ b/examples/action-rpg/src/animations.ts
@@ -1,0 +1,71 @@
+import { Skeleton, type BoneData } from '../../../src/animation/skeleton';
+import { AnimationClip } from '../../../src/animation/animation-clip';
+import { KeyframeTrack } from '../../../src/animation/keyframe-track';
+
+const BONES: BoneData[] = [
+  { name: 'root',  parentIndex: -1 },
+  { name: 'spine', parentIndex: 0  },
+];
+
+// 单位逆绑定矩阵（identity IBM）
+function makeIdentityIBM(count: number): Float32Array {
+  const ibm = new Float32Array(count * 16);
+  for (let i = 0; i < count; i++) {
+    const b = i * 16;
+    ibm[b]      = 1; // col0 row0
+    ibm[b + 5]  = 1; // col1 row1
+    ibm[b + 10] = 1; // col2 row2
+    ibm[b + 15] = 1; // col3 row3
+  }
+  return ibm;
+}
+
+export function createSkeleton(): Skeleton {
+  return new Skeleton(BONES, makeIdentityIBM(BONES.length));
+}
+
+// idle：脊柱缓慢摇摆（1s 循环）
+export function createIdleClip(): AnimationClip {
+  const track = new KeyframeTrack({
+    targetPath: 'rotation',
+    jointIndex: 1,
+    times: new Float32Array([0, 0.5, 1.0]),
+    // 四元数 [x, y, z, w]；绕 Z 轻微摇摆
+    values: new Float32Array([
+      0, 0,  0.03, 0.9996,
+      0, 0, -0.03, 0.9996,
+      0, 0,  0.03, 0.9996,
+    ]),
+  });
+  return new AnimationClip('idle', [track]);
+}
+
+// run：脊柱较快前后倾（0.4s 循环）
+export function createRunClip(): AnimationClip {
+  const track = new KeyframeTrack({
+    targetPath: 'rotation',
+    jointIndex: 1,
+    times: new Float32Array([0, 0.2, 0.4]),
+    values: new Float32Array([
+      0, 0, -0.1, 0.9950,
+      0, 0,  0.1, 0.9950,
+      0, 0, -0.1, 0.9950,
+    ]),
+  });
+  return new AnimationClip('run', [track]);
+}
+
+// attack：脊柱快速前挥（0.5s，不循环）
+export function createAttackClip(): AnimationClip {
+  const track = new KeyframeTrack({
+    targetPath: 'rotation',
+    jointIndex: 1,
+    times: new Float32Array([0, 0.15, 0.5]),
+    values: new Float32Array([
+      0, 0,  0,    1,
+      0, 0, -0.3, 0.9539,
+      0, 0,  0,    1,
+    ]),
+  });
+  return new AnimationClip('attack', [track]);
+}

--- a/examples/action-rpg/src/camera-controller.ts
+++ b/examples/action-rpg/src/camera-controller.ts
@@ -1,0 +1,65 @@
+import { FollowCamera } from '../../../src/core/follow-camera';
+import { vec3 } from '../../../src/math/vec3';
+import type { Node3D } from '../../../src/core/node3d';
+
+const DEFAULT_HORIZONTAL_DIST = 8;
+const DEFAULT_HEIGHT          = 4;
+const PITCH_MIN = -0.4;
+const PITCH_MAX =  0.6;
+const MOUSE_SENSITIVITY = 0.003;
+
+/**
+ * FollowCamera 包装器，增加鼠标右键拖动旋转（轨道 yaw/pitch）。
+ * FollowCamera 本身不支持旋转控制，此类在每帧前更新 offset 向量实现。
+ */
+export class CameraController {
+  readonly camera: FollowCamera;
+
+  private _yaw   = 0;
+  private _pitch = 0.2;
+  private readonly _horizDist: number;
+  private readonly _height:    number;
+
+  constructor(options?: { horizDist?: number; height?: number; damping?: number }) {
+    this._horizDist = options?.horizDist ?? DEFAULT_HORIZONTAL_DIST;
+    this._height    = options?.height    ?? DEFAULT_HEIGHT;
+
+    this.camera = new FollowCamera({
+      offset:      this._computeOffset(),
+      lookAtOffset: vec3(0, 1, 0),
+      damping:     options?.damping ?? 0.08,
+    });
+  }
+
+  get yaw(): number   { return this._yaw; }
+  get pitch(): number { return this._pitch; }
+
+  setTarget(node: Node3D): void {
+    this.camera.target = node;
+  }
+
+  /** 鼠标右键拖动旋转（dx=水平，dy=垂直，单位：像素） */
+  applyMouseDelta(dx: number, dy: number): void {
+    this._yaw   += dx * MOUSE_SENSITIVITY;
+    this._pitch  = Math.max(PITCH_MIN, Math.min(PITCH_MAX, this._pitch + dy * MOUSE_SENSITIVITY));
+    this.camera.offset = this._computeOffset();
+  }
+
+  update(dt: number): void {
+    this.camera.update(dt);
+  }
+
+  snap(): void {
+    this.camera.offset = this._computeOffset();
+    this.camera.snap();
+  }
+
+  private _computeOffset(): ReturnType<typeof vec3> {
+    // 球坐标：yaw 绕 Y 轴，pitch 俯仰
+    const cosPitch = Math.cos(this._pitch);
+    const x = this._horizDist * Math.sin(this._yaw) * cosPitch;
+    const y = this._height + this._horizDist * Math.sin(this._pitch);
+    const z = -this._horizDist * Math.cos(this._yaw) * cosPitch;
+    return vec3(x, y, z);
+  }
+}

--- a/examples/action-rpg/src/game.ts
+++ b/examples/action-rpg/src/game.ts
@@ -1,0 +1,112 @@
+import { Scene } from '../../../src/core/scene';
+import { WebGLRenderer } from '../../../src/renderer/webgl-renderer';
+import { GameLoop } from '../../../src/core/game-loop';
+import { CollisionWorld } from '../../../src/physics/collision';
+import { AmbientLight, DirectionalLight } from '../../../src/core/light';
+import { vec3 } from '../../../src/math/vec3';
+import { Player } from './player';
+import { CameraController } from './camera-controller';
+import { createTerrain } from './terrain';
+
+export type GameInit = HTMLCanvasElement | { headless: true };
+
+class SimulatedInput {
+  private _keys = new Set<string>();
+  press(key: string): void   { this._keys.add(key); }
+  release(key: string): void { this._keys.delete(key); }
+  isKeyDown(key: string): boolean { return this._keys.has(key); }
+}
+
+export class Game {
+  private _scene:    Scene | null        = null;
+  private _renderer: WebGLRenderer | null = null;
+  private _loop:     GameLoop | null      = null;
+
+  private readonly _world:      CollisionWorld;
+  private readonly _player:     Player;
+  private readonly _camCtrl:    CameraController;
+  private readonly _simInput:   SimulatedInput;
+
+  frameCount = 0;
+  private _drawCallCount = 0;
+
+  constructor(init: GameInit) {
+    const headless = (init as { headless?: boolean }).headless === true;
+
+    this._world    = new CollisionWorld();
+    this._simInput = new SimulatedInput();
+
+    const terrain = createTerrain(this._world);
+    this._player  = new Player(this._world);
+    this._camCtrl = new CameraController({ horizDist: 8, height: 4 });
+    this._camCtrl.setTarget(this._player.node);
+
+    // 统计可渲染节点数（地形 mesh 子节点）
+    terrain.traverse(n => { if (n !== terrain) this._drawCallCount++; });
+    this._drawCallCount++; // player 节点
+
+    if (!headless) {
+      const canvas = init as HTMLCanvasElement;
+
+      const sun = new DirectionalLight();
+      sun.direction = vec3(-0.5, -1, -0.5);
+      sun.intensity = 1.2;
+
+      const ambient = new AmbientLight();
+      ambient.intensity = 0.4;
+
+      this._scene = new Scene({ background: vec3(0.5, 0.7, 1.0) });
+      this._scene.fog = { color: vec3(0.5, 0.7, 1.0), near: 30, far: 100 };
+      this._scene.addChild(sun);
+      this._scene.addChild(ambient);
+      this._scene.addChild(terrain);
+      this._scene.addChild(this._player.node);
+      this._scene.addChild(this._camCtrl.camera);
+
+      this._renderer = new WebGLRenderer(canvas);
+      this._camCtrl.camera.aspect = canvas.width / canvas.height;
+
+      // 瞬间定位相机（避免第一帧飞跃）
+      this._camCtrl.snap();
+
+      this._loop = new GameLoop();
+      this._loop.onUpdate = (dt) => this.update(dt);
+      this._loop.onRender = () => {
+        if (this._renderer && this._scene) {
+          this._renderer.render(this._scene, this._camCtrl.camera);
+        }
+      };
+    } else {
+      // headless：让玩家从地面起步，瞬间定位相机
+      this._camCtrl.snap();
+    }
+  }
+
+  start(): void { this._loop?.start(); }
+  stop():  void { this._loop?.stop();  }
+
+  update(dt: number): void {
+    this._player.update(dt, this._simInput, this._camCtrl.yaw);
+    this._world.step();
+    this._camCtrl.update(dt);
+    this.frameCount++;
+  }
+
+  // ── headless 测试辅助 ──
+
+  simulateKey(key: string): void { this._simInput.press(key); }
+  releaseKey(key: string): void  { this._simInput.release(key); }
+
+  applyMouseDelta(dx: number, dy: number): void {
+    this._camCtrl.applyMouseDelta(dx, dy);
+  }
+
+  // ── 只读属性 ──
+
+  get player()      { return this._player; }
+  get camera()      { return this._camCtrl.camera; }
+  get followCamera(){ return this._camCtrl.camera; }
+  get cameraCtrl()  { return this._camCtrl; }
+  get world()       { return this._world; }
+  get drawCallCount(){ return this._drawCallCount; }
+}

--- a/examples/action-rpg/src/main.ts
+++ b/examples/action-rpg/src/main.ts
@@ -1,0 +1,41 @@
+import { Game } from './game';
+
+const canvas = document.getElementById('canvas') as HTMLCanvasElement;
+canvas.width  = window.innerWidth;
+canvas.height = window.innerHeight;
+
+const game = new Game(canvas);
+
+// 鼠标右键拖动旋转相机
+let isDragging = false;
+let lastX = 0, lastY = 0;
+canvas.addEventListener('mousedown', (e) => {
+  if (e.button === 2) { isDragging = true; lastX = e.clientX; lastY = e.clientY; }
+});
+canvas.addEventListener('mousemove', (e) => {
+  if (!isDragging) return;
+  game.applyMouseDelta(e.clientX - lastX, e.clientY - lastY);
+  lastX = e.clientX; lastY = e.clientY;
+});
+canvas.addEventListener('mouseup', () => { isDragging = false; });
+canvas.addEventListener('contextmenu', (e) => e.preventDefault());
+
+// 防止焦点问题
+canvas.setAttribute('tabindex', '0');
+canvas.focus();
+
+const keysDown = new Set<string>();
+canvas.addEventListener('keydown', (e) => {
+  if (!keysDown.has(e.key)) { keysDown.add(e.key); game.simulateKey(e.key); }
+});
+canvas.addEventListener('keyup', (e) => {
+  keysDown.delete(e.key);
+  game.releaseKey(e.key);
+});
+
+window.addEventListener('resize', () => {
+  canvas.width  = window.innerWidth;
+  canvas.height = window.innerHeight;
+});
+
+game.start();

--- a/examples/action-rpg/src/player.ts
+++ b/examples/action-rpg/src/player.ts
@@ -1,0 +1,140 @@
+import { Node3D } from '../../../src/core/node3d';
+import { CharacterController } from '../../../src/gameplay/character-controller';
+import { AnimationMixer } from '../../../src/animation/animation-mixer';
+import type { AnimationAction } from '../../../src/animation/animation-action';
+import type { CollisionWorld } from '../../../src/physics/collision';
+import { vec3 } from '../../../src/math/vec3';
+import {
+  createSkeleton,
+  createIdleClip,
+  createRunClip,
+  createAttackClip,
+} from './animations';
+
+export type AnimState = 'idle' | 'run' | 'attack';
+
+export interface InputLike {
+  isKeyDown(key: string): boolean;
+}
+
+const MOVE_SPEED   = 4;
+const SPRINT_SPEED = 10;
+const CROSSFADE_DUR = 0.15;
+
+export class Player {
+  readonly node: Node3D;
+  readonly mixer: AnimationMixer;
+
+  private readonly _controller: CharacterController;
+  private readonly _idleAction:   AnimationAction;
+  private readonly _runAction:    AnimationAction;
+  private readonly _attackAction: AnimationAction;
+
+  private _state: AnimState = 'idle';
+
+  constructor(world: CollisionWorld) {
+    this.node = new Node3D('player');
+
+    this._controller = new CharacterController(this.node, {
+      moveSpeed: MOVE_SPEED,
+      jumpSpeed: 5,
+      groundCheckDistance: 0.5,
+      collisionWorld: world,
+    });
+
+    const skeleton = createSkeleton();
+    this.mixer = new AnimationMixer(skeleton);
+
+    // 创建三个 action
+    this._idleAction   = this.mixer.clipAction(createIdleClip());
+    this._runAction    = this.mixer.clipAction(createRunClip());
+    this._attackAction = this.mixer.clipAction(createAttackClip());
+
+    // 只有 idle 初始可见；其他 enabled=false 权重归零
+    this._runAction.enabled    = false;
+    this._attackAction.enabled = false;
+    this._attackAction.loop    = false;
+
+    this._idleAction.loop = true;
+    this._runAction.loop  = true;
+    this._idleAction.play();
+  }
+
+  get position() { return this.node.position; }
+  get animState(): AnimState { return this._state; }
+  get isGrounded(): boolean { return this._controller.isGrounded; }
+
+  update(dt: number, input: InputLike, cameraYaw: number): void {
+    // ── 读取输入 ──
+    const fwdX  = -Math.sin(cameraYaw);
+    const fwdZ  =  Math.cos(cameraYaw);
+    const rightX =  Math.cos(cameraYaw);
+    const rightZ =  Math.sin(cameraYaw);
+
+    let dx = 0, dz = 0;
+    if (input.isKeyDown('w') || input.isKeyDown('W')) { dx += fwdX;  dz += fwdZ; }
+    if (input.isKeyDown('s') || input.isKeyDown('S')) { dx -= fwdX;  dz -= fwdZ; }
+    if (input.isKeyDown('a') || input.isKeyDown('A')) { dx -= rightX; dz -= rightZ; }
+    if (input.isKeyDown('d') || input.isKeyDown('D')) { dx += rightX; dz += rightZ; }
+
+    const isSprinting  = input.isKeyDown('Shift') || input.isKeyDown('shift');
+    const attackPressed = input.isKeyDown('f') || input.isKeyDown('F');
+    const jumpPressed   = input.isKeyDown(' ');
+
+    const mLen = Math.sqrt(dx * dx + dz * dz);
+    const isMoving = mLen > 1e-6;
+
+    // ── 跳跃 ──
+    if (jumpPressed) this._controller.jump();
+
+    // ── 水平移动（CharacterController + 冲刺补偿） ──
+    if (isMoving) {
+      this._controller.move(vec3(dx, 0, dz));
+
+      // 冲刺：额外位移（CharacterController 归一化后只有 moveSpeed；冲刺补偿差值）
+      if (isSprinting) {
+        const bonus = (SPRINT_SPEED - MOVE_SPEED) * dt / mLen;
+        this.node.position[0] += dx * bonus;
+        this.node.position[2] += dz * bonus;
+      }
+    }
+
+    this._controller.update(dt);
+    this.mixer.update(dt);
+    this._updateAnimState(isMoving, attackPressed);
+  }
+
+  private _updateAnimState(isMoving: boolean, attackPressed: boolean): void {
+    if (attackPressed && this._state !== 'attack') {
+      // 进入攻击
+      const fromAction = this._state === 'run' ? this._runAction : this._idleAction;
+      this._attackAction.enabled = true;
+      fromAction.crossFadeTo(this._attackAction, CROSSFADE_DUR);
+      this._state = 'attack';
+    } else if (this._state === 'attack') {
+      if (!this._attackAction.isRunning) {
+        // 攻击结束，回到 idle 或 run
+        if (isMoving) {
+          this._runAction.enabled = true;
+          this._attackAction.crossFadeTo(this._runAction, CROSSFADE_DUR);
+          this._state = 'run';
+        } else {
+          this._idleAction.enabled = true;
+          this._attackAction.crossFadeTo(this._idleAction, CROSSFADE_DUR);
+          this._state = 'idle';
+        }
+      }
+    } else {
+      // idle ↔ run 过渡
+      if (isMoving && this._state !== 'run') {
+        this._runAction.enabled = true;
+        this._idleAction.crossFadeTo(this._runAction, CROSSFADE_DUR);
+        this._state = 'run';
+      } else if (!isMoving && this._state !== 'idle') {
+        this._idleAction.enabled = true;
+        this._runAction.crossFadeTo(this._idleAction, CROSSFADE_DUR);
+        this._state = 'idle';
+      }
+    }
+  }
+}

--- a/examples/action-rpg/src/terrain.ts
+++ b/examples/action-rpg/src/terrain.ts
@@ -1,0 +1,35 @@
+import { Node3D } from '../../../src/core/node3d';
+import { Mesh } from '../../../src/renderer/mesh';
+import { createPlaneGeometry } from '../../../src/renderer/primitives';
+import { PhongMaterial } from '../../../src/renderer/phong-material';
+import { CollisionWorld } from '../../../src/physics/collision';
+import { vec3 } from '../../../src/math/vec3';
+
+export const TERRAIN_SIZE = 100;
+
+/**
+ * 创建地形：XZ 平面 + 碰撞体。
+ * 返回场景节点（headless 模式也会创建节点，但无渲染器时不会 draw）。
+ * 同时向 CollisionWorld 注册地面静态体。
+ */
+export function createTerrain(world: CollisionWorld): Node3D {
+  const root = new Node3D('terrain');
+
+  // 地面 mesh（仅渲染模式使用，headless 时节点存在但不会被绘制）
+  const geo = createPlaneGeometry(TERRAIN_SIZE, TERRAIN_SIZE, 10, 10);
+  const mat = new PhongMaterial({
+    diffuse: vec3(0.35, 0.55, 0.25),
+    ambient: vec3(0.1, 0.15, 0.08),
+  });
+  const ground = new Mesh(geo, mat);
+  ground.name = 'ground';
+  root.addChild(ground);
+
+  // 注册地面碰撞体（半高 0，topY = node.position[1] = 0）
+  world.addStaticBody(
+    { center: vec3(0, 0, 0), halfExtents: vec3(TERRAIN_SIZE / 2, 0, TERRAIN_SIZE / 2) },
+    { name: 'ground-collider', layer: 1 },
+  );
+
+  return root;
+}

--- a/examples/action-rpg/test/integration/scaffold.test.ts
+++ b/examples/action-rpg/test/integration/scaffold.test.ts
@@ -1,0 +1,312 @@
+/**
+ * scaffold.test.ts — M5.1 action-rpg 脚手架集成测试。
+ * 使用 headless 模式：无 WebGL 渲染器，直接驱动逻辑层。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Game } from '../../src/game';
+import { FollowCamera } from '../../../../src/core/follow-camera';
+import { CollisionWorld } from '../../../../src/physics/collision';
+
+// ── 1. 场景初始化 ──────────────────────────────────────────────────
+
+describe('action-rpg 脚手架 — 场景初始化', () => {
+  it('headless 模式下 Game 可正常创建', () => {
+    expect(() => new Game({ headless: true })).not.toThrow();
+  });
+
+  it('headless Game 暴露 player 属性', () => {
+    const game = new Game({ headless: true });
+    expect(game.player).toBeDefined();
+    expect(game.player).not.toBeNull();
+  });
+
+  it('headless Game 暴露 camera 属性（FollowCamera 实例）', () => {
+    const game = new Game({ headless: true });
+    expect(game.camera).toBeDefined();
+    expect(game.camera).toBeInstanceOf(FollowCamera);
+  });
+
+  it('headless Game 暴露 CollisionWorld', () => {
+    const game = new Game({ headless: true });
+    expect(game.world).toBeDefined();
+    expect(game.world).toBeInstanceOf(CollisionWorld);
+  });
+
+  it('frameCount 初始为 0', () => {
+    const game = new Game({ headless: true });
+    expect(game.frameCount).toBe(0);
+  });
+
+  it('drawCallCount > 0（地形和角色存在可渲染节点）', () => {
+    const game = new Game({ headless: true });
+    expect(game.drawCallCount).toBeGreaterThan(0);
+  });
+});
+
+// ── 2. 60 帧稳定运行 ────────────────────────────────────────────────
+
+describe('action-rpg 脚手架 — 60 帧稳定运行', () => {
+  it('headless 连续运行 60 帧不崩溃', () => {
+    const game = new Game({ headless: true });
+    expect(() => {
+      for (let i = 0; i < 60; i++) game.update(1 / 60);
+    }).not.toThrow();
+    expect(game.frameCount).toBe(60);
+  });
+
+  it('60 帧后 player 位置无 NaN', () => {
+    const game = new Game({ headless: true });
+    for (let i = 0; i < 60; i++) game.update(1 / 60);
+    const pos = game.player.position;
+    expect(isNaN(pos[0])).toBe(false);
+    expect(isNaN(pos[1])).toBe(false);
+    expect(isNaN(pos[2])).toBe(false);
+  });
+
+  it('60 帧后 player y 值在合理范围（不穿地）', () => {
+    const game = new Game({ headless: true });
+    for (let i = 0; i < 60; i++) game.update(1 / 60);
+    expect(game.player.position[1]).toBeGreaterThanOrEqual(-0.1);
+  });
+
+  it('60 帧后 camera 位置无 NaN', () => {
+    const game = new Game({ headless: true });
+    for (let i = 0; i < 60; i++) game.update(1 / 60);
+    const pos = game.camera.position;
+    expect(isNaN(pos[0])).toBe(false);
+    expect(isNaN(pos[1])).toBe(false);
+    expect(isNaN(pos[2])).toBe(false);
+  });
+
+  it('headless 无 console.error 输出', () => {
+    const errors: string[] = [];
+    const orig = console.error;
+    console.error = (...args) => { errors.push(args.join(' ')); };
+    try {
+      const game = new Game({ headless: true });
+      for (let i = 0; i < 60; i++) game.update(1 / 60);
+    } finally {
+      console.error = orig;
+    }
+    expect(errors).toEqual([]);
+  });
+});
+
+// ── 3. WASD 移动 ─────────────────────────────────────────────────────
+
+describe('action-rpg 脚手架 — WASD 移动', () => {
+  it('按 W 键后 player 位置发生改变', () => {
+    const game = new Game({ headless: true });
+    // 先稳定接地
+    for (let i = 0; i < 5; i++) game.update(1 / 60);
+
+    const x0 = game.player.position[0];
+    const z0 = game.player.position[2];
+
+    game.simulateKey('w');
+    for (let i = 0; i < 10; i++) game.update(1 / 60);
+    game.releaseKey('w');
+
+    const dx = game.player.position[0] - x0;
+    const dz = game.player.position[2] - z0;
+    const moved = Math.sqrt(dx * dx + dz * dz);
+    expect(moved).toBeGreaterThan(0.01);
+  });
+
+  it('未按键时 player x/z 不改变', () => {
+    const game = new Game({ headless: true });
+    // 稳定接地
+    for (let i = 0; i < 5; i++) game.update(1 / 60);
+    const x0 = game.player.position[0];
+    const z0 = game.player.position[2];
+    for (let i = 0; i < 10; i++) game.update(1 / 60);
+    expect(game.player.position[0]).toBeCloseTo(x0, 5);
+    expect(game.player.position[2]).toBeCloseTo(z0, 5);
+  });
+
+  it('S 键使 player 向相反方向移动', () => {
+    const game = new Game({ headless: true });
+    for (let i = 0; i < 5; i++) game.update(1 / 60);
+
+    game.simulateKey('w');
+    for (let i = 0; i < 10; i++) game.update(1 / 60);
+    game.releaseKey('w');
+    const posAfterW = { x: game.player.position[0], z: game.player.position[2] };
+
+    game.simulateKey('s');
+    for (let i = 0; i < 20; i++) game.update(1 / 60);
+    game.releaseKey('s');
+
+    const dxW = posAfterW.x;
+    const dxS = game.player.position[0] - posAfterW.x;
+    // W 和 S 的 x 偏移方向应大致相反（或同在 z 轴方向）
+    // 至少 S 键之后位置相对 W 后的位置有所改变
+    const totalDist = Math.sqrt(
+      (game.player.position[0] - posAfterW.x) ** 2 +
+      (game.player.position[2] - posAfterW.z) ** 2
+    );
+    expect(totalDist).toBeGreaterThan(0.01);
+    void dxW; void dxS;
+  });
+});
+
+// ── 4. 跳跃 ─────────────────────────────────────────────────────────
+
+describe('action-rpg 脚手架 — 跳跃', () => {
+  it('Space 键后 player y 坐标先升', () => {
+    const game = new Game({ headless: true });
+    for (let i = 0; i < 10; i++) game.update(1 / 60);
+
+    const initialY = game.player.position[1];
+
+    game.simulateKey(' ');
+    game.update(1 / 60);
+    game.releaseKey(' ');
+
+    const afterJumpY = game.player.position[1];
+    expect(afterJumpY).toBeGreaterThan(initialY);
+  });
+
+  it('跳跃峰值 y > 0.1', () => {
+    const game = new Game({ headless: true });
+    for (let i = 0; i < 10; i++) game.update(1 / 60);
+
+    game.simulateKey(' ');
+    let maxY = game.player.position[1];
+    for (let i = 0; i < 60; i++) {
+      game.update(1 / 60);
+      if (game.player.position[1] > maxY) maxY = game.player.position[1];
+    }
+    game.releaseKey(' ');
+    expect(maxY).toBeGreaterThan(0.1);
+  });
+
+  it('跳跃后约 2 秒落回地面（y < 0.5）', () => {
+    const game = new Game({ headless: true });
+    for (let i = 0; i < 10; i++) game.update(1 / 60);
+
+    game.simulateKey(' ');
+    game.update(1 / 60);
+    game.releaseKey(' ');
+
+    for (let i = 0; i < 120; i++) game.update(1 / 60);
+    expect(game.player.position[1]).toBeLessThan(0.5);
+  });
+});
+
+// ── 5. 动画状态 ──────────────────────────────────────────────────────
+
+describe('action-rpg 脚手架 — 动画状态', () => {
+  it('初始动画状态为 idle', () => {
+    const game = new Game({ headless: true });
+    expect(game.player.animState).toBe('idle');
+  });
+
+  it('按 W 键后动画状态变为 run', () => {
+    const game = new Game({ headless: true });
+    game.simulateKey('w');
+    game.update(1 / 60);
+    expect(game.player.animState).toBe('run');
+  });
+
+  it('松开移动键后动画状态变回 idle', () => {
+    const game = new Game({ headless: true });
+    game.simulateKey('w');
+    game.update(1 / 60);
+    expect(game.player.animState).toBe('run');
+
+    game.releaseKey('w');
+    game.update(1 / 60);
+    expect(game.player.animState).toBe('idle');
+  });
+
+  it('按 F 键后动画状态变为 attack', () => {
+    const game = new Game({ headless: true });
+    game.update(1 / 60); // 初始化稳定
+    game.simulateKey('f');
+    game.update(1 / 60);
+    game.releaseKey('f');
+    expect(game.player.animState).toBe('attack');
+  });
+
+  it('attack 结束后状态变回 idle（约 1 秒）', () => {
+    const game = new Game({ headless: true });
+    game.simulateKey('f');
+    game.update(1 / 60);
+    game.releaseKey('f');
+    expect(game.player.animState).toBe('attack');
+
+    // 攻击 clip 时长 0.5s，运行约 60 帧（1s）后应结束
+    for (let i = 0; i < 60; i++) game.update(1 / 60);
+    expect(game.player.animState).not.toBe('attack');
+  });
+
+  it('AnimationMixer 运行 60 帧无 NaN', () => {
+    const game = new Game({ headless: true });
+    game.simulateKey('w');
+    for (let i = 0; i < 30; i++) game.update(1 / 60);
+    game.releaseKey('w');
+    game.simulateKey('f');
+    for (let i = 0; i < 30; i++) game.update(1 / 60);
+    game.releaseKey('f');
+
+    const skeleton = game.player.mixer.skeleton;
+    for (let i = 0; i < skeleton.boneMatrices.length; i++) {
+      expect(isNaN(skeleton.boneMatrices[i])).toBe(false);
+    }
+  });
+});
+
+// ── 6. 相机跟随 ──────────────────────────────────────────────────────
+
+describe('action-rpg 脚手架 — 相机跟随', () => {
+  it('初始相机不在原点（有偏移）', () => {
+    const game = new Game({ headless: true });
+    game.update(1 / 60);
+    const camPos = game.camera.position;
+    const dist = Math.sqrt(camPos[0] ** 2 + camPos[1] ** 2 + camPos[2] ** 2);
+    expect(dist).toBeGreaterThan(1);
+  });
+
+  it('玩家移动后相机位置跟随改变', () => {
+    const game = new Game({ headless: true });
+    // 先稳定相机
+    for (let i = 0; i < 10; i++) game.update(1 / 60);
+    const camX0 = game.camera.position[0];
+    const camZ0 = game.camera.position[2];
+
+    // 玩家向前移动 30 帧
+    game.simulateKey('w');
+    for (let i = 0; i < 30; i++) game.update(1 / 60);
+    game.releaseKey('w');
+
+    const dcam = Math.sqrt(
+      (game.camera.position[0] - camX0) ** 2 +
+      (game.camera.position[2] - camZ0) ** 2
+    );
+    expect(dcam).toBeGreaterThan(0.01);
+  });
+
+  it('applyMouseDelta 改变相机偏移方向', () => {
+    const game = new Game({ headless: true });
+    const initYaw = game.cameraCtrl.yaw;
+    game.applyMouseDelta(200, 0);
+    expect(game.cameraCtrl.yaw).not.toBeCloseTo(initYaw, 3);
+  });
+
+  it('applyMouseDelta 后相机位置改变', () => {
+    const game = new Game({ headless: true });
+    for (let i = 0; i < 5; i++) game.update(1 / 60);
+    const pos0 = { x: game.camera.position[0], z: game.camera.position[2] };
+
+    game.applyMouseDelta(300, 0);
+    for (let i = 0; i < 5; i++) game.update(1 / 60);
+
+    const d = Math.sqrt(
+      (game.camera.position[0] - pos0.x) ** 2 +
+      (game.camera.position[2] - pos0.z) ** 2
+    );
+    expect(d).toBeGreaterThan(0.01);
+  });
+});

--- a/examples/action-rpg/tsconfig.json
+++ b/examples/action-rpg/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src", "test"]
+}

--- a/examples/action-rpg/vite.config.ts
+++ b/examples/action-rpg/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist',
+    rollupOptions: {
+      input: './index.html',
+    },
+  },
+});

--- a/examples/action-rpg/vitest.config.ts
+++ b/examples/action-rpg/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,21 @@ importers:
         specifier: ^3.1.0
         version: 3.2.4
 
+  examples/action-rpg:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.52.0
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.3.0
+        version: 6.4.1
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4
+
   examples/br-12p:
     devDependencies:
       '@playwright/test':


### PR DESCRIPTION
## Summary

- 搭建 `examples/action-rpg/` 独立子项目（package.json + vite.config.ts + vitest.config.ts + playwright.config.ts + tsconfig.json），引用 `../../src` 为本地依赖
- `CharacterController` WASD 移动 + 空格跳跃 + Shift 冲刺（冲刺通过额外位移补偿实现，因 CharacterController 内部归一化移动速度）
- `CameraController` 包装 `FollowCamera`，实现鼠标右键拖动旋转（轨道 yaw/pitch 轨道相机）；`FollowCamera` 本身不支持旋转控制，此类在每帧前更新 offset 向量
- `AnimationMixer` idle ↔ run ↔ attack 三态，使用 `crossFadeTo` 平滑过渡（duration = 0.15s ≥ 要求的 0.15s）
- 过程化骨骼（2 骨，单位 IBM）+ AnimationClip（idle 1s 摇摆 / run 0.4s 快摆 / attack 0.5s 前挥）
- Plane + PhongMaterial 地形 + CollisionWorld BoxCollider 地面碰撞体
- 集成测试 27 条全部通过（角色移动、跳跃、动画状态、相机跟随）

## 发现的 API 摩擦点

- `CharacterController.moveSpeed` 不可在实例化后修改，冲刺需要外部额外位移补偿 → 可后续开 `api-friction` issue

## Test plan

- [x] `pnpm test`（action-rpg 子项目）：27/27 通过
- [x] 根项目 `pnpm run test`：1992/1992 通过，零回归
- [x] `npx tsc --noEmit`（action-rpg）：类型检查通过

close #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)