### PR TITLE
feat: M5.3 战斗系统 — 近战 TrailRenderer 剑气 + 远程 Curve3 弓箭弹道

### DIFF
--- a/examples/action-rpg/src/combat.ts
+++ b/examples/action-rpg/src/combat.ts
@@ -1,0 +1,244 @@
+/**
+ * CombatSystem — 战斗系统，支持近战（剑气）和远程（弓箭弹道）。
+ *
+ * 近战：扇形 hitbox (3m × 90°) + TrailRenderer 剑气 + 粒子爆发 + Health.takeDamage(25)
+ * 远程：Curve3 CatmullRom 抛物线弹道 + TubeGeometry 箭体 + 粒子爆发 + Health.takeDamage(40)
+ */
+
+import { Node3D } from '../../../src/core/node3d';
+import { TrailRenderer } from '../../../src/renderer/trail';
+import { Curve3 } from '../../../src/math/curve3';
+import { createTubeGeometry } from '../../../src/renderer/tube-geometry';
+import { Mesh } from '../../../src/renderer/mesh';
+import { PhongMaterial } from '../../../src/renderer/phong-material';
+import { ParticleEmitter } from '../../../src/renderer/particle-emitter';
+import { vec3, type Vec3 } from '../../../src/math/vec3';
+import type { Health } from '../../../src/gameplay/health';
+
+export type WeaponType = 'sword' | 'bow';
+
+export interface CombatTarget {
+  node: Node3D;
+  health: Health;
+  readonly isDead: boolean;
+}
+
+const SWORD_COOLDOWN = 0.5;
+const BOW_COOLDOWN   = 1.0;
+const SWORD_RANGE    = 3.0;
+const SWORD_HALF_ARC = Math.PI / 4;  // 90° 扇形的半角
+const SWORD_DAMAGE   = 25;
+const BOW_DAMAGE     = 40;
+const BOW_FLIGHT_T   = 1.0;
+const BOW_DIST       = 20.0;
+const ARROW_HIT_R    = 0.5;
+const ARROW_ARC_H    = 2.0;  // 抛物线弧顶高度
+
+interface Arrow {
+  curve: Curve3;
+  progress: number;
+  active: boolean;
+  node: Node3D;
+}
+
+export class CombatSystem {
+  weapon: WeaponType = 'sword';
+
+  private _cooldown = 0;
+  private _arrows: Arrow[] = [];
+  private _enemies: readonly CombatTarget[];
+  private _swordTip: Node3D;
+
+  readonly trail: TrailRenderer;
+  readonly particles: ParticleEmitter;
+
+  /** 命中计数，供测试观察 */
+  hitCount = 0;
+  lastHitTarget: CombatTarget | null = null;
+
+  constructor(playerNode: Node3D, enemies: readonly CombatTarget[]) {
+    this._enemies = enemies;
+
+    // 剑尖节点（挂在玩家节点下，稍微偏右前方）
+    this._swordTip = new Node3D('sword-tip');
+    this._swordTip.position[0] = 0.5;
+    this._swordTip.position[1] = 1.0;
+    this._swordTip.position[2] = 0.5;
+    playerNode.addChild(this._swordTip);
+
+    // TrailRenderer 附着剑尖
+    this.trail = new TrailRenderer({
+      width: 0.4,
+      lifetime: 0.4,
+      color: vec3(0.3, 0.6, 1.0),
+      colorEnd: vec3(0.1, 0.2, 0.8),
+    });
+    this._swordTip.addChild(this.trail);
+
+    // 粒子爆发：命中效果
+    this.particles = new ParticleEmitter({
+      maxParticles: 40,
+      emissionRate: 0,
+      lifetime: { min: 0.2, max: 0.5 },
+      speed: { min: 2, max: 6 },
+      size: { min: 0.05, max: 0.2 },
+      color: vec3(1, 0.7, 0.1),
+      colorEnd: vec3(1, 0.1, 0),
+      spread: Math.PI / 3,
+      gravity: vec3(0, -5, 0),
+    });
+  }
+
+  get canAttack(): boolean { return this._cooldown <= 0; }
+  get activeCooldown(): number { return this._cooldown; }
+
+  switchWeapon(type: WeaponType): void {
+    this.weapon = type;
+  }
+
+  /**
+   * 发动攻击。
+   * @param playerPos    玩家当前世界坐标
+   * @param playerForward 玩家朝向（归一化，XZ 平面）
+   * @returns 是否成功攻击（冷却未到期时返回 false）
+   */
+  attack(playerPos: Vec3, playerForward: Vec3): boolean {
+    if (this._cooldown > 0) return false;
+    return this.weapon === 'sword'
+      ? this._meleeAttack(playerPos, playerForward)
+      : this._bowAttack(playerPos, playerForward);
+  }
+
+  update(dt: number): void {
+    if (this._cooldown > 0) this._cooldown = Math.max(0, this._cooldown - dt);
+
+    // 近战冷却期间更新剑气轨迹
+    if (this.weapon === 'sword' && this._cooldown > 0) {
+      this.trail.update(dt);
+    }
+
+    // 更新飞行中的弓箭
+    for (const arrow of this._arrows) {
+      if (!arrow.active) continue;
+
+      arrow.progress += dt / BOW_FLIGHT_T;
+      if (arrow.progress >= 1) {
+        arrow.active = false;
+        continue;
+      }
+
+      const pos = arrow.curve.getPoint(arrow.progress);
+      arrow.node.position[0] = pos[0];
+      arrow.node.position[1] = pos[1];
+      arrow.node.position[2] = pos[2];
+
+      // 每帧检测与所有敌人的距离
+      for (const target of this._enemies) {
+        if (target.isDead) continue;
+
+        const dx = target.node.position[0] - pos[0];
+        const dy = target.node.position[1] - pos[1];
+        const dz = target.node.position[2] - pos[2];
+        const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+        if (dist < ARROW_HIT_R) {
+          target.health.takeDamage(BOW_DAMAGE);
+          this._spawnHitEffect(target.node.position);
+          this.lastHitTarget = target;
+          this.hitCount++;
+          arrow.active = false;
+          break;
+        }
+      }
+    }
+
+    // 清理已失活的箭
+    this._arrows = this._arrows.filter(a => a.active);
+
+    this.particles.update(dt);
+  }
+
+  // ── 私有方法 ────────────────────────────────────────────
+
+  private _meleeAttack(playerPos: Vec3, playerForward: Vec3): boolean {
+    this._cooldown = SWORD_COOLDOWN;
+    this.trail.reset();
+
+    const cosCone = Math.cos(SWORD_HALF_ARC);
+    let hitAny = false;
+
+    for (const target of this._enemies) {
+      if (target.isDead) continue;
+
+      const dx = target.node.position[0] - playerPos[0];
+      const dz = target.node.position[2] - playerPos[2];
+      const dist = Math.sqrt(dx * dx + dz * dz);
+      if (dist > SWORD_RANGE) continue;
+
+      // XZ 平面扇形角度检测
+      const nx = dist > 1e-6 ? dx / dist : 0;
+      const nz = dist > 1e-6 ? dz / dist : 0;
+      const cosAngle = nx * playerForward[0] + nz * playerForward[2];
+      if (cosAngle < cosCone) continue;
+
+      target.health.takeDamage(SWORD_DAMAGE);
+      this._spawnHitEffect(target.node.position);
+      this.lastHitTarget = target;
+      this.hitCount++;
+      hitAny = true;
+    }
+
+    return hitAny;
+  }
+
+  private _bowAttack(playerPos: Vec3, playerForward: Vec3): boolean {
+    this._cooldown = BOW_COOLDOWN;
+
+    const startPos = vec3(playerPos[0], playerPos[1], playerPos[2]);
+    const endPos   = vec3(
+      playerPos[0] + playerForward[0] * BOW_DIST,
+      playerPos[1],
+      playerPos[2] + playerForward[2] * BOW_DIST,
+    );
+    const midPos = vec3(
+      (startPos[0] + endPos[0]) / 2,
+      startPos[1] + ARROW_ARC_H,
+      (startPos[2] + endPos[2]) / 2,
+    );
+
+    const curve = new Curve3([startPos, midPos, endPos]);
+
+    // 创建箭体节点（TubeGeometry 管道 + PhongMaterial emissive）
+    const arrowNode = new Node3D('arrow');
+    arrowNode.position[0] = startPos[0];
+    arrowNode.position[1] = startPos[1];
+    arrowNode.position[2] = startPos[2];
+
+    // 生成简短箭体几何（0.4m 长的微型曲线管道）
+    const arrowCurve = new Curve3([
+      vec3(0, 0, -0.2),
+      vec3(0, 0,  0.0),
+      vec3(0, 0,  0.2),
+    ]);
+    const arrowGeom = createTubeGeometry({
+      curve: arrowCurve,
+      tubularSegments: 8,
+      radius: 0.04,
+      radialSegments: 6,
+    });
+    const arrowMat = new PhongMaterial({
+      emissive: vec3(1, 0.5, 0.1),
+    });
+    arrowNode.addChild(new Mesh(arrowGeom, arrowMat));
+
+    this._arrows.push({ curve, progress: 0, active: true, node: arrowNode });
+    return true;
+  }
+
+  private _spawnHitEffect(pos: Vec3): void {
+    this.particles.position[0] = pos[0];
+    this.particles.position[1] = pos[1] + 0.5;
+    this.particles.position[2] = pos[2];
+    this.particles.emit(15);
+  }
+}

