### PR TITLE
feat: ColorLUTPass — 基于 Lookup Texture 的专业调色后处理 (#366)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -5,6 +5,7 @@
  */
 
 import { RenderTarget } from './render-target';
+import { Texture } from './texture';
 
 /* ── EffectPass 接口 ── */
 
@@ -1653,6 +1654,114 @@ void main() {
     if (uLevels) gl.uniform1f(uLevels, this.levels);
     const uIntensity = gl.getUniformLocation(program, 'u_intensity');
     if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
+  }
+}
+
+/* ── ColorLUTPass ── */
+
+export interface ColorLUTOptions {
+  /** LUT 纹理，必须是 512×512（64³）tiled atlas 格式 */
+  texture: Texture;
+  /** 混合强度 0..1。0 = 原图，1 = 完全应用 LUT。默认 1 */
+  intensity?: number;
+}
+
+/** 基于 Lookup Texture 的专业调色后处理：64³ LUT 展开为 512×512 tiled atlas（8×8 tiles） */
+export class ColorLUTPass implements EffectPass {
+  readonly name = 'colorLUT';
+  enabled = true;
+  texture: Texture;
+  intensity: number;
+
+  private _glTex: WebGLTexture | null = null;
+  private _glTexVersion = -1;
+
+  constructor(options: ColorLUTOptions) {
+    if (options.texture == null) {
+      throw new Error('ColorLUTPass: texture 不能为 null 或 undefined');
+    }
+    const intensity = options.intensity ?? 1;
+    if (!Number.isFinite(intensity) || intensity < 0 || intensity > 1) {
+      throw new Error(`ColorLUTPass: intensity (${intensity}) 必须在 [0, 1] 范围内`);
+    }
+    this.texture = options.texture;
+    this.intensity = intensity;
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+varying vec2 v_texCoord;
+uniform sampler2D u_texture;
+uniform sampler2D u_lut;
+uniform float u_intensity;
+
+vec3 sampleLUT(vec3 color) {
+  float blueIndex = color.b * 63.0;
+  float blueLow = floor(blueIndex);
+  float blueHigh = min(blueLow + 1.0, 63.0);
+  float blueLerp = blueIndex - blueLow;
+
+  vec2 quad;
+  quad.y = floor(blueLow / 8.0);
+  quad.x = blueLow - quad.y * 8.0;
+
+  vec2 texPosLow;
+  texPosLow.x = (quad.x * 64.0 + color.r * 63.0 + 0.5) / 512.0;
+  texPosLow.y = (quad.y * 64.0 + color.g * 63.0 + 0.5) / 512.0;
+
+  quad.y = floor(blueHigh / 8.0);
+  quad.x = blueHigh - quad.y * 8.0;
+
+  vec2 texPosHigh;
+  texPosHigh.x = (quad.x * 64.0 + color.r * 63.0 + 0.5) / 512.0;
+  texPosHigh.y = (quad.y * 64.0 + color.g * 63.0 + 0.5) / 512.0;
+
+  vec3 lowColor = texture2D(u_lut, texPosLow).rgb;
+  vec3 highColor = texture2D(u_lut, texPosHigh).rgb;
+  return mix(lowColor, highColor, blueLerp);
+}
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  vec3 graded = sampleLUT(color.rgb);
+  gl_FragColor = vec4(mix(color.rgb, graded, u_intensity), color.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    // 上传/更新 LUT 纹理到 GPU（按 version 缓存）
+    if (!this._glTex || this._glTexVersion !== this.texture.version) {
+      if (this._glTex) gl.deleteTexture(this._glTex);
+      const tex = gl.createTexture();
+      if (tex) {
+        gl.bindTexture(gl.TEXTURE_2D, tex);
+        gl.texImage2D(
+          gl.TEXTURE_2D, 0, gl.RGBA,
+          this.texture.width, this.texture.height, 0,
+          gl.RGBA, gl.UNSIGNED_BYTE, this.texture.data,
+        );
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.bindTexture(gl.TEXTURE_2D, null);
+      }
+      this._glTex = tex;
+      this._glTexVersion = this.texture.version;
+    }
+
+    // 绑定 LUT 纹理到 texture unit 1（u_texture 已由 PostProcessor 绑定到 unit 0）
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, this._glTex);
+    const uLut = gl.getUniformLocation(program, 'u_lut');
+    if (uLut) gl.uniform1i(uLut, 1);
+
+    const uIntensity = gl.getUniformLocation(program, 'u_intensity');
+    if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
+
+    gl.activeTexture(gl.TEXTURE0);
   }
 }
 

