### PR TITLE
feat: 实现 SSAOPass — 屏幕空间环境光遮蔽后处理 (#374)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -2067,3 +2067,102 @@ void main() {
     if (uIntensity) gl.uniform1f(uIntensity, this.intensity);
   }
 }
+
+/* ── SSAOOptions ── */
+
+export interface SSAOOptions {
+  /** 遮蔽强度（0=无 SSAO，1=标准，2=过曝）。默认 1，范围 [0, 5] */
+  intensity?: number;
+  /** 采样半径（视图空间，单位米）。默认 0.5，必须 > 0 */
+  radius?: number;
+  /** 自遮蔽偏移（避免精度问题导致表面自身被遮蔽）。默认 0.025，范围 [0, 0.1] */
+  bias?: number;
+  /** 相机近平面 */
+  near?: number;
+  /** 相机远平面，必须 > near */
+  far?: number;
+}
+
+/** 屏幕空间环境光遮蔽后处理：通过采样邻域深度差估算遮蔽，让物体接触面与凹陷区域产生柔和阴影。 */
+export class SSAOPass implements EffectPass {
+  readonly name = 'ssao';
+  enabled = true;
+  readonly usesDepth = true;
+
+  intensity: number;
+  radius: number;
+  bias: number;
+  near: number;
+  far: number;
+
+  constructor(opts: SSAOOptions = {}) {
+    this.intensity = opts.intensity ?? 1;
+    this.radius = opts.radius ?? 0.5;
+    this.bias = opts.bias ?? 0.025;
+    this.near = opts.near ?? 0.1;
+    this.far = opts.far ?? 100;
+
+    if (this.intensity < 0 || this.intensity > 5)
+      throw new Error('SSAOPass: intensity must be in [0, 5]');
+    if (!(this.radius > 0)) throw new Error('SSAOPass: radius must be > 0');
+    if (this.bias < 0 || this.bias > 0.1)
+      throw new Error('SSAOPass: bias must be in [0, 0.1]');
+    if (!(this.near > 0)) throw new Error('SSAOPass: near must be > 0');
+    if (!(this.far > this.near)) throw new Error('SSAOPass: far must be > near');
+  }
+
+  getFragmentShader(): string {
+    return `
+      precision mediump float;
+      varying vec2 v_texCoord;
+      uniform sampler2D u_texture;
+      uniform sampler2D u_depthTexture;
+      uniform vec2 u_texelSize;
+      uniform float u_intensity;
+      uniform float u_radius;
+      uniform float u_bias;
+      uniform float u_near;
+      uniform float u_far;
+      ${LINEARIZE_DEPTH_GLSL}
+      void main() {
+        vec4 color = texture2D(u_texture, v_texCoord);
+        float centerDepth = linearizeDepth(texture2D(u_depthTexture, v_texCoord).r, u_near, u_far);
+        // 8 个固定方向采样（圆形分布，WebGL 1.0 不支持随机数组 uniform）
+        const int N = 8;
+        vec2 dirs[8];
+        dirs[0] = vec2( 1.0,  0.0);
+        dirs[1] = vec2( 0.7,  0.7);
+        dirs[2] = vec2( 0.0,  1.0);
+        dirs[3] = vec2(-0.7,  0.7);
+        dirs[4] = vec2(-1.0,  0.0);
+        dirs[5] = vec2(-0.7, -0.7);
+        dirs[6] = vec2( 0.0, -1.0);
+        dirs[7] = vec2( 0.7, -0.7);
+        float occlusion = 0.0;
+        for (int i = 0; i < 8; i++) {
+          vec2 sampleUV = v_texCoord + dirs[i] * u_texelSize * u_radius * 50.0;
+          float sampleDepth = linearizeDepth(texture2D(u_depthTexture, sampleUV).r, u_near, u_far);
+          // 若邻域深度比中心更近（前方挡住），算作遮蔽
+          float diff = centerDepth - sampleDepth;
+          if (diff > u_bias && diff < u_radius) {
+            occlusion += 1.0;
+          }
+        }
+        occlusion = 1.0 - (occlusion / float(N)) * u_intensity;
+        gl_FragColor = vec4(color.rgb * occlusion, color.a);
+      }
+    `.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const set = (name: string, v: number) => {
+      const loc = gl.getUniformLocation(program, name);
+      if (loc) gl.uniform1f(loc, v);
+    };
+    set('u_intensity', this.intensity);
+    set('u_radius', this.radius);
+    set('u_bias', this.bias);
+    set('u_near', this.near);
+    set('u_far', this.far);
+  }
+}