--- a/examples/action-rpg/src/game.ts
+++ b/examples/action-rpg/src/game.ts
@@ -8,6 +8,7 @@ import { Player } from './player';
 import { CameraController } from './camera-controller';
 import { createTerrain } from './terrain';
 import { EnemyManager } from './enemy-manager';
+import { CombatSystem } from './combat';
 import { HUD } from './hud';
 import type { BitmapFontData, BitmapCharData } from '../../../src/renderer/bitmap-font';
 
@@ -40,6 +41,7 @@ export class Game {
   private readonly _camCtrl:      CameraController;
   private readonly _simInput:     SimulatedInput;
   private readonly _enemyManager: EnemyManager;
+  private readonly _combat:       CombatSystem;
 
   frameCount = 0;
   private _drawCallCount = 0;
@@ -56,6 +58,7 @@ export class Game {
     this._camCtrl.setTarget(this._player.node);
 
     this._enemyManager = new EnemyManager(this._player.node);
+    this._combat = new CombatSystem(this._player.node, this._enemyManager.enemies);
 
     // 统计可渲染节点数（地形 mesh 子节点）
     terrain.traverse(n => { if (n !== terrain) this._drawCallCount++; });
@@ -110,7 +113,13 @@ export class Game {
           this._hud?.toggleEscMenu();
         } else if (e.key === 'i' || e.key === 'I') {
           this._hud?.toggleInventory();
-        } else if (e.key >= '1' && e.key <= '4') {
+        } else if (e.key === '1') {
+          this._combat.switchWeapon('sword');
+          this._hud?.selectSkill(0);
+        } else if (e.key === '2') {
+          this._combat.switchWeapon('bow');
+          this._hud?.selectSkill(1);
+        } else if (e.key === '3' || e.key === '4') {
           const slot = parseInt(e.key) - 1;
           this._hud?.selectSkill(slot);
         }
@@ -138,7 +147,21 @@ export class Game {
       return;
     }
 
+    // 武器切换（headless 模式通过 simulateKey 驱动）
+    if (this._simInput.isKeyDown('1')) this._combat.switchWeapon('sword');
+    if (this._simInput.isKeyDown('2')) this._combat.switchWeapon('bow');
+
     this._player.update(dt, this._simInput, this._camCtrl.yaw);
+
+    // 攻击指令：按 F 键时同步触发战斗系统
+    if (this._simInput.isKeyDown('f') || this._simInput.isKeyDown('F')) {
+      const yaw  = this._camCtrl.yaw;
+      const fwdX = -Math.sin(yaw);
+      const fwdZ =  Math.cos(yaw);
+      this._combat.attack(this._player.position, vec3(fwdX, 0, fwdZ));
+    }
+
+    this._combat.update(dt);
     this._world.step();
     this._camCtrl.update(dt);
     this._enemyManager.update(1 / 60);
@@ -165,4 +188,5 @@ export class Game {
   get hud()           { return this._hud; }
   get drawCallCount() { return this._drawCallCount; }
   get enemyManager()  { return this._enemyManager; }
+  get combat()        { return this._combat; }
 }

--- a/test/integration/combat.test.ts
+++ b/test/integration/combat.test.ts
@@ -1,0 +1,252 @@
+/**
+ * 集成测试 — M5.3 战斗系统 (Issue #358)
+ *
+ * 验证：
+ * - 玩家可按 1/2 切换近战/远程武器
+ * - 近战（剑）：扇形 hitbox 命中 Enemy，Health.takeDamage(25)
+ * - 远程（弓）：Curve3 抛物线弹道飞行，命中 Enemy，Health.takeDamage(40)
+ * - 攻击冷却时间（剑 0.5s / 弓 1s）
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Node3D } from '../../src/core/node3d';
+import { Health } from '../../src/gameplay/health';
+import { vec3 } from '../../src/math/vec3';
+import { CombatSystem, type CombatTarget } from '../../examples/action-rpg/src/combat';
+
+const DT = 1 / 60;
+
+/** 创建最简单的 CombatTarget mock */
+function makeTarget(x = 0, y = 0, z = 0, maxHp = 100): CombatTarget {
+  const node = new Node3D('target');
+  node.position[0] = x;
+  node.position[1] = y;
+  node.position[2] = z;
+  const health = new Health(maxHp);
+  return { node, health, get isDead() { return health.isDead; } };
+}
+
+// ── 1. 武器切换 ──────────────────────────────────────────────────────
+
+describe('CombatSystem — 武器切换', () => {
+  it('初始武器为 sword', () => {
+    const player = new Node3D('player');
+    const system = new CombatSystem(player, []);
+    expect(system.weapon).toBe('sword');
+  });
+
+  it('switchWeapon("bow") 切换为弓', () => {
+    const player = new Node3D('player');
+    const system = new CombatSystem(player, []);
+    system.switchWeapon('bow');
+    expect(system.weapon).toBe('bow');
+  });
+
+  it('switchWeapon("sword") 切回剑', () => {
+    const player = new Node3D('player');
+    const system = new CombatSystem(player, []);
+    system.switchWeapon('bow');
+    system.switchWeapon('sword');
+    expect(system.weapon).toBe('sword');
+  });
+});
+
+// ── 2. 近战（剑）──────────────────────────────────────────────────────
+
+describe('CombatSystem — 近战（剑）', () => {
+  const PLAYER_POS    = vec3(0, 0, 0);
+  const PLAYER_FORWARD = vec3(0, 0, 1);  // 朝 +Z
+
+  it('2m 正前方敌人被命中，HP 减少 25', () => {
+    const player  = new Node3D('player');
+    const target  = makeTarget(0, 0, 2);  // 正前方 2m
+    const system  = new CombatSystem(player, [target]);
+
+    const hit = system.attack(PLAYER_POS, PLAYER_FORWARD);
+
+    expect(hit).toBe(true);
+    expect(target.health.current).toBe(75);  // 100 - 25
+  });
+
+  it('4m 以外的敌人不被命中（超出 3m range）', () => {
+    const player = new Node3D('player');
+    const target = makeTarget(0, 0, 4);  // 4m，超出范围
+    const system = new CombatSystem(player, [target]);
+
+    const hit = system.attack(PLAYER_POS, PLAYER_FORWARD);
+
+    expect(hit).toBe(false);
+    expect(target.health.current).toBe(100);
+  });
+
+  it('正后方 2m 的敌人不被命中（扇形角度外）', () => {
+    const player = new Node3D('player');
+    const target = makeTarget(0, 0, -2);  // 正后方
+    const system = new CombatSystem(player, [target]);
+
+    const hit = system.attack(PLAYER_POS, PLAYER_FORWARD);
+
+    expect(hit).toBe(false);
+    expect(target.health.current).toBe(100);
+  });
+
+  it('扇形内多个敌人全部被命中', () => {
+    const player  = new Node3D('player');
+    const t1 = makeTarget(0, 0, 2);
+    const t2 = makeTarget(1, 0, 2);  // 稍偏右，仍在 90° 扇形内
+    const system  = new CombatSystem(player, [t1, t2]);
+
+    system.attack(PLAYER_POS, PLAYER_FORWARD);
+
+    expect(t1.health.current).toBeLessThan(100);
+    expect(t2.health.current).toBeLessThan(100);
+  });
+
+  it('近战冷却期间无法再次攻击', () => {
+    const player = new Node3D('player');
+    const target = makeTarget(0, 0, 2);
+    const system = new CombatSystem(player, [target]);
+
+    system.attack(PLAYER_POS, PLAYER_FORWARD);
+    // 冷却期内再次攻击应失败
+    const secondHit = system.attack(PLAYER_POS, PLAYER_FORWARD);
+    expect(secondHit).toBe(false);
+    // 敌人只受到一次伤害
+    expect(target.health.current).toBe(75);
+  });
+
+  it('冷却结束（0.5s）后可再次攻击', () => {
+    const player = new Node3D('player');
+    const target = makeTarget(0, 0, 2);
+    const system = new CombatSystem(player, [target]);
+
+    system.attack(PLAYER_POS, PLAYER_FORWARD);
+    expect(target.health.current).toBe(75);
+
+    // 推进超过 0.5s 冷却（35 帧 ≈ 0.583s，浮点安全）
+    for (let i = 0; i < 35; i++) system.update(DT);
+
+    system.attack(PLAYER_POS, PLAYER_FORWARD);
+    expect(target.health.current).toBe(50);
+  });
+
+  it('hitCount 记录命中次数', () => {
+    const player = new Node3D('player');
+    const target = makeTarget(0, 0, 2);
+    const system = new CombatSystem(player, [target]);
+
+    expect(system.hitCount).toBe(0);
+    system.attack(PLAYER_POS, PLAYER_FORWARD);
+    expect(system.hitCount).toBe(1);
+  });
+
+  it('lastHitTarget 记录最后命中的目标', () => {
+    const player = new Node3D('player');
+    const target = makeTarget(0, 0, 2);
+    const system = new CombatSystem(player, [target]);
+
+    system.attack(PLAYER_POS, PLAYER_FORWARD);
+    expect(system.lastHitTarget).toBe(target);
+  });
+});
+
+// ── 3. 远程（弓）──────────────────────────────────────────────────────
+
+describe('CombatSystem — 远程（弓）', () => {
+  it('攻击后弓的冷却为 1s，canAttack 为 false', () => {
+    const player = new Node3D('player');
+    const system = new CombatSystem(player, []);
+    system.switchWeapon('bow');
+
+    system.attack(vec3(0, 0, 0), vec3(0, 0, 1));
+    expect(system.canAttack).toBe(false);
+    expect(system.activeCooldown).toBeGreaterThan(0.9);
+  });
+
+  it('弓射出的箭在 1s 飞行后命中正前方 20m 处的敌人', () => {
+    const player = new Node3D('player');
+    // 敌人放在弓箭的目标位置（正前方 20m）
+    const target = makeTarget(0, 0, 20);
+    const system = new CombatSystem(player, [target]);
+    system.switchWeapon('bow');
+
+    system.attack(vec3(0, 0, 0), vec3(0, 0, 1));
+
+    // 推进约 1s（箭飞行完毕前的最后几帧一定经过目标点附近）
+    for (let i = 0; i < 60; i++) system.update(DT);
+
+    expect(target.health.current).toBe(60);  // 100 - 40
+    expect(system.hitCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('弓箭命中后敌人 HP 减少 40', () => {
+    const player = new Node3D('player');
+    const target = makeTarget(0, 0, 20);
+    const system = new CombatSystem(player, [target]);
+    system.switchWeapon('bow');
+
+    system.attack(vec3(0, 0, 0), vec3(0, 0, 1));
+    for (let i = 0; i < 60; i++) system.update(DT);
+
+    const damage = 100 - target.health.current;
+    expect(damage).toBe(40);
+  });
+
+  it('弓箭不命中路径外的敌人（侧面 10m）', () => {
+    const player = new Node3D('player');
+    // 敌人在侧面，不在箭的路径上
+    const target = makeTarget(10, 0, 10);
+    const system = new CombatSystem(player, [target]);
+    system.switchWeapon('bow');
+
+    system.attack(vec3(0, 0, 0), vec3(0, 0, 1));
+    for (let i = 0; i < 60; i++) system.update(DT);
+
+    // 侧面 10m 处不应被命中（弹道是 Z 轴方向）
+    expect(target.health.current).toBe(100);
+  });
+
+  it('弓冷却期间无法再次射击', () => {
+    const player = new Node3D('player');
+    const system = new CombatSystem(player, []);
+    system.switchWeapon('bow');
+
+    const first  = system.attack(vec3(0, 0, 0), vec3(0, 0, 1));
+    const second = system.attack(vec3(0, 0, 0), vec3(0, 0, 1));
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+});
+
+// ── 4. 综合：两种武器各命中至少 1 个 Enemy ──────────────────────────
+
+describe('CombatSystem — 两种武器命中验证', () => {
+  it('剑和弓各能命中至少 1 个敌人并扣血', () => {
+    const player = new Node3D('player');
+    // 近战目标偏侧方（不在 Z 轴弓箭路径上），仍在 90° 扇形内
+    const meleeTgt = makeTarget(1, 0, 1.5);  // 距离 1.8m，斜前方
+    // 弓箭目标在正前方 20m（Z 轴，不被近战波及）
+    const bowTgt   = makeTarget(0, 0, 20);
+
+    const system = new CombatSystem(player, [meleeTgt, bowTgt]);
+    const forward = vec3(0, 0, 1);
+    const pos     = vec3(0, 0, 0);
+
+    // 近战攻击
+    system.switchWeapon('sword');
+    system.attack(pos, forward);
+    expect(meleeTgt.health.current).toBeLessThan(100);
+
+    // 等近战冷却结束（35 帧 ≈ 0.583s）
+    for (let i = 0; i < 35; i++) system.update(DT);
+
+    system.switchWeapon('bow');
+    system.attack(pos, forward);
+    // 等待弓箭飞行完毕
+    for (let i = 0; i < 60; i++) system.update(DT);
+
+    expect(bowTgt.health.current).toBeLessThan(100);
+    expect(system.hitCount).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## 概述

实现 Issue #358 M5.3 战斗系统，整合近战和远程两种攻击模式。

## 新增文件

- `examples/action-rpg/src/combat.ts` — `CombatSystem` 类
- `test/integration/combat.test.ts` — 17 个集成测试用例

## 修改文件

- `examples/action-rpg/src/game.ts` — 集成 CombatSystem，处理 1/2 武器切换和 F 键攻击

## 功能实现

### 近战（剑）
- 扇形 hitbox：3m 范围 × 90°（±45°）前方扇形
- `TrailRenderer` 附着剑尖节点，攻击窗口期生成剑气飘带
- 命中时 `ParticleEmitter.emit(15)` 爆发粒子
- `Enemy.Health.takeDamage(25)`，冷却时间 0.5s

### 远程（弓）
- `Curve3` CatmullRom 三点抛物线：玩家位置 → 弧顶（高 2m）→ 前方 20m 目标
- `TubeGeometry` 箭体 + `PhongMaterial emissive` 发光效果
- 飞行 ~1s，每帧检测距离 < 0.5m 命中
- 命中时粒子爆发 + `Health.takeDamage(40)`，冷却时间 1s

### 武器切换
- 键盘 1 → 近战剑，2 → 远程弓
- headless 模式通过 `simulateKey('1')` / `simulateKey('2')` 驱动

## 测试结果

```
Test Files  150 passed (150)
      Tests  2027 passed (2027)
```

新增 `combat.test.ts` 覆盖：武器切换、近战命中/miss/冷却、弓箭命中/miss/冷却、综合两种武器各命中 1+ 敌人。

close #358