--- a/test/unit/renderer/colorlut-pass.test.ts
+++ b/test/unit/renderer/colorlut-pass.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { ColorLUTPass } from '../../../src/renderer/post-process';
+import { Texture } from '../../../src/renderer/texture';
+
+function makeLUT(): Texture {
+  // 512×512 RGBA 纯色 LUT（identity LUT 占位）
+  const data = new Uint8Array(512 * 512 * 4);
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = 128; data[i + 1] = 128; data[i + 2] = 128; data[i + 3] = 255;
+  }
+  return Texture.fromData(512, 512, data);
+}
+
+describe('ColorLUTPass', () => {
+  describe('constructor defaults', () => {
+    it('should default intensity to 1', () => {
+      const pass = new ColorLUTPass({ texture: makeLUT() });
+      expect(pass.intensity).toBe(1);
+    });
+
+    it('should have name "colorLUT" and enabled=true', () => {
+      const pass = new ColorLUTPass({ texture: makeLUT() });
+      expect(pass.name).toBe('colorLUT');
+      expect(pass.enabled).toBe(true);
+    });
+
+    it('should store the provided texture', () => {
+      const lut = makeLUT();
+      const pass = new ColorLUTPass({ texture: lut });
+      expect(pass.texture).toBe(lut);
+    });
+  });
+
+  describe('custom options', () => {
+    it('should accept custom intensity', () => {
+      const pass = new ColorLUTPass({ texture: makeLUT(), intensity: 0.5 });
+      expect(pass.intensity).toBe(0.5);
+    });
+
+    it('should accept boundary intensity values', () => {
+      const p0 = new ColorLUTPass({ texture: makeLUT(), intensity: 0 });
+      expect(p0.intensity).toBe(0);
+      const p1 = new ColorLUTPass({ texture: makeLUT(), intensity: 1 });
+      expect(p1.intensity).toBe(1);
+    });
+  });
+
+  describe('parameter validation', () => {
+    it('should throw when texture is missing', () => {
+      expect(() => new ColorLUTPass({ texture: null as any })).toThrow();
+      expect(() => new ColorLUTPass({ texture: undefined as any })).toThrow();
+    });
+
+    it('should throw when intensity out of [0, 1]', () => {
+      expect(() => new ColorLUTPass({ texture: makeLUT(), intensity: -0.1 })).toThrow();
+      expect(() => new ColorLUTPass({ texture: makeLUT(), intensity: 1.1 })).toThrow();
+      expect(() => new ColorLUTPass({ texture: makeLUT(), intensity: 2 })).toThrow();
+    });
+
+    it('should throw on NaN', () => {
+      expect(() => new ColorLUTPass({ texture: makeLUT(), intensity: NaN })).toThrow();
+    });
+
+    it('should throw on Infinity', () => {
+      expect(() => new ColorLUTPass({ texture: makeLUT(), intensity: Infinity })).toThrow();
+    });
+  });
+
+  describe('getFragmentShader', () => {
+    it('should return GLSL containing expected uniforms', () => {
+      const pass = new ColorLUTPass({ texture: makeLUT() });
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('u_lut');
+      expect(shader).toContain('u_texture');
+      expect(shader).toContain('u_intensity');
+    });
+
+    it('should reference LUT tile math (8x8 atlas)', () => {
+      const pass = new ColorLUTPass({ texture: makeLUT() });
+      const shader = pass.getFragmentShader();
+      // 任一形式：8.0 / 512.0 / 64.0 都可以
+      const hasTileMath = /\b8(\.0)?\b/.test(shader) || /\b64(\.0)?\b/.test(shader) || /\b512(\.0)?\b/.test(shader);
+      expect(hasTileMath).toBe(true);
+    });
+
+    it('should do mix() between original and LUT-sampled result', () => {
+      const pass = new ColorLUTPass({ texture: makeLUT() });
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('mix(');
+    });
+  });
+
+  describe('EffectPass contract', () => {
+    it('should be toggleable via enabled flag', () => {
+      const pass = new ColorLUTPass({ texture: makeLUT() });
+      pass.enabled = false;
+      expect(pass.enabled).toBe(false);
+    });
+
+    it('should expose setUniforms method', () => {
+      const pass = new ColorLUTPass({ texture: makeLUT() });
+      expect(typeof pass.setUniforms).toBe('function');
+    });
+  });
+});


### PR DESCRIPTION
## 实现内容

新增 `ColorLUTPass` 类，支持行业标准 64³ LUT 调色（Photoshop / DaVinci Resolve 通用格式）。

## 关键设计

- **LUT 格式**：512×512 tiled atlas（8×8 tiles，每 tile 64×64，B 维度通过 tile 位置编码）
- **GLSL 实现**：tile 定位 + bilinear 插值（跨 B 维度双线性采样）+ `mix()` 原图融合
- **双纹理绑定**：`u_texture`（scene）→ unit 0，`u_lut` → unit 1，与 PostProcessor 管线兼容
- **参数校验**：texture null 检查 + intensity 有限性/范围 [0,1] 校验

## 验收结果

- [x] `pnpm exec vitest run test/unit/renderer/colorlut-pass.test.ts` → **14/14 通过**
- [x] `pnpm exec vitest run test/unit/renderer/` → **787/787 通过，零回归**
- [x] Pass 可被 `PostProcess.addPass()` 加入链路，`enabled=false` 时跳过

close #366