--- a/test/unit/renderer/ssao-pass.test.ts
+++ b/test/unit/renderer/ssao-pass.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SSAOPass } from '../../../src/renderer/post-process';
+
+function makeProgram(): any { return { id: 'prog' }; }
+function makeGL(): any {
+  const calls: any[] = [];
+  return {
+    _calls: calls,
+    getUniformLocation: vi.fn((_p, name: string) => ({ name })),
+    uniform1f: vi.fn((loc: any, v: number) => calls.push(['uniform1f', loc.name, v])),
+  };
+}
+
+describe('SSAOPass — constructor', () => {
+  it('default options', () => {
+    const p = new SSAOPass();
+    expect(p.intensity).toBe(1);
+    expect(p.radius).toBe(0.5);
+    expect(p.bias).toBe(0.025);
+    expect(p.near).toBe(0.1);
+    expect(p.far).toBe(100);
+    expect(p.enabled).toBe(true);
+    expect(p.usesDepth).toBe(true);
+    expect(p.name).toBe('ssao');
+  });
+
+  it('accepts custom options', () => {
+    const p = new SSAOPass({ intensity: 1.5, radius: 1.0, bias: 0.05, near: 0.5, far: 200 });
+    expect(p.intensity).toBe(1.5);
+    expect(p.radius).toBe(1.0);
+    expect(p.bias).toBe(0.05);
+    expect(p.near).toBe(0.5);
+    expect(p.far).toBe(200);
+  });
+
+  it('throws on intensity < 0', () => {
+    expect(() => new SSAOPass({ intensity: -0.1 })).toThrow(/intensity/);
+  });
+
+  it('throws on intensity > 5', () => {
+    expect(() => new SSAOPass({ intensity: 5.1 })).toThrow(/intensity/);
+  });
+
+  it('throws on radius <= 0', () => {
+    expect(() => new SSAOPass({ radius: 0 })).toThrow(/radius/);
+    expect(() => new SSAOPass({ radius: -1 })).toThrow(/radius/);
+  });
+
+  it('throws on bias < 0', () => {
+    expect(() => new SSAOPass({ bias: -0.01 })).toThrow(/bias/);
+  });
+
+  it('throws on bias > 0.1', () => {
+    expect(() => new SSAOPass({ bias: 0.11 })).toThrow(/bias/);
+  });
+
+  it('throws on near <= 0', () => {
+    expect(() => new SSAOPass({ near: 0 })).toThrow(/near/);
+  });
+
+  it('throws on far <= near', () => {
+    expect(() => new SSAOPass({ near: 10, far: 5 })).toThrow(/far/);
+  });
+});
+
+describe('SSAOPass — getFragmentShader', () => {
+  it('returns GLSL with u_depthTexture sampler', () => {
+    const src = new SSAOPass().getFragmentShader();
+    expect(src).toContain('uniform sampler2D u_depthTexture');
+  });
+
+  it('GLSL contains linearizeDepth call', () => {
+    const src = new SSAOPass().getFragmentShader();
+    expect(src).toContain('linearizeDepth');
+  });
+
+  it('GLSL declares all 5 numeric uniforms', () => {
+    const src = new SSAOPass().getFragmentShader();
+    for (const name of ['u_intensity', 'u_radius', 'u_bias', 'u_near', 'u_far']) {
+      expect(src).toContain(name);
+    }
+  });
+
+  it('GLSL contains occlusion accumulation logic', () => {
+    const src = new SSAOPass().getFragmentShader();
+    expect(src).toContain('occlusion');
+  });
+});
+
+describe('SSAOPass — setUniforms', () => {
+  it('binds all 5 uniforms with current values', () => {
+    const gl = makeGL();
+    const prog = makeProgram();
+    const p = new SSAOPass({ intensity: 1.5, radius: 1.0, bias: 0.05, near: 0.5, far: 200 });
+    p.setUniforms(gl, prog);
+    const got = (gl as any)._calls
+      .filter((c: any[]) => c[0] === 'uniform1f')
+      .map((c: any[]) => [c[1], c[2]]);
+    expect(got).toContainEqual(['u_intensity', 1.5]);
+    expect(got).toContainEqual(['u_radius', 1.0]);
+    expect(got).toContainEqual(['u_bias', 0.05]);
+    expect(got).toContainEqual(['u_near', 0.5]);
+    expect(got).toContainEqual(['u_far', 200]);
+  });
+});


### PR DESCRIPTION
## 概述

实现 `SSAOPass`（Screen-Space Ambient Occlusion）后处理，让物体接触面与凹陷区域产生柔和阴影。

## 实现要点

- `SSAOPass` 实现 `EffectPass` 接口，`usesDepth = true` 触发 PostProcessor 绑定 `u_depthTexture`
- 依赖 #372 引入的 `LINEARIZE_DEPTH_GLSL` 将非线性深度转为线性视图空间深度
- GLSL shader 使用 8 个固定方向圆形分布采样（WebGL 1.0 兼容，不用随机 uniform 数组）
- depth diff > bias 且 < radius 时累加遮蔽，最终乘以颜色输出
- 5 个参数均带默认值与边界校验，越界抛 Error

## 测试

- 新增 `test/unit/renderer/ssao-pass.test.ts`（14 个测试全部通过）
- 全量单元测试：155 files / 2102 tests ✅

close #374