### PR TITLE
feat: 实现 DepthFogPass — 基于深度的距离雾后处理 (#378)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -2166,3 +2166,125 @@ export class SSAOPass implements EffectPass {
     set('u_far', this.far);
   }
 }
+
+/* ── DepthFogOptions ── */
+
+export interface DepthFogOptions {
+  /** 雾色 RGB（0..1）。默认 [0.7, 0.7, 0.8]（蓝灰色）*/
+  color?: [number, number, number];
+  /** 雾密度，越大越浓。default 1。must be > 0 */
+  density?: number;
+  /** linear 模式起始距离。default 1。must be > 0 */
+  near?: number;
+  /** linear 模式终点距离。default 50。must be > near */
+  far?: number;
+  /** 雾衰减模式。'linear' / 'exp' / 'exp2'。default 'exp' */
+  mode?: 'linear' | 'exp' | 'exp2';
+}
+
+/** 基于深度纹理的距离雾后处理 Pass。 */
+export class DepthFogPass implements EffectPass {
+  readonly name = 'depthFog';
+  enabled = true;
+  readonly usesDepth = true;
+
+  color: [number, number, number];
+  density: number;
+  near: number;
+  far: number;
+  mode: 'linear' | 'exp' | 'exp2';
+
+  constructor(opts?: DepthFogOptions) {
+    const color = opts?.color ?? [0.7, 0.7, 0.8];
+    const density = opts?.density ?? 1;
+    const near = opts?.near ?? 1;
+    const far = opts?.far ?? 50;
+    const mode = opts?.mode ?? 'exp';
+
+    if (!Array.isArray(color) || color.length !== 3)
+      throw new Error('DepthFogPass: color 必须是 3 元素数组');
+    if (!(density > 0))
+      throw new Error('DepthFogPass: density 必须 > 0');
+    if (!(near > 0))
+      throw new Error('DepthFogPass: near 必须 > 0');
+    if (!(far > near))
+      throw new Error('DepthFogPass: far 必须 > near');
+    if (mode !== 'linear' && mode !== 'exp' && mode !== 'exp2')
+      throw new Error(`DepthFogPass: mode 必须是 'linear' | 'exp' | 'exp2'，得到 '${mode}'`);
+
+    this.color = color;
+    this.density = density;
+    this.near = near;
+    this.far = far;
+    this.mode = mode;
+  }
+
+  getFragmentShader(): string {
+    if (this.mode === 'linear') {
+      return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform sampler2D u_depthTexture;
+uniform vec3 u_fogColor;
+uniform float u_near;
+uniform float u_far;
+varying vec2 v_texCoord;
+${LINEARIZE_DEPTH_GLSL}
+void main() {
+  vec4 srcColor = texture2D(u_texture, v_texCoord);
+  float depth = linearizeDepth(texture2D(u_depthTexture, v_texCoord).r, u_near, u_far);
+  float factor = clamp((depth - u_near) / (u_far - u_near), 0.0, 1.0);
+  gl_FragColor = vec4(mix(srcColor.rgb, u_fogColor, factor), srcColor.a);
+}
+`.trim();
+    }
+    if (this.mode === 'exp') {
+      return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform sampler2D u_depthTexture;
+uniform vec3 u_fogColor;
+uniform float u_density;
+uniform float u_near;
+uniform float u_far;
+varying vec2 v_texCoord;
+${LINEARIZE_DEPTH_GLSL}
+void main() {
+  vec4 srcColor = texture2D(u_texture, v_texCoord);
+  float depth = linearizeDepth(texture2D(u_depthTexture, v_texCoord).r, u_near, u_far);
+  float factor = 1.0 - exp(-u_density * depth);
+  gl_FragColor = vec4(mix(srcColor.rgb, u_fogColor, factor), srcColor.a);
+}
+`.trim();
+    }
+    // exp2
+    return `
+precision mediump float;
+uniform sampler2D u_texture;
+uniform sampler2D u_depthTexture;
+uniform vec3 u_fogColor;
+uniform float u_density;
+uniform float u_near;
+uniform float u_far;
+varying vec2 v_texCoord;
+${LINEARIZE_DEPTH_GLSL}
+void main() {
+  vec4 srcColor = texture2D(u_texture, v_texCoord);
+  float depth = linearizeDepth(texture2D(u_depthTexture, v_texCoord).r, u_near, u_far);
+  float factor = 1.0 - exp(-u_density * u_density * depth * depth);
+  gl_FragColor = vec4(mix(srcColor.rgb, u_fogColor, factor), srcColor.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uFogColor = gl.getUniformLocation(program, 'u_fogColor');
+    if (uFogColor) gl.uniform3f(uFogColor, this.color[0], this.color[1], this.color[2]);
+    const uDensity = gl.getUniformLocation(program, 'u_density');
+    if (uDensity) gl.uniform1f(uDensity, this.density);
+    const uNear = gl.getUniformLocation(program, 'u_near');
+    if (uNear) gl.uniform1f(uNear, this.near);
+    const uFar = gl.getUniformLocation(program, 'u_far');
+    if (uFar) gl.uniform1f(uFar, this.far);
+  }
+}

--- a/test/unit/renderer/depth-fog-pass.test.ts
+++ b/test/unit/renderer/depth-fog-pass.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { DepthFogPass } from '../../../src/renderer/post-process';
+
+describe('DepthFogPass', () => {
+  it('默认参数', () => {
+    const p = new DepthFogPass();
+    expect(p.name).toBe('depthFog');
+    expect(p.enabled).toBe(true);
+    expect(p.usesDepth).toBe(true);
+    expect(p.color).toEqual([0.7, 0.7, 0.8]);
+    expect(p.density).toBe(1);
+    expect(p.near).toBe(1);
+    expect(p.far).toBe(50);
+    expect(p.mode).toBe('exp');
+  });
+
+  it('自定义参数', () => {
+    const p = new DepthFogPass({
+      color: [1, 0, 0],
+      density: 0.5,
+      near: 5,
+      far: 100,
+      mode: 'linear',
+    });
+    expect(p.color).toEqual([1, 0, 0]);
+    expect(p.density).toBe(0.5);
+    expect(p.near).toBe(5);
+    expect(p.far).toBe(100);
+    expect(p.mode).toBe('linear');
+  });
+
+  it('校验 density > 0', () => {
+    expect(() => new DepthFogPass({ density: 0 })).toThrow(/density/i);
+    expect(() => new DepthFogPass({ density: -1 })).toThrow(/density/i);
+    expect(() => new DepthFogPass({ density: NaN })).toThrow(/density/i);
+  });
+
+  it('校验 near > 0', () => {
+    expect(() => new DepthFogPass({ near: 0 })).toThrow(/near/i);
+    expect(() => new DepthFogPass({ near: -0.1 })).toThrow(/near/i);
+  });
+
+  it('校验 far > near', () => {
+    expect(() => new DepthFogPass({ near: 10, far: 5 })).toThrow(/far/i);
+    expect(() => new DepthFogPass({ near: 10, far: 10 })).toThrow(/far/i);
+  });
+
+  it('校验 mode 必须是合法值', () => {
+    expect(() => new DepthFogPass({ mode: 'foo' as any })).toThrow(/mode/i);
+  });
+
+  it('校验 color 必须是 3 元素数组', () => {
+    expect(() => new DepthFogPass({ color: [1, 0] as any })).toThrow(/color/i);
+    expect(() => new DepthFogPass({ color: [1, 0, 0, 0] as any })).toThrow(/color/i);
+  });
+
+  it('getFragmentShader 返回有效 GLSL 字符串', () => {
+    const p = new DepthFogPass();
+    const src = p.getFragmentShader();
+    expect(src).toContain('precision');
+    expect(src).toContain('u_texture');
+    expect(src).toContain('u_depthTexture');
+    expect(src).toContain('linearizeDepth');
+    expect(src).toContain('mix(');
+  });
+
+  it('linear/exp/exp2 三种 mode 各产生不同 GLSL', () => {
+    const linear = new DepthFogPass({ mode: 'linear' }).getFragmentShader();
+    const exp = new DepthFogPass({ mode: 'exp' }).getFragmentShader();
+    const exp2 = new DepthFogPass({ mode: 'exp2' }).getFragmentShader();
+    expect(linear).not.toEqual(exp);
+    expect(exp).not.toEqual(exp2);
+    expect(linear).not.toEqual(exp2);
+  });
+
+  it('修改 enabled 字段', () => {
+    const p = new DepthFogPass();
+    p.enabled = false;
+    expect(p.enabled).toBe(false);
+  });
+
+  it('修改运行时参数', () => {
+    const p = new DepthFogPass();
+    p.density = 2.5;
+    p.color = [0.1, 0.2, 0.3];
+    expect(p.density).toBe(2.5);
+    expect(p.color).toEqual([0.1, 0.2, 0.3]);
+  });
+});


### PR DESCRIPTION
## 概述

实现 Phase 52 KR1 — DepthFogPass：基于深度纹理的屏幕空间距离雾后处理 Pass。

## 实现要点

- 复用 DepthPass 约定：`usesDepth = true` + `u_depthTexture` + `LINEARIZE_DEPTH_GLSL`
- 支持三种衰减模式，各生成独立 GLSL（无运行时 if 分支，GPU 性能最优）：
  - `linear`：`clamp((depth - near) / (far - near), 0, 1)`
  - `exp`：`1.0 - exp(-density * depth)`
  - `exp2`：`1.0 - exp(-density * density * depth * depth)`
- 构造器内完整参数校验（density > 0、near > 0、far > near、color 3元素、mode 合法值）
- alpha 通道保持，仅 RGB 参与雾色混合

## 测试

- 11 个单元测试全绿
- 全量 157 个测试文件 / 2125 个测试零回归

close #378