### PR TITLE
feat: DitherPass — Bayer 矩阵有序抖动后处理 (#368)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1711,3 +1711,124 @@ void main() {
   }
 }
 
+/* ── DitherOptions ── */
+
+export type DitherMatrix = 'bayer4x4' | 'bayer8x8';
+
+export interface DitherOptions {
+  /** 抖动矩阵类型。bayer4x4 = 16 级阈值（粗），bayer8x8 = 64 级（细）。默认 'bayer4x4' */
+  matrix?: DitherMatrix;
+  /** 每通道量化等级数 [2, 16]，决定抖动后的最终色阶。默认 4 */
+  levels?: number;
+  /** 混合强度 0..1。默认 1 */
+  intensity?: number;
+}
+
+/** Bayer 矩阵有序抖动后处理：通过 4×4 或 8×8 Bayer 矩阵比较像素亮度与阈值，
+ *  把色阶压缩到 2-8 级同时保留视觉层次，适用于像素艺术 / Game Boy / 复古 8-bit 风格。
+ */
+export class DitherPass implements EffectPass {
+  readonly name = 'dither';
+  enabled = true;
+  matrix: DitherMatrix;
+  levels: number;
+  intensity: number;
+
+  constructor(options?: DitherOptions) {
+    const matrix = options?.matrix ?? 'bayer4x4';
+    const levels = options?.levels ?? 4;
+    const intensity = options?.intensity ?? 1;
+
+    if (matrix !== 'bayer4x4' && matrix !== 'bayer8x8') {
+      throw new Error(`DitherPass: matrix ("${matrix}") 必须是 'bayer4x4' 或 'bayer8x8'`);
+    }
+    if (!Number.isFinite(levels) || !Number.isInteger(levels) || levels < 2 || levels > 16) {
+      throw new Error(`DitherPass: levels (${levels}) 必须是 [2, 16] 范围内的整数`);
+    }
+    if (!Number.isFinite(intensity) || intensity < 0 || intensity > 1) {
+      throw new Error(`DitherPass: intensity (${intensity}) 必须在 [0, 1] 范围内`);
+    }
+
+    this.matrix = matrix;
+    this.levels = levels;
+    this.intensity = intensity;
+  }
+
+  getFragmentShader(): string {
+    if (this.matrix === 'bayer4x4') {
+      return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_levels;
+uniform float u_intensity;
+varying vec2 v_texCoord;
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  float fx = mod(gl_FragCoord.x, 4.0);
+  float fy = mod(gl_FragCoord.y, 4.0);
+  vec4 r0 = vec4( 0.0,  8.0,  2.0, 10.0);
+  vec4 r1 = vec4(12.0,  4.0, 14.0,  6.0);
+  vec4 r2 = vec4( 3.0, 11.0,  1.0,  9.0);
+  vec4 r3 = vec4(15.0,  7.0, 13.0,  5.0);
+  vec4 row;
+  if      (fy < 1.0) row = r0;
+  else if (fy < 2.0) row = r1;
+  else if (fy < 3.0) row = r2;
+  else               row = r3;
+  float bval;
+  if      (fx < 1.0) bval = row.x;
+  else if (fx < 2.0) bval = row.y;
+  else if (fx < 3.0) bval = row.z;
+  else               bval = row.w;
+  float threshold = bval / 16.0 - 0.5;
+  vec3 dithered = floor(color.rgb * u_levels + threshold) / max(u_levels - 1.0, 1.0);
+  dithered = clamp(dithered, 0.0, 1.0);
+  gl_FragColor = vec4(mix(color.rgb, dithered, u_intensity), color.a);
+}
+`.trim();
+    }
+    // bayer8x8
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform float u_levels;
+uniform float u_intensity;
+varying vec2 v_texCoord;
+float sel8(vec4 lo, vec4 hi, float x) {
+  if      (x < 1.0) return lo.x;
+  else if (x < 2.0) return lo.y;
+  else if (x < 3.0) return lo.z;
+  else if (x < 4.0) return lo.w;
+  else if (x < 5.0) return hi.x;
+  else if (x < 6.0) return hi.y;
+  else if (x < 7.0) return hi.z;
+  else               return hi.w;
+}
+void main() {
+  vec4 color = texture2D(u_texture, v_texCoord);
+  float fx = mod(gl_FragCoord.x, 8.0);
+  float fy = mod(gl_FragCoord.y, 8.0);
+  float bval;
+  if      (fy < 1.0) bval = sel8(vec4( 0.,32., 8.,40.), vec4( 2.,34.,10.,42.), fx);
+  else if (fy < 2.0) bval = sel8(vec4(48.,16.,56.,24.), vec4(50.,18.,58.,26.), fx);
+  else if (fy < 3.0) bval = sel8(vec4(12.,44., 4.,36.), vec4(14.,46., 6.,38.), fx);
+  else if (fy < 4.0) bval = sel8(vec4(60.,28.,52.,20.), vec4(62.,30.,54.,22.), fx);
+  else if (fy < 5.0) bval = sel8(vec4( 3.,35.,11.,43.), vec4( 1.,33., 9.,41.), fx);
+  else if (fy < 6.0) bval = sel8(vec4(51.,19.,59.,27.), vec4(49.,17.,57.,25.), fx);
+  else if (fy < 7.0) bval = sel8(vec4(15.,47., 7.,39.), vec4(13.,45., 5.,37.), fx);
+  else               bval = sel8(vec4(63.,31.,55.,23.), vec4(61.,29.,53.,21.), fx);
+  float threshold = bval / 64.0 - 0.5;
+  vec3 dithered = floor(color.rgb * u_levels + threshold) / max(u_levels - 1.0, 1.0);
+  dithered = clamp(dithered, 0.0, 1.0);
+  gl_FragColor = vec4(mix(color.rgb, dithered, u_intensity), color.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uLevels = gl.getUniformLocation(program, 'u_levels');
+    if (uLevels) gl.uniform1f(uLevels, this.levels);
+    const uIntensity = gl.getUniformLocation(program, 'u_intensity');
+    if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
+  }
+}

--- a/test/unit/renderer/dither-pass.test.ts
+++ b/test/unit/renderer/dither-pass.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { DitherPass } from '../../../src/renderer/post-process';
+
+describe('DitherPass', () => {
+  describe('constructor defaults', () => {
+    it('should default matrix to "bayer4x4"', () => {
+      const pass = new DitherPass();
+      expect(pass.matrix).toBe('bayer4x4');
+    });
+
+    it('should default levels to 4', () => {
+      const pass = new DitherPass();
+      expect(pass.levels).toBe(4);
+    });
+
+    it('should default intensity to 1', () => {
+      const pass = new DitherPass();
+      expect(pass.intensity).toBe(1);
+    });
+
+    it('should have name "dither" and enabled=true', () => {
+      const pass = new DitherPass();
+      expect(pass.name).toBe('dither');
+      expect(pass.enabled).toBe(true);
+    });
+  });
+
+  describe('custom options', () => {
+    it('should accept bayer8x8', () => {
+      const pass = new DitherPass({ matrix: 'bayer8x8' });
+      expect(pass.matrix).toBe('bayer8x8');
+    });
+
+    it('should accept custom levels', () => {
+      const pass = new DitherPass({ levels: 8 });
+      expect(pass.levels).toBe(8);
+    });
+
+    it('should accept boundary levels', () => {
+      expect(new DitherPass({ levels: 2 }).levels).toBe(2);
+      expect(new DitherPass({ levels: 16 }).levels).toBe(16);
+    });
+
+    it('should accept custom intensity', () => {
+      const pass = new DitherPass({ intensity: 0.5 });
+      expect(pass.intensity).toBe(0.5);
+    });
+  });
+
+  describe('parameter validation', () => {
+    it('should throw on unknown matrix', () => {
+      expect(() => new DitherPass({ matrix: 'bayer16x16' as any })).toThrow();
+      expect(() => new DitherPass({ matrix: '' as any })).toThrow();
+    });
+
+    it('should throw when levels < 2', () => {
+      expect(() => new DitherPass({ levels: 1 })).toThrow();
+      expect(() => new DitherPass({ levels: 0 })).toThrow();
+    });
+
+    it('should throw when levels > 16', () => {
+      expect(() => new DitherPass({ levels: 17 })).toThrow();
+      expect(() => new DitherPass({ levels: 100 })).toThrow();
+    });
+
+    it('should throw when levels is not integer', () => {
+      expect(() => new DitherPass({ levels: 3.5 })).toThrow();
+    });
+
+    it('should throw on NaN/Infinity', () => {
+      expect(() => new DitherPass({ levels: NaN })).toThrow();
+      expect(() => new DitherPass({ levels: Infinity })).toThrow();
+      expect(() => new DitherPass({ intensity: NaN })).toThrow();
+      expect(() => new DitherPass({ intensity: Infinity })).toThrow();
+    });
+
+    it('should throw when intensity out of [0, 1]', () => {
+      expect(() => new DitherPass({ intensity: -0.01 })).toThrow();
+      expect(() => new DitherPass({ intensity: 1.01 })).toThrow();
+    });
+  });
+
+  describe('getFragmentShader — bayer4x4', () => {
+    it('should contain 4x4 matrix constants and modulo-4 indexing', () => {
+      const pass = new DitherPass({ matrix: 'bayer4x4' });
+      const shader = pass.getFragmentShader();
+      expect(shader).toContain('u_texture');
+      expect(shader).toContain('u_levels');
+      expect(shader).toContain('u_intensity');
+      // 16 = 4x4 matrix normalization divisor
+      expect(shader).toMatch(/\b16(\.0)?\b/);
+      // mod 4 indexing for bayer4x4
+      expect(shader).toMatch(/mod\([^)]+,\s*4(\.0)?\)/);
+    });
+  });
+
+  describe('getFragmentShader — bayer8x8', () => {
+    it('should contain 8x8 matrix constants and modulo-8 indexing', () => {
+      const pass = new DitherPass({ matrix: 'bayer8x8' });
+      const shader = pass.getFragmentShader();
+      // 64 = 8x8 normalization divisor
+      expect(shader).toMatch(/\b64(\.0)?\b/);
+      expect(shader).toMatch(/mod\([^)]+,\s*8(\.0)?\)/);
+    });
+
+    it('should differ from bayer4x4 shader', () => {
+      const a = new DitherPass({ matrix: 'bayer4x4' }).getFragmentShader();
+      const b = new DitherPass({ matrix: 'bayer8x8' }).getFragmentShader();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('EffectPass contract', () => {
+    it('should be toggleable via enabled flag', () => {
+      const pass = new DitherPass();
+      pass.enabled = false;
+      expect(pass.enabled).toBe(false);
+    });
+
+    it('should expose setUniforms method', () => {
+      const pass = new DitherPass();
+      expect(typeof pass.setUniforms).toBe('function');
+    });
+  });
+});


### PR DESCRIPTION
## 概述

实现 Issue #368 要求的 `DitherPass` 后处理效果，支持 Bayer 4×4 和 8×8 矩阵有序抖动，
适用于像素艺术 / Game Boy / 复古 8-bit 风格游戏。

## 变更内容

- `src/renderer/post-process.ts` — 新增 `DitherMatrix` 类型、`DitherOptions` 接口和 `DitherPass` 类
- `test/unit/renderer/dither-pass.test.ts` — 19 个单元测试（从 Issue body 复制）

## 验收结果

- [x] `pnpm exec vitest run test/unit/renderer/dither-pass.test.ts` — 19/19 全绿
- [x] `pnpm exec vitest run test/unit/renderer/` — 792/792 零回归
- [x] `DitherPass` 实现 `EffectPass` 接口，可通过 `PostProcess.addPass()` 加入链路，`enabled=false` 时跳过
- [x] `bayer4x4` shader 含 `mod(..., 4.0)` + `/16.0`；`bayer8x8` shader 含 `mod(..., 8.0)` + `/64.0`，两个 shader 内容不同

## 实现细节

- **WebGL 1.0 兼容**：使用 4 个 `vec4` 行向量 + `if/else` 链替代 GLSL ES 3.0 的数组字面量语法
- **像素坐标**：通过 `gl_FragCoord.xy` 获取屏幕像素坐标，无需额外注入 `u_resolution` uniform
- **参数校验**：`matrix` 非法 → throw；`levels` 非整数/越界/非有限 → throw；`intensity` 越界/非有限 → throw

close #368