### PR TITLE
feat: PosterizePass 色阶量化后处理 (#367)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1593,6 +1593,69 @@ void main() {
   }
 }
 
+/* ── PosterizeOptions ── */
+
+export interface PosterizeOptions {
+  /** 每通道量化等级数，整数 [2, 32]。默认 6 */
+  levels?: number;
+  /** 混合强度 [0, 1]。0=原图，1=完全量化。默认 1 */
+  intensity?: number;
+}
+
+/** 色阶量化后处理：按固定 levels 量化 RGB 通道，产生漫画/赛璐璐/复古风格 */
+export class PosterizePass implements EffectPass {
+  readonly name = 'posterize';
+  enabled = true;
+  levels: number;
+  intensity: number;
+
+  constructor(options?: PosterizeOptions) {
+    const levels = options?.levels ?? 6;
+    const intensity = options?.intensity ?? 1;
+
+    if (!Number.isFinite(levels)) {
+      throw new Error(`PosterizePass: levels (${levels}) 必须是有限整数`);
+    }
+    if (!Number.isInteger(levels)) {
+      throw new Error(`PosterizePass: levels (${levels}) 必须是整数`);
+    }
+    if (levels < 2 || levels > 32) {
+      throw new Error(`PosterizePass: levels (${levels}) 必须在 [2, 32] 范围内`);
+    }
+    if (!Number.isFinite(intensity)) {
+      throw new Error(`PosterizePass: intensity (${intensity}) 必须是有限数值`);
+    }
+    if (intensity < 0 || intensity > 1) {
+      throw new Error(`PosterizePass: intensity (${intensity}) 必须在 [0, 1] 范围内`);
+    }
+
+    this.levels = levels;
+    this.intensity = intensity;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+varying vec2 v_texCoord;
+uniform sampler2D u_texture;
+uniform float u_levels;
+uniform float u_intensity;
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  vec3 quantized = floor(color.rgb * u_levels) / max(u_levels - 1.0, 1.0);
+  gl_FragColor = vec4(mix(color.rgb, clamp(quantized, 0.0, 1.0), u_intensity), color.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uLevels = gl.getUniformLocation(program, 'u_levels');
+    if (uLevels) gl.uniform1f(uLevels, this.levels);
+    const uIntensity = gl.getUniformLocation(program, 'u_intensity');
+    if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
+  }
+}
+
 /* ── VibrancePass ── */
 
 export interface VibranceOptions {

--- a/test/unit/renderer/posterize-pass.test.ts
+++ b/test/unit/renderer/posterize-pass.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { PosterizePass } from '../../../src/renderer/post-process';
+
+describe('PosterizePass', () => {
+  describe('constructor defaults', () => {
+    it('should default levels to 6', () => {
+      const pass = new PosterizePass();
+      expect(pass.levels).toBe(6);
+    });
+
+    it('should default intensity to 1', () => {
+      const pass = new PosterizePass();
+      expect(pass.intensity).toBe(1);
+    });
+
+    it('should have name "posterize" and enabled=true', () => {
+      const pass = new PosterizePass();
+      expect(pass.name).toBe('posterize');
+      expect(pass.enabled).toBe(true);
+    });
+  });
+
+  describe('custom options', () => {
+    it('should accept custom levels', () => {
+      const pass = new PosterizePass({ levels: 4 });
+      expect(pass.levels).toBe(4);
+    });
+
+    it('should accept boundary levels values', () => {
+      expect(new PosterizePass({ levels: 2 }).levels).toBe(2);
+      expect(new PosterizePass({ levels: 32 }).levels).toBe(32);
+    });
+
+    it('should accept custom intensity', () => {
+      const pass = new PosterizePass({ intensity: 0.5 });
+      expect(pass.intensity).toBe(0.5);
+    });
+
+    it('should accept boundary intensity values', () => {
+      expect(new PosterizePass({ intensity: 0 }).intensity).toBe(0);
+      expect(new PosterizePass({ intensity: 1 }).intensity).toBe(1);
+    });
+  });
+
+  describe('parameter validation', () => {
+    it('should throw when levels < 2', () => {
+      expect(() => new PosterizePass({ levels: 1 })).toThrow();
+      expect(() => new PosterizePass({ levels: 0 })).toThrow();
+      expect(() => new PosterizePass({ levels: -1 })).toThrow();
+    });
+
+    it('should throw when levels > 32', () => {
+      expect(() => new PosterizePass({ levels: 33 })).toThrow();
+      expect(() => new PosterizePass({ levels: 100 })).toThrow();
+    });
+
+    it('should throw when levels is not an integer', () => {
+      expect(() => new PosterizePass({ levels: 3.5 })).toThrow();
+      expect(() => new PosterizePass({ levels: 2.7 })).toThrow();
+    });
+
+    it('should throw when levels is NaN / Infinity', () => {
+      expect(() => new PosterizePass({ levels: NaN })).toThrow();
+      expect(() => new PosterizePass({ levels: Infinity })).toThrow();
+    });
+
+    it('should throw when intensity out of [0, 1]', () => {
+      expect(() => new PosterizePass({ intensity: -0.1 })).toThrow();
+      expect(() => new PosterizePass({ intensity: 1.1 })).toThrow();
+    });
+
+    it('should throw when intensity is NaN / Infinity', () => {
+      expect(() => new PosterizePass({ intensity: NaN })).toThrow();
+      expect(() => new PosterizePass({ intensity: Infinity })).toThrow();
+    });
+  });
+
+  describe('getFragmentShader', () => {
+    it('should contain u_levels and u_intensity uniforms', () => {
+      const pass = new PosterizePass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('u_levels');
+      expect(shader).toContain('u_intensity');
+      expect(shader).toContain('u_texture');
+    });
+
+    it('should use floor() and division for quantization', () => {
+      const pass = new PosterizePass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('floor(');
+    });
+
+    it('should mix original and quantized results', () => {
+      const pass = new PosterizePass();
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('mix(');
+    });
+  });
+
+  describe('EffectPass contract', () => {
+    it('should be toggleable via enabled flag', () => {
+      const pass = new PosterizePass();
+      pass.enabled = false;
+      expect(pass.enabled).toBe(false);
+    });
+
+    it('should expose setUniforms method', () => {
+      const pass = new PosterizePass();
+      expect(typeof pass.setUniforms).toBe('function');
+    });
+  });
+});


### PR DESCRIPTION
## 变更摘要

新增 `PosterizePass` 后处理 Pass，实现 RGB 通道色阶量化效果。

- 核心算法：`floor(rgb * levels) / (levels - 1)`
- 参数 `levels`：整数 [2, 32]，默认 6（漫画感）
- 参数 `intensity`：float [0, 1]，默认 1（完全量化）
- 完整参数校验：NaN / Infinity / 非整数 / 越界 → throw

## 测试

- `pnpm exec vitest run test/unit/renderer/posterize-pass.test.ts` — 18 个测试全绿
- `pnpm exec vitest run test/unit/renderer/` — 67 个文件 791 个测试零回归

close #367