### PR TITLE
feat: 实现 DOFPass — 景深模糊后处理 (#373)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -1697,6 +1697,92 @@ void main() {
   }
 }
 
+/* ── DOFPass ── */
+
+export interface DOFOptions {
+  /** 焦点距离（视图空间，单位米）— 处于此距离的物体最清晰。默认 5 */
+  focusDistance?: number;
+  /** 焦点范围 — 距 focusDistance 在此范围内仍清晰，超出开始模糊。默认 2，必须 > 0 */
+  focusRange?: number;
+  /** 最大模糊半径（屏幕像素）— CoC=1 处的采样半径。默认 4，范围 [0, 20] */
+  blurRadius?: number;
+  /** 相机近平面（用于 linearizeDepth）。默认 0.1 */
+  near?: number;
+  /** 相机远平面。默认 100，必须 > near */
+  far?: number;
+}
+
+export class DOFPass implements EffectPass {
+  readonly name = 'dof';
+  enabled = true;
+  readonly usesDepth = true;
+
+  focusDistance: number;
+  focusRange: number;
+  blurRadius: number;
+  near: number;
+  far: number;
+
+  constructor(opts: DOFOptions = {}) {
+    this.focusDistance = opts.focusDistance ?? 5;
+    this.focusRange = opts.focusRange ?? 2;
+    this.blurRadius = opts.blurRadius ?? 4;
+    this.near = opts.near ?? 0.1;
+    this.far = opts.far ?? 100;
+
+    if (!Number.isFinite(this.focusDistance)) throw new Error('DOFPass: focusDistance must be finite');
+    if (!(this.focusRange > 0)) throw new Error('DOFPass: focusRange must be > 0');
+    if (this.blurRadius < 0 || this.blurRadius > 20)
+      throw new Error('DOFPass: blurRadius must be in [0, 20]');
+    if (!(this.near > 0)) throw new Error('DOFPass: near must be > 0');
+    if (!(this.far > this.near)) throw new Error('DOFPass: far must be > near');
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+varying vec2 v_texCoord;
+uniform sampler2D u_texture;
+uniform sampler2D u_depthTexture;
+uniform vec2 u_texelSize;
+uniform float u_focusDistance;
+uniform float u_focusRange;
+uniform float u_blurRadius;
+uniform float u_near;
+uniform float u_far;
+${LINEARIZE_DEPTH_GLSL}
+void main() {
+  float d = texture2D(u_depthTexture, v_texCoord).r;
+  float linearD = linearizeDepth(d, u_near, u_far);
+  float coc = clamp(abs(linearD - u_focusDistance) / u_focusRange, 0.0, 1.0);
+  float r = u_blurRadius * coc;
+  vec4 sum = vec4(0.0);
+  float w = 0.0;
+  for (int i = -1; i <= 1; i++) {
+    for (int j = -1; j <= 1; j++) {
+      vec2 off = vec2(float(i), float(j)) * u_texelSize * r;
+      sum += texture2D(u_texture, v_texCoord + off);
+      w += 1.0;
+    }
+  }
+  gl_FragColor = sum / w;
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const set = (name: string, v: number) => {
+      const loc = gl.getUniformLocation(program, name);
+      if (loc) gl.uniform1f(loc, v);
+    };
+    set('u_focusDistance', this.focusDistance);
+    set('u_focusRange', this.focusRange);
+    set('u_blurRadius', this.blurRadius);
+    set('u_near', this.near);
+    set('u_far', this.far);
+  }
+}
+
 /* ── ColorLUTPass ── */
 
 export interface ColorLUTOptions {

--- a/test/unit/renderer/dof-pass.test.ts
+++ b/test/unit/renderer/dof-pass.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DOFPass } from '../../../src/renderer/post-process';
+
+function makeProgram(): any { return { id: 'prog' }; }
+function makeGL(): any {
+  const calls: any[] = [];
+  return {
+    _calls: calls,
+    getUniformLocation: vi.fn((_p, name: string) => ({ name })),
+    uniform1f: vi.fn((loc: any, v: number) => calls.push(['uniform1f', loc.name, v])),
+  };
+}
+
+describe('DOFPass — constructor', () => {
+  it('default options', () => {
+    const p = new DOFPass();
+    expect(p.focusDistance).toBe(5);
+    expect(p.focusRange).toBe(2);
+    expect(p.blurRadius).toBe(4);
+    expect(p.near).toBe(0.1);
+    expect(p.far).toBe(100);
+    expect(p.enabled).toBe(true);
+    expect(p.usesDepth).toBe(true);
+    expect(p.name).toBe('dof');
+  });
+
+  it('accepts custom options', () => {
+    const p = new DOFPass({ focusDistance: 10, focusRange: 5, blurRadius: 8, near: 0.5, far: 200 });
+    expect(p.focusDistance).toBe(10);
+    expect(p.focusRange).toBe(5);
+    expect(p.blurRadius).toBe(8);
+    expect(p.near).toBe(0.5);
+    expect(p.far).toBe(200);
+  });
+
+  it('throws on non-finite focusDistance', () => {
+    expect(() => new DOFPass({ focusDistance: NaN })).toThrow(/focusDistance/);
+    expect(() => new DOFPass({ focusDistance: Infinity })).toThrow(/focusDistance/);
+  });
+
+  it('throws on focusRange <= 0', () => {
+    expect(() => new DOFPass({ focusRange: 0 })).toThrow(/focusRange/);
+    expect(() => new DOFPass({ focusRange: -1 })).toThrow(/focusRange/);
+  });
+
+  it('throws on blurRadius < 0', () => {
+    expect(() => new DOFPass({ blurRadius: -1 })).toThrow(/blurRadius/);
+  });
+
+  it('throws on blurRadius > 20', () => {
+    expect(() => new DOFPass({ blurRadius: 21 })).toThrow(/blurRadius/);
+  });
+
+  it('throws on near <= 0', () => {
+    expect(() => new DOFPass({ near: 0 })).toThrow(/near/);
+  });
+
+  it('throws on far <= near', () => {
+    expect(() => new DOFPass({ near: 10, far: 5 })).toThrow(/far/);
+    expect(() => new DOFPass({ near: 10, far: 10 })).toThrow(/far/);
+  });
+});
+
+describe('DOFPass — getFragmentShader', () => {
+  it('returns GLSL with u_depthTexture sampler', () => {
+    const p = new DOFPass();
+    const src = p.getFragmentShader();
+    expect(src).toContain('uniform sampler2D u_depthTexture');
+  });
+
+  it('GLSL contains linearizeDepth call', () => {
+    const src = new DOFPass().getFragmentShader();
+    expect(src).toContain('linearizeDepth');
+  });
+
+  it('GLSL declares all 5 numeric uniforms', () => {
+    const src = new DOFPass().getFragmentShader();
+    for (const name of ['u_focusDistance', 'u_focusRange', 'u_blurRadius', 'u_near', 'u_far']) {
+      expect(src).toContain(name);
+    }
+  });
+});
+
+describe('DOFPass — setUniforms', () => {
+  it('binds all 5 uniforms with current values', () => {
+    const gl = makeGL();
+    const prog = makeProgram();
+    const p = new DOFPass({ focusDistance: 7, focusRange: 3, blurRadius: 6, near: 0.5, far: 200 });
+    p.setUniforms(gl, prog);
+    const got = (gl as any)._calls
+      .filter((c: any[]) => c[0] === 'uniform1f')
+      .map((c: any[]) => [c[1], c[2]]);
+    expect(got).toContainEqual(['u_focusDistance', 7]);
+    expect(got).toContainEqual(['u_focusRange', 3]);
+    expect(got).toContainEqual(['u_blurRadius', 6]);
+    expect(got).toContainEqual(['u_near', 0.5]);
+    expect(got).toContainEqual(['u_far', 200]);
+  });
+});


### PR DESCRIPTION
## 概述

实现 DOFPass（Depth of Field 景深模糊）后处理，依赖 #372 DepthPass 提供的基础设施。

## 变更

- `src/renderer/post-process.ts`：追加 `DOFOptions` 接口和 `DOFPass` 类
- `test/unit/renderer/dof-pass.test.ts`：12 个单元测试（构造器/shader/uniform 三组）

## 实现细节

- `usesDepth = true`，触发 PostProcessor 自动绑定 `u_depthTexture` 到 texture unit 1
- Fragment shader 内联 `LINEARIZE_DEPTH_GLSL`，将非线性深度转为视图空间线性深度
- CoC = clamp(|linearD - focusDistance| / focusRange, 0, 1)，9-tap box blur 随 CoC 缩放
- 5 个参数带默认值与边界校验（非有限值/越界均抛 Error）

## 测试结果

```
✓ test/unit/renderer/dof-pass.test.ts (12 tests)
Test Files  155 passed (155)
Tests       2100 passed (2100)
```

close #373