### PR TITLE
feat: 实现 DepthPass — 深度纹理 RenderTarget + linearizeDepth + u_depthTexture 约定

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -7,6 +7,19 @@
 import { RenderTarget } from './render-target';
 import { Texture } from './texture';
 
+/* ── LINEARIZE_DEPTH_GLSL 辅助函数 ── */
+
+/**
+ * GLSL 函数：把 [0,1] 区间的非线性深度（从 depthTexture 采样得）转换为线性视图空间深度。
+ * 调用方：DOFPass / SSAOPass / MotionBlurPass 在 fragment shader 中 #include。
+ */
+export const LINEARIZE_DEPTH_GLSL = `
+float linearizeDepth(float d, float near, float far) {
+  float z = d * 2.0 - 1.0;
+  return (2.0 * near * far) / (far + near - z * (far - near));
+}
+`.trim();
+
 /* ── EffectPass 接口 ── */
 
 export interface EffectPass {
@@ -18,6 +31,8 @@ export interface EffectPass {
   getFragmentShader(): string;
   /** 设置 pass 特有的 uniform（在 render 前由 PostProcessor 调用） */
   setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void;
+  /** 可选：声明此 pass 需要 u_depthTexture（默认 false） */
+  readonly usesDepth?: boolean;
 }
 
 /* ── 全屏四边形顶点着色器 ── */
@@ -51,6 +66,8 @@ export class PostProcessor {
   private _textures: (WebGLTexture | null)[] = [null, null];
   // 全屏四边形 VBO
   private _vbo: WebGLBuffer | null = null;
+  // 当前帧的深度纹理（由外部通过 setDepthTexture 注入）
+  private _depthTexture: WebGLTexture | null = null;
 
   get width(): number { return this._width; }
   get height(): number { return this._height; }
@@ -59,6 +76,15 @@ export class PostProcessor {
   addPass(pass: EffectPass): this {
     this.passes.push(pass);
     return this;
+  }
+
+  /**
+   * 设置当前帧场景渲染的深度纹理。
+   * 当 EffectPass.usesDepth === true 时，PostProcessor 会将此纹理绑定到 texture unit 1，
+   * 并在 program 上设置 uniform `u_depthTexture`。
+   */
+  setDepthTexture(tex: WebGLTexture | null): void {
+    this._depthTexture = tex;
   }
 
   /** 按名称移除 pass（不存在时静默，可链式调用） */
@@ -120,6 +146,9 @@ export class PostProcessor {
         gl.uniform2f(uTexelSize, 1.0 / this._width, 1.0 / this._height);
       }
 
+      // 若 pass 需要深度纹理，绑定到 unit 1
+      this._bindDepthForPass(gl, pass, prog);
+
       // 由 pass 设置自定义 uniform
       pass.setUniforms(gl, prog);
 
@@ -156,6 +185,17 @@ export class PostProcessor {
   }
 
   // ── 私有辅助 ──
+
+  /** 当 pass.usesDepth=true 且有深度纹理时，绑定到 unit 1 并设置 u_depthTexture uniform */
+  _bindDepthForPass(gl: WebGLRenderingContext, pass: EffectPass, prog: WebGLProgram): void {
+    if (pass.usesDepth && this._depthTexture) {
+      gl.activeTexture(gl.TEXTURE1);
+      gl.bindTexture(gl.TEXTURE_2D, this._depthTexture);
+      const loc = gl.getUniformLocation(prog, 'u_depthTexture');
+      if (loc) gl.uniform1i(loc, 1);
+    }
+    gl.activeTexture(gl.TEXTURE0);
+  }
 
   private _programCache = new Map<string, WebGLProgram>();
 

--- a/src/renderer/render-target.ts
+++ b/src/renderer/render-target.ts
@@ -9,24 +9,30 @@ export interface RenderTargetOptions {
   height: number;
   /** 是否创建深度附件（默认 true） */
   depthBuffer?: boolean;
+  /** 是否将深度作为可采样纹理而非 renderbuffer（需 WEBGL_depth_texture 扩展，默认 false） */
+  depthAsTexture?: boolean;
 }
 
 export class RenderTarget {
   readonly width: number;
   readonly height: number;
   readonly depthBuffer: boolean;
+  readonly depthAsTexture: boolean;
 
   /** WebGL framebuffer handle（初始化后非 null） */
   framebuffer: WebGLFramebuffer | null = null;
   /** 颜色纹理附件 */
   colorTexture: WebGLTexture | null = null;
-  /** 深度渲染缓冲附件 */
+  /** 深度渲染缓冲附件（depthAsTexture=false 时使用） */
   depthRenderbuffer: WebGLRenderbuffer | null = null;
+  /** 深度纹理附件（depthAsTexture=true 时使用，可在 shader 中采样） */
+  depthTexture: WebGLTexture | null = null;
 
   constructor(opts: RenderTargetOptions) {
     this.width = opts.width;
     this.height = opts.height;
     this.depthBuffer = opts.depthBuffer ?? true;
+    this.depthAsTexture = opts.depthAsTexture ?? false;
   }
 
   /**
@@ -50,14 +56,29 @@ export class RenderTarget {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
 
-    // 可选：创建深度渲染缓冲附件（DEPTH_COMPONENT16）
+    // 可选：创建深度附件（renderbuffer 或 texture）
     let rbo: WebGLRenderbuffer | null = null;
+    let depthTex: WebGLTexture | null = null;
     if (this.depthBuffer) {
-      rbo = gl.createRenderbuffer();
-      if (!rbo) throw new Error('Failed to create depth renderbuffer');
-      gl.bindRenderbuffer(gl.RENDERBUFFER, rbo);
-      gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, this.width, this.height);
-      gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, rbo);
+      if (this.depthAsTexture) {
+        const ext = gl.getExtension('WEBGL_depth_texture');
+        if (!ext) throw new Error('WEBGL_depth_texture extension required for depthAsTexture');
+        depthTex = gl.createTexture();
+        if (!depthTex) throw new Error('Failed to create depth texture');
+        gl.bindTexture(gl.TEXTURE_2D, depthTex);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, this.width, this.height, 0, gl.DEPTH_COMPONENT, gl.UNSIGNED_INT, null);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, depthTex, 0);
+      } else {
+        rbo = gl.createRenderbuffer();
+        if (!rbo) throw new Error('Failed to create depth renderbuffer');
+        gl.bindRenderbuffer(gl.RENDERBUFFER, rbo);
+        gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, this.width, this.height);
+        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, rbo);
+      }
     }
 
     // 验证 FBO 完整性
@@ -71,6 +92,7 @@ export class RenderTarget {
     this.framebuffer = fbo;
     this.colorTexture = tex;
     this.depthRenderbuffer = rbo;
+    this.depthTexture = depthTex;
   }
 
   /** 释放所有 GPU 资源 */
@@ -78,6 +100,10 @@ export class RenderTarget {
     if (this.depthRenderbuffer) {
       gl.deleteRenderbuffer(this.depthRenderbuffer);
       this.depthRenderbuffer = null;
+    }
+    if (this.depthTexture) {
+      gl.deleteTexture(this.depthTexture);
+      this.depthTexture = null;
     }
     if (this.colorTexture) {
       gl.deleteTexture(this.colorTexture);

--- a/test/unit/renderer/depth-pass.test.ts
+++ b/test/unit/renderer/depth-pass.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RenderTarget } from '../../../src/renderer/render-target';
+import { PostProcessor, LINEARIZE_DEPTH_GLSL, type EffectPass } from '../../../src/renderer/post-process';
+
+function createMockGL(opts: { hasDepthTextureExt?: boolean } = {}): any {
+  const hasExt = opts.hasDepthTextureExt ?? true;
+  const calls: any[] = [];
+  return {
+    _calls: calls,
+    FRAMEBUFFER: 0x8d40, COLOR_ATTACHMENT0: 0x8ce0, DEPTH_ATTACHMENT: 0x8d00,
+    TEXTURE_2D: 0x0de1, RGBA: 0x1908, UNSIGNED_BYTE: 0x1401,
+    DEPTH_COMPONENT: 0x1902, UNSIGNED_INT: 0x1405, UNSIGNED_SHORT: 0x1403,
+    NEAREST: 0x2600, LINEAR: 0x2601, CLAMP_TO_EDGE: 0x812f,
+    TEXTURE_MIN_FILTER: 0x2801, TEXTURE_MAG_FILTER: 0x2800,
+    TEXTURE_WRAP_S: 0x2802, TEXTURE_WRAP_T: 0x2803,
+    DEPTH_COMPONENT16: 0x81a5, RENDERBUFFER: 0x8d41,
+    FRAMEBUFFER_COMPLETE: 0x8cd5,
+    TEXTURE0: 0x84c0, TEXTURE1: 0x84c1,
+    getExtension: vi.fn((name: string) => (name === 'WEBGL_depth_texture' && hasExt) ? {} : null),
+    createFramebuffer: vi.fn(() => ({ id: 'fbo' })),
+    bindFramebuffer: vi.fn(),
+    createTexture: vi.fn(() => ({ id: Math.random() })),
+    bindTexture: vi.fn((target: number, tex: any) => calls.push(['bindTexture', target, tex])),
+    texImage2D: vi.fn(),
+    texParameteri: vi.fn(),
+    framebufferTexture2D: vi.fn((_t: number, attachment: number, _tt: number, tex: any) =>
+      calls.push(['framebufferTexture2D', attachment, tex])
+    ),
+    createRenderbuffer: vi.fn(() => ({ id: 'rbo' })),
+    bindRenderbuffer: vi.fn(),
+    renderbufferStorage: vi.fn(),
+    framebufferRenderbuffer: vi.fn(),
+    checkFramebufferStatus: vi.fn(() => 0x8cd5),
+    deleteFramebuffer: vi.fn(),
+    deleteTexture: vi.fn(),
+    deleteRenderbuffer: vi.fn(),
+    activeTexture: vi.fn((unit: number) => calls.push(['activeTexture', unit])),
+    getUniformLocation: vi.fn((_p, name: string) => ({ name })),
+    uniform1i: vi.fn((loc: any, v: number) => calls.push(['uniform1i', loc?.name, v])),
+  };
+}
+
+describe('RenderTarget — depthAsTexture', () => {
+  it('depthAsTexture=false (default) keeps backward-compat depthRenderbuffer path', () => {
+    const gl = createMockGL();
+    const rt = new RenderTarget({ width: 256, height: 256 });
+    rt.initialize(gl);
+    expect(rt.depthRenderbuffer).not.toBeNull();
+    expect(rt.depthTexture).toBeNull();
+  });
+
+  it('depthAsTexture=true creates depthTexture and skips renderbuffer', () => {
+    const gl = createMockGL({ hasDepthTextureExt: true });
+    const rt = new RenderTarget({ width: 256, height: 256, depthAsTexture: true });
+    rt.initialize(gl);
+    expect(rt.depthTexture).not.toBeNull();
+    expect(rt.depthRenderbuffer).toBeNull();
+    // depthTexture should be attached to DEPTH_ATTACHMENT
+    const depthAttach = (gl as any)._calls.find(
+      (c: any[]) => c[0] === 'framebufferTexture2D' && c[1] === gl.DEPTH_ATTACHMENT
+    );
+    expect(depthAttach).toBeDefined();
+  });
+
+  it('throws clear error when WEBGL_depth_texture extension unavailable', () => {
+    const gl = createMockGL({ hasDepthTextureExt: false });
+    const rt = new RenderTarget({ width: 256, height: 256, depthAsTexture: true });
+    expect(() => rt.initialize(gl)).toThrow(/WEBGL_depth_texture/);
+  });
+});
+
+describe('LINEARIZE_DEPTH_GLSL', () => {
+  it('exports a GLSL string with linearizeDepth function definition', () => {
+    expect(typeof LINEARIZE_DEPTH_GLSL).toBe('string');
+    expect(LINEARIZE_DEPTH_GLSL).toContain('linearizeDepth');
+    expect(LINEARIZE_DEPTH_GLSL).toContain('float');
+    expect(LINEARIZE_DEPTH_GLSL).toContain('near');
+    expect(LINEARIZE_DEPTH_GLSL).toContain('far');
+  });
+
+  it('GLSL function uses standard NDC unprojection formula', () => {
+    // 验证 GLSL 内含 (2.0 * near * far) 这个标准 formula 的核心项
+    expect(LINEARIZE_DEPTH_GLSL).toMatch(/2\.0\s*\*\s*near\s*\*\s*far/);
+  });
+});
+
+describe('PostProcessor — setDepthTexture + u_depthTexture binding', () => {
+  function makePass(usesDepth: boolean): EffectPass {
+    return {
+      name: 'mock',
+      enabled: true,
+      usesDepth,
+      getFragmentShader: () => 'precision mediump float; void main(){ gl_FragColor=vec4(1.0); }',
+      setUniforms: () => {},
+    };
+  }
+
+  it('setDepthTexture stores texture handle', () => {
+    const pp = new PostProcessor();
+    const tex = { id: 'depth' } as any;
+    pp.setDepthTexture(tex);
+    // 没有 public getter 也可以；验证后续 binding 时能用
+    expect(() => pp.setDepthTexture(null)).not.toThrow();
+    expect(() => pp.setDepthTexture(tex)).not.toThrow();
+  });
+
+  it('binds depth texture to unit 1 + u_depthTexture uniform when pass.usesDepth=true', () => {
+    const gl = createMockGL();
+    const pp = new PostProcessor();
+    const tex = { id: 'depth' } as any;
+    pp.setDepthTexture(tex);
+    const pass = makePass(true);
+    // 测试 PostProcessor 内部绑定逻辑（可能需要 framework 暴露内部辅助方法或通过 render 路径）
+    // 这里假设 PostProcessor 暴露 _bindDepthForPass(gl, pass, prog) 内部辅助
+    const prog = { id: 'prog' } as any;
+    // 若内部辅助名不同，测试可用 spy 验证 uniform1i('u_depthTexture', 1) 被调用
+    if (typeof (pp as any)._bindDepthForPass === 'function') {
+      (pp as any)._bindDepthForPass(gl, pass, prog);
+    }
+    // 验证 unit 1 被激活并绑定 + uniform1i 设为 1
+    const activated1 = (gl as any)._calls.find(
+      (c: any[]) => c[0] === 'activeTexture' && c[1] === gl.TEXTURE1
+    );
+    expect(activated1).toBeDefined();
+    const uniform = (gl as any)._calls.find(
+      (c: any[]) => c[0] === 'uniform1i' && c[1] === 'u_depthTexture' && c[2] === 1
+    );
+    expect(uniform).toBeDefined();
+  });
+
+  it('does NOT bind depth when pass.usesDepth=false (back-compat)', () => {
+    const gl = createMockGL();
+    const pp = new PostProcessor();
+    pp.setDepthTexture({ id: 'depth' } as any);
+    const pass = makePass(false);
+    const prog = { id: 'prog' } as any;
+    if (typeof (pp as any)._bindDepthForPass === 'function') {
+      (pp as any)._bindDepthForPass(gl, pass, prog);
+    }
+    const uniform = (gl as any)._calls.find(
+      (c: any[]) => c[0] === 'uniform1i' && c[1] === 'u_depthTexture'
+    );
+    expect(uniform).toBeUndefined();
+  });
+
+  it('does NOT bind depth when depthTexture is null', () => {
+    const gl = createMockGL();
+    const pp = new PostProcessor();
+    pp.setDepthTexture(null);
+    const pass = makePass(true);
+    const prog = { id: 'prog' } as any;
+    if (typeof (pp as any)._bindDepthForPass === 'function') {
+      (pp as any)._bindDepthForPass(gl, pass, prog);
+    }
+    const uniform = (gl as any)._calls.find(
+      (c: any[]) => c[0] === 'uniform1i' && c[1] === 'u_depthTexture'
+    );
+    expect(uniform).toBeUndefined();
+  });
+});
+
+describe('EffectPass interface — usesDepth backward compatibility', () => {
+  it('existing passes without usesDepth field continue to work', () => {
+    const legacyPass: EffectPass = {
+      name: 'legacy',
+      enabled: true,
+      getFragmentShader: () => 'void main() {}',
+      setUniforms: () => {},
+    };
+    expect(legacyPass.usesDepth).toBeUndefined();
+    // 在 PostProcessor 中也应被当作 usesDepth=false 处理
+  });
+});


### PR DESCRIPTION
## 变更摘要

Phase 51 KR1：为深度相关后处理（DOF / SSAO / MotionBlur）补齐基础设施。

- **RenderTarget.depthAsTexture**：新增选项，`true` 时通过 `WEBGL_depth_texture` 扩展创建可采样深度纹理附件；`false`（默认）保持原有 renderbuffer 行为，完全向后兼容
- **LINEARIZE_DEPTH_GLSL**：从 `post-process.ts` 导出的 GLSL 辅助函数，标准 NDC → 线性视图空间深度转换
- **EffectPass.usesDepth**：可选字段，旧 23 个 Pass 无需修改
- **PostProcessor.setDepthTexture()**：存储当前帧深度纹理 handle
- **PostProcessor._bindDepthForPass()**：`usesDepth=true` 时自动绑定深度纹理到 texture unit 1 + 设置 `u_depthTexture` uniform

## 测试

- 新建 `test/unit/renderer/depth-pass.test.ts`（10 个用例全部通过）
- 全量单元测试：154 files / 2088 tests，0 失败

close #372