### PR TITLE
feat: 实现 AtmosphericPerspectivePass — 大气透视远处颜色衰减后处理 (#380)

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 AI-native 3D game engine. WebGL 1.0, column-major Mat4, zero external dependencies.
 
-Generated: 2026-04-16 from 89 source files.
+Generated: 2026-04-27 from 112 source files.
 Regenerate: `node scripts/gen-llms-txt.mjs`
 
 This file is a **symbol index**, not full API docs. For method signatures and
@@ -16,11 +16,26 @@ parameter details, read the source file directly (path shown in each section).
 AssetManager — 集中式资产加载器，提供 URL 级缓存、进度追踪和生命周期管理。 所有资产通过 key 标识，相同 key 只加载一次。
 - `class AssetManager` — AssetManager — 集中式资产加载器，提供 URL 级缓存、进度追踪和生命周期管理。
 
+### `src/core/camera-shake.ts`
+CameraShake — 层叠式相机抖动管理器。 支持多层抖动叠加（地震 + 爆炸 + 后坐力），每层独立衰减。 使用伪随机噪声 + 指数衰减，输出 position + rotation offset 应用到相机。
+- `interface ShakeLayerOptions` — CameraShake — 层叠式相机抖动管理器。
+- `class CameraShake`
+
+### `src/core/camera-switcher.ts`
+CameraSwitcher — 多相机注册与切换管理器。 注册多个命名相机，按名切换；支持堆栈模式（push/pop）。 典型用途：游戏主视角 / 过场相机 / 调试俯视 / UI 相机 无缝切换。
+- `class CameraSwitcher`
+
 ### `src/core/camera.ts`
 Camera 抽象基类 + PerspectiveCamera + OrthographicCamera。 Camera extends Node3D，保留场景图参与能力。
 - `abstract class Camera extends Node3D` — Camera 抽象基类 + PerspectiveCamera + OrthographicCamera。
 - `class PerspectiveCamera extends Camera`
 - `class OrthographicCamera extends Camera`
+
+### `src/core/cinematic-camera.ts`
+CinematicCamera — 关键帧驱动过场动画相机。 支持线性或 CatmullRom 插值关键帧序列（position + lookAt + fov）。 典型用途：游戏过场动画、回放镜头、UI 演示自动镜头。
+- `interface Keyframe`
+- `interface CinematicCameraOptions`
+- `class CinematicCamera extends PerspectiveCamera`
 
 ### `src/core/clock.ts`
 Clock — 游戏循环时间管理。 使用 performance.now() 提供高精度帧间隔和累计时间。
@@ -108,7 +123,6 @@ Color — RGB 颜色类，游戏开发标准颜色操作。 内部以 [0,1] 浮�
 
 ### `src/math/curve3.ts`
 Curve3 — CatmullRom 3D 参数化样条曲线。 通过控制点序列创建平滑 3D 曲线，支持： - getPoint(t)        — 参数 t∈[0,1] 处的位置 - getTangent(t)      — 参数 t 处的归一化切线 - getPoints(n)       — n+1 个等参数间距的采样点 - getLength()        — 弧长近似 - getPointAtLength(d) — 弧长 d 处的位置 CatmullRom 插值经过所有控制点，tension 参数控制曲率。
-- `const __STUB__` — Curve3 — CatmullRom 3D 参数化样条曲线。
 - `interface Curve3Options`
 - `class Curve3`
 
@@ -197,6 +211,11 @@ BitmapText — 基于 BitmapFont atlas 的文字渲染节点 继承 Mesh，为�
 - `class BitmapTextMaterial extends Material` — BitmapText — 基于 BitmapFont atlas 的文字渲染节点
 - `class BitmapText extends Mesh` — BitmapText — 文字渲染节点，继承 Mesh。
 
+### `src/renderer/capsule-geometry.ts`
+CapsuleGeometry — 胶囊体几何（两半球 + 中段圆柱）。 角色碰撞代理、胶囊关节、快速角色模型、药丸形物体的标准形状。 结构（中心在原点，Y 轴为胶囊轴）： - 上半球：capSegments+1 环，从极点 (0, halfL+radius, 0) 到赤道 (halfL, radius 水平圆) - 下半球：capSegments+1 环，从赤道 (-halfL, radius 水平圆) 到极点 (0, -halfL-radius, 0) - 中段圆柱通过上下赤道环之间的四边形带隐式存在（若 length=0 退化为球体） 总环数 = 2*(capSegments+1)，每环 radialSegments+1 顶点。
+- `interface CapsuleGeometryOptions`
+- `function createCapsuleGeometry (opts: CapsuleGeometryOptions`
+
 ### `src/renderer/cube-texture.ts`
 CubeTexture — 6 面立方体贴图，用于天空盒和环境映射。 每个面是一张正方形 RGBA 图片（Uint8Array），按标准顺序排列： +X, -X, +Y, -Y, +Z, -Z（gl.TEXTURE_CUBE_MAP_POSITIVE_X 等）。
 - `const CubeTextureFace` — CubeTexture — 6 面立方体贴图，用于天空盒和环境映射。
@@ -221,6 +240,11 @@ Geometry — holds vertex/index buffer data for a mesh. Positions and colors are
 ### `src/renderer/instanced-mesh.ts`
 InstancedMesh — 单 Geometry + Material 渲染多个实例，共用一次 draw call。 基于 WebGL 1.0 ANGLE_instanced_arrays 扩展。 API 参考 Three.js InstancedMesh，但简化为仅支持 per-instance 变换和颜色。
 - `class InstancedMesh extends Mesh`
+
+### `src/renderer/lathe-geometry.ts`
+LatheGeometry — 2D profile 绕 Y 轴旋转成型几何体。 用于生成花瓶、酒杯、陶罐、灯罩等旋转对称模型。
+- `interface LatheGeometryOptions`
+- `function createLatheGeometry (opts: LatheGeometryOptions): Geometry`
 
 ### `src/renderer/line-renderer.ts`
 LineRenderer — 3D 线段/折线渲染。 支持 LINES（成对线段）、LINE_STRIP（连续折线）、LINE_LOOP（封闭折线）三种绘制模式。 用于调试可视化（路径/包围盒/射线）和游戏效果（激光/轨迹/连线）。
@@ -248,17 +272,69 @@ ParticleRenderer — GPU 粒子点精灵渲染器。 使用 gl.POINTS 原语和 
 - `class ParticleRenderer`
 
 ### `src/renderer/phong-material.ts`
-PhongMaterial — Blinn-Phong 光照材质 支持：漫反射贴图、自发光、多光源
+PhongMaterial — Blinn-Phong 光照材质 支持：漫反射贴图、自发光、多光源、环境映射
 - `interface PhongMaterialOptions`
 - `class PhongMaterial extends Material`
 
 ### `src/renderer/post-process.ts`
-PostProcessor — 后处理管线。 基于 ping-pong FBO 实现多 pass 效果链，内置灰度、模糊、泛光三种效果。
-- `interface EffectPass` — PostProcessor — 后处理管线。
+PostProcessor — 后处理管线。 基于 ping-pong FBO 实现多 pass 效果链，内置灰度、模糊、泛光、色调映射四种效果。
+- `const LINEARIZE_DEPTH_GLSL` — PostProcessor — 后处理管线。
+- `interface EffectPass`
 - `class PostProcessor`
 - `class GrayscalePass implements EffectPass` — 灰度化效果：使用亮度公式 dot(rgb, vec3(0.299, 0.587, 0.114))
 - `class BlurPass implements EffectPass` — 高斯模糊效果：5-tap 高斯核双向采样
 - `class BloomPass implements EffectPass` — 泛光效果：亮度阈值提取 → 模糊 → 与原图叠加
+- `type TonemapMode`
+- `interface TonemapOptions`
+- `class TonemapPass implements EffectPass` — ACES Filmic Tonemapping（Narkowicz 2015 简化版）+ Reinhard 双模式色调映射后处理
+- `interface VignetteOptions`
+- `class VignettePass implements EffectPass` — 屏幕暗角效果：径向 smoothstep 衰减，营造电影感聚焦中心
+- `interface FilmGrainOptions`
+- `class FilmGrainPass implements EffectPass` — 胶片颗粒噪声后处理：在最终输出上叠加伪随机噪声，模拟电影胶片颗粒感
+- `interface ChromaticAberrationOptions`
+- `class ChromaticAberrationPass implements EffectPass` — RGB 通道色差效果：模拟镜头色散，常用于赛博朋克 / 恐怖 / 动作风格
+- `interface PixelateOptions`
+- `class PixelatePass implements EffectPass` — 像素化后处理：将屏幕划分为像素网格，每格统一采样，模拟复古像素游戏视觉
+- `interface FXAAOptions`
+- `class FXAAPass implements EffectPass` — 快速近似抗锯齿（Timothy Lottes FXAA 3.11 简化版）：基于亮度对比消除锯齿边缘
+- `interface OutlineOptions`
+- `class OutlinePass implements EffectPass` — Sobel 边缘检测描边后处理：基于亮度梯度识别边缘并叠加描边色
+- `interface SharpenOptions`
+- `class SharpenPass implements EffectPass` — Laplacian 5-tap cross kernel 锐化后处理：提升图像细节清晰度
+- `interface SepiaOptions`
+- `class SepiaPass implements EffectPass` — 复古棕褐色调色后处理：经典 sepia 矩阵变换，用 mix 融合原色与 sepia 色
+- `interface SaturationOptions`
+- `class SaturationPass implements EffectPass` — 饱和度调整后处理：Rec. 709 luma-based desaturation，支持 0=灰度 / 1=原色 / 2=过饱和
+- `interface HueRotateOptions`
+- `class HueRotatePass implements EffectPass` — HSV 色相旋转后处理：通过 YIQ 色彩空间旋转矩阵实现快速色相偏移
+- `interface ContrastOptions`
+- `class ContrastPass implements EffectPass` — 围绕 midpoint 缩放的对比度调整后处理
+- `interface ScanlineOptions`
+- `class ScanlinePass implements EffectPass` — CRT 扫描线复古后处理：模拟 CRT 显示器水平扫描线，适用于复古/retro wave 风格
+- `interface LensDistortionOptions`
+- `class LensDistortionPass implements EffectPass` — 镜头畸变后处理：基于 r^2 + k2*r^4 径向畸变模型实现桶形/枕形畸变，支持色差模拟
+- `class GammaPass implements EffectPass` — sRGB gamma 校正后处理：线性空间转显示器空间（pre-display encoding）
+- `class ExposurePass implements EffectPass` — EV stops 曝光补偿后处理：+1 stop = ×2 亮度，-1 stop = ÷2 亮度，CPU 侧预计算 pow(2, ev)
+- `class WhiteBalancePass implements EffectPass` — 色温白平衡后处理：补偿光源色温偏差，营造时段/天气氛围
+- `interface HighlightShadowOptions`
+- `class HighlightShadowPass implements EffectPass` — 高光/阴影分区调整：基于 Rec.709 luma mask 独立控制亮区和暗区
+- `interface LiftGammaGainOptions`
+- `class LiftGammaGainPass implements EffectPass` — 三段调色后处理：分别控制阴影 lift、中间调 gamma、高光 gain（DaVinci Resolve 标准公式）
+- `interface PosterizeOptions`
+- `class PosterizePass implements EffectPass` — 色阶量化后处理：按固定 levels 量化 RGB 通道，产生漫画/赛璐璐/复古风格
+- `interface DOFOptions`
+- `class DOFPass implements EffectPass`
+- `interface ColorLUTOptions`
+- `class ColorLUTPass implements EffectPass` — 基于 Lookup Texture 的专业调色后处理：64³ LUT 展开为 512×512 tiled atlas（8×8 tiles）
+- `interface VibranceOptions`
+- `class VibrancePass implements EffectPass` — 自然饱和度后处理：对未饱和色影响大、对已饱和色影响小（Lightroom Vibrance 业界标准）
+- `type DitherMatrix`
+- `interface DitherOptions`
+- `class DitherPass implements EffectPass` — Bayer 矩阵有序抖动后处理：通过 4×4 或 8×8 Bayer 矩阵比较像素亮度与阈值，
+- `interface SSAOOptions`
+- `class SSAOPass implements EffectPass` — 屏幕空间环境光遮蔽后处理：通过采样邻域深度差估算遮蔽，让物体接触面与凹陷区域产生柔和阴影。
+- `interface AtmosphericPerspectiveOptions`
+- `class AtmosphericPerspectivePass implements EffectPass`
 
 ### `src/renderer/primitives.ts`
 - `function createPlaneGeometry (` — 平面几何体，位于 XZ 平面，以原点为中心，法线朝 +Y。
@@ -287,8 +363,7 @@ RenderTarget — 离屏渲染目标（FBO 封装）。 用于阴影贴图、后�
 
 ### `src/renderer/shader-material.ts`
 ShaderMaterial — 自定义着色器材质，支持声明式 uniform 绑定。 AI Agent 可编写任意 GLSL vertex/fragment shader，并通过 uniforms map 声明 自定义 uniform 变量。WebGLRenderer 自动检测 ShaderMaterial 并绑定所有声明的 uniform。 内置 uniform（渲染器自动注入，无需声明）： u_mvp          mat4  — model-view-projection 矩阵 u_modelMatrix  mat4  — model 矩阵 u_viewMatrix   mat4  — view 矩阵 u_projMatrix   mat4  — projection 矩阵 u_time         float — 累计时间（秒） u_resolution   vec2  — canvas 尺寸（像素）
-- `const __STUB__` — ShaderMaterial — 自定义着色器材质，支持声明式 uniform 绑定。
-- `type UniformType` — Supported uniform types matching WebGL 1.0 uniform calls.
+- `type UniformType` — ShaderMaterial — 自定义着色器材质，支持声明式 uniform 绑定。
 - `interface UniformDef` — A single uniform declaration: type + current value.
 - `interface ShaderMaterialOptions`
 - `class ShaderMaterial extends Material`
@@ -299,6 +374,8 @@ ShadowMap — 方向光阴影映射。 使用 RenderTarget 渲染深度纹理，
 - `const SHADOW_VERTEX_CODE` — 顶点着色器代码部分：计算阴影纹理坐标
 - `const SHADOW_FRAGMENT_PARS` — 片元着色器声明部分：阴影贴图采样器与 varying
 - `const SHADOW_FRAGMENT_CODE` — 片元着色器代码部分：采样阴影贴图并计算阴影因子（硬阴影）
+- `const PCF_3X3_FRAGMENT_CODE` — 3x3 PCF 展开式，9 次采样（WebGL 1.0 兼容，无 for 循环）
+- `const PCF_5X5_FRAGMENT_CODE` — 5x5 PCF 展开式，25 次采样（WebGL 1.0 兼容，无 for 循环）
 
 ### `src/renderer/skinned-mesh.ts`
 SkinnedMesh — 带骨骼蒙皮的可渲染节点。 扩展 Mesh，持有 Skeleton 引用，用于骨骼动画渲染。
@@ -338,6 +415,11 @@ TrailRenderer — 动态拖尾效果渲染器。 跟随父节点的世界位置�
 - `interface TrailPoint`
 - `interface TrailRendererOptions`
 - `class TrailRenderer extends Node3D`
+
+### `src/renderer/tube-geometry.ts`
+TubeGeometry — 沿 Curve3 路径扫掠的管道几何体。 为 Curve3 (Phase 35) 提供可视化管道表面：轨道、蛇形路径、电缆、河流等。 实现思路： 1. 沿 curve 采样 tubularSegments+1 个环 2. 每个环使用平行传输 (parallel transport) frame 生成 radialSegments+1 个顶点 3. 顶点环展开为四边形带 (2 三角形/四边形)
+- `interface TubeGeometryOptions`
+- `function createTubeGeometry (opts: TubeGeometryOptions): Geometry`
 
 ### `src/renderer/webgl-renderer.ts`
 WebGLRenderer — traverses the scene graph and renders all Mesh nodes. Uses WebGL 1.0 for maximum compatibility (WeChat mini-games).
@@ -391,6 +473,10 @@ CollisionWorld — 基于 SphereCollider 的碰撞检测系统。 支持碰撞�
 
 ## src/navigation/
 
+### `src/navigation/funnel.ts`
+Funnel — Simple Stupid Funnel Algorithm for path smoothing. Pure function that converts a sequence of portal edges (shared edges between adjacent NavMesh polygons) into a string-pulled smooth path. The portal edges are specified as two parallel arrays of left and right edge vertices. Reference: Mikko Mononen, "Simple Stupid Funnel Algorithm" (2010). API: funnelSmooth(start: Vec3, end: Vec3, portalsLeft: Vec3[], portalsRight: Vec3[]): Vec3[] The result always includes `start` as the first waypoint and `end` as the last. The XZ plane is used for funnel tests (Y is preserved from portal vertices).
+- `function funnelSmooth (`
+
 ### `src/navigation/nav-agent.ts`
 NavAgent — path-following navigation agent. Attaches to a Node3D and moves it along a sequence of world-space waypoints. Provides speed control, waypoint callbacks, and arrival detection.
 - `class NavAgent` — NavAgent — path-following navigation agent.
@@ -398,6 +484,16 @@ NavAgent — path-following navigation agent. Attaches to a Node3D and moves it 
 ### `src/navigation/nav-grid.ts`
 NavGrid — 2D grid-based navigation map. Represents a walkability grid for A* pathfinding. Each cell has a walkable flag and a traversal cost. Supports world ↔ grid coordinate conversion.
 - `class NavGrid` — NavGrid — 2D grid-based navigation map.
+
+### `src/navigation/nav-mesh-agent.ts`
+NavMeshAgent — 3D path-following agent for NavMesh waypoints. Attaches to a Node3D and moves it along a sequence of 3D waypoints (Vec3[]). Unlike NavAgent (2D [x,z] waypoints), NavMeshAgent operates in full 3D space with Y-axis awareness, enabling slopes, ramps, and multi-level navigation.
+- `type AgentCallback`
+- `type WaypointCallback`
+- `class NavMeshAgent`
+
+### `src/navigation/nav-mesh.ts`
+NavMesh — 基于多边形（三角形）的 3D 导航网格。 支持不规则三角形导航、自动邻接计算、A* 寻路。 适用于坡道、楼梯、不规则地形等真实 3D 场景。
+- `class NavMesh`
 
 ### `src/navigation/pathfinder.ts`
 A* Pathfinder — grid-based shortest path search. Finds optimal paths on a NavGrid using the A* algorithm. Supports 4-direction (cardinal) and 8-direction (diagonal) movement, custom cell costs, and iteration limits.
@@ -440,6 +536,10 @@ EventEmitter — 通用事件发射器 Lightweight typed event emitter for game 
 - `type EventMap` — EventEmitter — 通用事件发射器
 - `class EventEmitter <T extends EventMap` — Generic typed event emitter.
 
+### `src/gameplay/health.ts`
+- `type HealthEvents`
+- `class Health extends EventEmitter<HealthEvents>`
+
 ### `src/gameplay/object-pool.ts`
 ObjectPool — 通用泛型对象池 通过 factory + reset 模式复用对象，避免 GC 压力。
 - `class ObjectPool <T>` — ObjectPool — 通用泛型对象池
@@ -457,6 +557,12 @@ Timer — 基于帧更新的游戏定时器系统。 支持 setTimeout（延迟�
 
 ## src/ui/
 
+### `src/ui/stats-overlay.ts`
+StatsOverlay — 内置 FPS / drawCalls / triangles HUD 组件 集成 RenderInfo + 帧时间统计，自动每 N 秒刷新显示。 AI Agent 调试性能时不需要每次手写 UI 代码。
+- `interface RenderInfoSnapshot`
+- `interface StatsOverlayOptions`
+- `class StatsOverlay`
+
 ### `src/ui/ui-button.ts`
 UIButton — 可交互按钮 UI 元素。 支持 normal/pressed/disabled 三种视觉状态、标签文字、onClick 回调。 简化游戏菜单/暂停/重启等常见按钮场景。
 - `interface UIButtonOptions extends UIElementOptions`
@@ -465,6 +571,12 @@ UIButton — 可交互按钮 UI 元素。 支持 normal/pressed/disabled 三种�
 ### `src/ui/ui-canvas.ts`
 UICanvas — 屏幕空间 2D 覆盖层容器。 管理正交投影矩阵（像素坐标系，左上角 0,0）和 UI 元素树。 提供 hitTest 用于点击/触摸交互。 渲染器通过 renderUI(canvas) 在 3D 场景之后渲染此层。
 - `class UICanvas`
+
+### `src/ui/ui-dropdown.ts`
+UIDropdown — 下拉选择 UI 元素。 用于难度 / 角色 / 分辨率 / 语言等离散选项选择。 核心能力：options 数组 + selectedIndex + open/close 展开状态 + 选中触发 onChange 回调。
+- `interface UIDropdownOption`
+- `interface UIDropdownOptions extends UIElementOptions`
+- `class UIDropdown extends UIElement`
 
 ### `src/ui/ui-element.ts`
 UIElement — 2D UI 元素基类。 所有 HUD/UI 组件（UIRect, UIText, UIProgressBar）的公共基类。 提供位置、尺寸、锚点、可见性、不透明度、子元素树、交互回调。
@@ -494,6 +606,16 @@ UIProgressBar — 进度条 UI 元素。 可配置填充方向、背景色、填
 UIRect — 矩形 UI 元素。 纯色或纹理填充的矩形，用于面板、按钮背景、遮罩等。
 - `interface UIRectOptions extends UIElementOptions`
 - `class UIRect extends UIElement`
+
+### `src/ui/ui-slider.ts`
+UISlider — 可拖动滑块 UI 元素。 用于音量 / 亮度 / 难度 / 游戏速度等范围参数调节。
+- `interface UISliderOptions extends UIElementOptions`
+- `class UISlider extends UIElement`
+
+### `src/ui/ui-text-input.ts`
+UITextInput — 文本输入框 UI 元素。 用于玩家名 / 聊天 / 搜索 / 作弊码等输入场景。
+- `interface UITextInputOptions extends UIElementOptions`
+- `class UITextInput extends UIElement`
 
 ### `src/ui/ui-text.ts`
 UIText — 屏幕空间文字 UI 元素。 使用 BitmapFont 在像素坐标系中渲染文字。 支持字号缩放、颜色、对齐方式。
@@ -540,3 +662,52 @@ Rotating triangle renderer — incremental feature on top of static renderer. Ad
 Minimal WebGL renderer — Phase 0 spike. Renders a colored triangle to validate the headless visual testing pipeline.
 - `function initRenderer (canvas: HTMLCanvasElement): RendererState` — Minimal WebGL renderer — Phase 0 spike.
 - `function renderFrame (state: RendererState): void` — Render one frame — static colored triangle.
+
+## src/debug/
+
+### `src/debug/debug-draw.ts`
+DebugDraw — immediate-mode 调试绘制 API 提供 frame 内有效的 line/sphere/box/arrow 绘制，调用一次只在当前帧显示， 自动累积到 buffer，flush() 后清空。供 AI Agent 调试运行时几何/路径/碰撞用。
+- `interface DebugLine`
+- `interface DebugSphere`
+- `interface DebugBox`
+- `interface DebugArrow`
+- `class DebugDraw`
+
+### `src/debug/scene-dumper.ts`
+SceneTreeDumper — 场景图 JSON 序列化 把 Node3D 层级序列化为 JSON 友好的纯数据结构（含 transform / mesh refs / 子树）， 用于调试运行时场景状态、对比快照、AI Agent 自查场景结构。
+- `interface SerializedNode`
+- `interface DumpOptions`
+- `function dumpScene (root: Node3D, options?: DumpOptions): SerializedNode`
+- `function dumpSceneJSON (root: Node3D, options?: DumpOptions, indent?: number): string`
+
+## src/net/
+
+### `src/net/interpolator.ts`
+- `interface Vec3Like`
+- `class RemoteEntityInterpolator`
+
+### `src/net/mock-network.ts`
+- `class MockNetwork implements INetworkTransport`
+- `function createMockNetwork (): MockNetwork`
+- `function resetMockNetwork (): void`
+
+### `src/net/network-client.ts`
+- `interface NetworkClientOptions`
+- `class NetworkClient`
+
+### `src/net/state-sync.ts`
+- `interface StateSyncOptions`
+- `class StateSync <TState`
+
+### `src/net/transport.ts`
+- `interface INetworkTransport`
+
+## src/terrain/
+
+### `src/terrain/splatmap-material.ts`
+- `interface SplatmapMaterialOptions`
+- `class SplatmapMaterial`
+
+### `src/terrain/terrain.ts`
+- `interface TerrainOptions`
+- `class Terrain`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
@@ -104,478 +104,308 @@ importers:
 
 packages:
 
-  /@esbuild/aix-ppc64@0.25.12:
+  '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-arm64@0.25.12:
+  '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-arm@0.25.12:
+  '@esbuild/android-arm@0.25.12':
     resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-x64@0.25.12:
+  '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/darwin-arm64@0.25.12:
+  '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/darwin-x64@0.25.12:
+  '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/freebsd-arm64@0.25.12:
+  '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/freebsd-x64@0.25.12:
+  '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-arm64@0.25.12:
+  '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-arm@0.25.12:
+  '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-ia32@0.25.12:
+  '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-loong64@0.25.12:
+  '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-mips64el@0.25.12:
+  '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-ppc64@0.25.12:
+  '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-riscv64@0.25.12:
+  '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-s390x@0.25.12:
+  '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-x64@0.25.12:
+  '@esbuild/linux-x64@0.25.12':
     resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/netbsd-arm64@0.25.12:
+  '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/netbsd-x64@0.25.12:
+  '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/openbsd-arm64@0.25.12:
+  '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/openbsd-x64@0.25.12:
+  '@esbuild/openbsd-x64@0.25.12':
     resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/openharmony-arm64@0.25.12:
+  '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/sunos-x64@0.25.12:
+  '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-arm64@0.25.12:
+  '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-ia32@0.25.12:
+  '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-x64@0.25.12:
+  '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@jridgewell/sourcemap-codec@1.5.5:
+  '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-    dev: true
 
-  /@playwright/test@1.52.0:
+  '@playwright/test@1.52.0':
     resolution: {integrity: sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==}
     engines: {node: '>=18'}
     hasBin: true
-    dependencies:
-      playwright: 1.52.0
-    dev: true
 
-  /@rollup/rollup-android-arm-eabi@4.60.1:
+  '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
     cpu: [arm]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-android-arm64@4.60.1:
+  '@rollup/rollup-android-arm64@4.60.1':
     resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
     cpu: [arm64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-darwin-arm64@4.60.1:
+  '@rollup/rollup-darwin-arm64@4.60.1':
     resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
     cpu: [arm64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-darwin-x64@4.60.1:
+  '@rollup/rollup-darwin-x64@4.60.1':
     resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
     cpu: [x64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-freebsd-arm64@4.60.1:
+  '@rollup/rollup-freebsd-arm64@4.60.1':
     resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
     cpu: [arm64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-freebsd-x64@4.60.1:
+  '@rollup/rollup-freebsd-x64@4.60.1':
     resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
     cpu: [x64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.60.1:
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm-musleabihf@4.60.1:
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.60.1:
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.60.1:
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-loong64-gnu@4.60.1:
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-loong64-musl@4.60.1:
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-ppc64-gnu@4.60.1:
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-ppc64-musl@4.60.1:
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.60.1:
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-riscv64-musl@4.60.1:
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-s390x-gnu@4.60.1:
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.60.1:
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.60.1:
+  '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-openbsd-x64@4.60.1:
+  '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
     cpu: [x64]
     os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-openharmony-arm64@4.60.1:
+  '@rollup/rollup-openharmony-arm64@4.60.1':
     resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
     cpu: [arm64]
     os: [openharmony]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.60.1:
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
     resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
     cpu: [arm64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.60.1:
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
     resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
     cpu: [ia32]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-x64-gnu@4.60.1:
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
     resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
     cpu: [x64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.60.1:
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
     resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
     cpu: [x64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@types/chai@5.2.3:
+  '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
-    dependencies:
-      '@types/deep-eql': 4.0.2
-      assertion-error: 2.0.1
-    dev: true
 
-  /@types/deep-eql@4.0.2:
+  '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
-    dev: true
 
-  /@types/estree@1.0.8:
+  '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-    dev: true
 
-  /@vitest/expect@3.2.4:
+  '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
-    dev: true
 
-  /@vitest/mocker@3.2.4(vite@6.4.1):
+  '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
@@ -585,76 +415,39 @@ packages:
         optional: true
       vite:
         optional: true
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-      vite: 6.4.1
-    dev: true
 
-  /@vitest/pretty-format@3.2.4:
+  '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
-    dependencies:
-      tinyrainbow: 2.0.0
-    dev: true
 
-  /@vitest/runner@3.2.4:
+  '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
-    dependencies:
-      '@vitest/utils': 3.2.4
-      pathe: 2.0.3
-      strip-literal: 3.1.0
-    dev: true
 
-  /@vitest/snapshot@3.2.4:
+  '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
-    dependencies:
-      '@vitest/pretty-format': 3.2.4
-      magic-string: 0.30.21
-      pathe: 2.0.3
-    dev: true
 
-  /@vitest/spy@3.2.4:
+  '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
-    dependencies:
-      tinyspy: 4.0.4
-    dev: true
 
-  /@vitest/utils@3.2.4:
+  '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
-    dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
-    dev: true
 
-  /assertion-error@2.0.1:
+  assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
-    dev: true
 
-  /cac@6.7.14:
+  cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
-    dev: true
 
-  /chai@5.3.3:
+  chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
-    dev: true
 
-  /check-error@2.1.3:
+  check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
-    dev: true
 
-  /debug@4.4.3:
+  debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -662,65 +455,27 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-    dependencies:
-      ms: 2.1.3
-    dev: true
 
-  /deep-eql@5.0.2:
+  deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
-    dev: true
 
-  /es-module-lexer@1.7.0:
+  es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
-    dev: true
 
-  /esbuild@0.25.12:
+  esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
-    dev: true
 
-  /estree-walker@3.0.3:
+  estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
-    dependencies:
-      '@types/estree': 1.0.8
-    dev: true
 
-  /expect-type@1.3.0:
+  expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
-    dev: true
 
-  /fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -728,223 +483,123 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-    dependencies:
-      picomatch: 4.0.4
-    dev: true
 
-  /fsevents@2.3.2:
+  fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /fsevents@2.3.3:
+  fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /js-tokens@9.0.1:
+  js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-    dev: true
 
-  /loupe@3.2.1:
+  loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-    dev: true
 
-  /magic-string@0.30.21:
+  magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-    dev: true
 
-  /ms@2.1.3:
+  ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
 
-  /nanoid@3.3.11:
+  nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
-  /pathe@2.0.3:
+  pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-    dev: true
 
-  /pathval@2.0.1:
+  pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
-    dev: true
 
-  /picocolors@1.1.1:
+  picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-    dev: true
 
-  /picomatch@4.0.4:
+  picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
-    dev: true
 
-  /pixel-buffer-diff@1.4.0:
+  pixel-buffer-diff@1.4.0:
     resolution: {integrity: sha512-ELO02chzyRFfzYIQwNePYZ0ls3P33+b+IOP+e7/j0SlGcPjQi9QDUVnP46kvmtuwluW1tqmHjmMBQ5TLiEUcTg==}
-    dev: true
 
-  /playwright-core@1.52.0:
+  playwright-core@1.52.0:
     resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
     engines: {node: '>=18'}
     hasBin: true
-    dev: true
 
-  /playwright@1.52.0:
+  playwright@1.52.0:
     resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
     engines: {node: '>=18'}
     hasBin: true
-    dependencies:
-      playwright-core: 1.52.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
 
-  /pngjs@7.0.0:
+  pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
-    dev: true
 
-  /postcss@8.5.8:
+  postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-    dev: true
 
-  /rollup@4.60.1:
+  rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.1
-      '@rollup/rollup-android-arm64': 4.60.1
-      '@rollup/rollup-darwin-arm64': 4.60.1
-      '@rollup/rollup-darwin-x64': 4.60.1
-      '@rollup/rollup-freebsd-arm64': 4.60.1
-      '@rollup/rollup-freebsd-x64': 4.60.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
-      '@rollup/rollup-linux-arm64-gnu': 4.60.1
-      '@rollup/rollup-linux-arm64-musl': 4.60.1
-      '@rollup/rollup-linux-loong64-gnu': 4.60.1
-      '@rollup/rollup-linux-loong64-musl': 4.60.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
-      '@rollup/rollup-linux-ppc64-musl': 4.60.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
-      '@rollup/rollup-linux-riscv64-musl': 4.60.1
-      '@rollup/rollup-linux-s390x-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-musl': 4.60.1
-      '@rollup/rollup-openbsd-x64': 4.60.1
-      '@rollup/rollup-openharmony-arm64': 4.60.1
-      '@rollup/rollup-win32-arm64-msvc': 4.60.1
-      '@rollup/rollup-win32-ia32-msvc': 4.60.1
-      '@rollup/rollup-win32-x64-gnu': 4.60.1
-      '@rollup/rollup-win32-x64-msvc': 4.60.1
-      fsevents: 2.3.3
-    dev: true
 
-  /siginfo@2.0.0:
+  siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-    dev: true
 
-  /source-map-js@1.2.1:
+  source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
-  /stackback@0.0.2:
+  stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-    dev: true
 
-  /std-env@3.10.0:
+  std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-    dev: true
 
-  /strip-literal@3.1.0:
+  strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
-    dependencies:
-      js-tokens: 9.0.1
-    dev: true
 
-  /tinybench@2.9.0:
+  tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-    dev: true
 
-  /tinyexec@0.3.2:
+  tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
-    dev: true
 
-  /tinyglobby@0.2.15:
+  tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-    dev: true
 
-  /tinypool@1.1.1:
+  tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
-    dev: true
 
-  /tinyrainbow@2.0.0:
+  tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
-    dev: true
 
-  /tinyspy@4.0.4:
+  tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
-    dev: true
 
-  /typescript@5.9.3:
+  typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
-  /vite-node@3.2.4:
+  vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.4.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-    dev: true
 
-  /vite@6.4.1:
+  vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -983,18 +638,8 @@ packages:
         optional: true
       yaml:
         optional: true
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rollup: 4.60.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
 
-  /vitest@3.2.4:
+  vitest@3.2.4:
     resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -1021,6 +666,421 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@playwright/test@1.52.0':
+    dependencies:
+      playwright: 1.52.0
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@6.4.1)':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      vite: 6.4.1
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    dependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  js-tokens@9.0.1: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pixel-buffer-diff@1.4.0: {}
+
+  playwright-core@1.52.0: {}
+
+  playwright@1.52.0:
+    dependencies:
+      playwright-core: 1.52.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  typescript@5.9.3: {}
+
+  vite-node@3.2.4:
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@6.4.1:
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rollup: 4.60.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@3.2.4:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -1058,13 +1118,8 @@ packages:
       - terser
       - tsx
       - yaml
-    dev: true
 
-  /why-is-node-running@2.3.0:
-    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
-    engines: {node: '>=8'}
-    hasBin: true
+  why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-    dev: true

--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -2288,3 +2288,89 @@ void main() {
     if (uFar) gl.uniform1f(uFar, this.far);
   }
 }
+
+/* ── AtmosphericPerspectivePass ── */
+
+export interface AtmosphericPerspectiveOptions {
+  /** 天空色 RGB (0..1)。default [0.6, 0.75, 0.9] (晴朗天空蓝) */
+  skyColor?: [number, number, number];
+  /** 大气密度。default 0.02。must be > 0 */
+  density?: number;
+  /** 远处饱和度衰减强度 0..1。default 0.5。must be in [0, 1] */
+  desaturation?: number;
+  /** 起作用的最近距离（近于此距离不混合）。default 5。must be >= 0 */
+  near?: number;
+  /** 完全混合到天空色的距离。default 100。must be > near */
+  far?: number;
+}
+
+export class AtmosphericPerspectivePass implements EffectPass {
+  readonly name = 'atmosphericPerspective';
+  enabled = true;
+  readonly usesDepth = true;
+
+  skyColor: [number, number, number];
+  density: number;
+  desaturation: number;
+  near: number;
+  far: number;
+
+  constructor(opts: AtmosphericPerspectiveOptions = {}) {
+    this.skyColor = opts.skyColor ?? [0.6, 0.75, 0.9];
+    this.density = opts.density ?? 0.02;
+    this.desaturation = opts.desaturation ?? 0.5;
+    this.near = opts.near ?? 5;
+    this.far = opts.far ?? 100;
+
+    if (!Array.isArray(this.skyColor) || this.skyColor.length !== 3)
+      throw new Error('AtmosphericPerspectivePass: skyColor must be a 3-element array');
+    if (!(this.density > 0))
+      throw new Error('AtmosphericPerspectivePass: density must be > 0');
+    if (this.desaturation < 0 || this.desaturation > 1)
+      throw new Error('AtmosphericPerspectivePass: desaturation must be in [0, 1]');
+    if (!(this.near >= 0))
+      throw new Error('AtmosphericPerspectivePass: near must be >= 0');
+    if (!(this.far > this.near))
+      throw new Error('AtmosphericPerspectivePass: far must be > near');
+  }
+
+  getFragmentShader(): string {
+    return `
+precision mediump float;
+varying vec2 v_texCoord;
+uniform sampler2D u_texture;
+uniform sampler2D u_depthTexture;
+uniform vec3 u_skyColor;
+uniform float u_density;
+uniform float u_desaturation;
+uniform float u_near;
+uniform float u_far;
+${LINEARIZE_DEPTH_GLSL}
+void main() {
+  vec4 src = texture2D(u_texture, v_texCoord);
+  float d = texture2D(u_depthTexture, v_texCoord).r;
+  float linearD = linearizeDepth(d, 0.1, 1000.0);
+  float t = clamp((linearD - u_near) / (u_far - u_near), 0.0, 1.0);
+  float factor = 1.0 - exp(-u_density * (linearD - u_near));
+  factor = clamp(factor * t, 0.0, 1.0);
+  float luma = dot(src.rgb, vec3(0.299, 0.587, 0.114));
+  vec3 desaturated = mix(src.rgb, vec3(luma), factor * u_desaturation);
+  vec3 final = mix(desaturated, u_skyColor, factor);
+  gl_FragColor = vec4(final, src.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const loc3 = gl.getUniformLocation(program, 'u_skyColor');
+    if (loc3) gl.uniform3fv(loc3, this.skyColor);
+    const set = (name: string, v: number) => {
+      const loc = gl.getUniformLocation(program, name);
+      if (loc) gl.uniform1f(loc, v);
+    };
+    set('u_density', this.density);
+    set('u_desaturation', this.desaturation);
+    set('u_near', this.near);
+    set('u_far', this.far);
+  }
+}

--- a/test/unit/renderer/atmospheric-perspective-pass.test.ts
+++ b/test/unit/renderer/atmospheric-perspective-pass.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { AtmosphericPerspectivePass } from '../../../src/renderer/post-process';
+
+describe('AtmosphericPerspectivePass', () => {
+  it('默认参数', () => {
+    const p = new AtmosphericPerspectivePass();
+    expect(p.name).toBe('atmosphericPerspective');
+    expect(p.enabled).toBe(true);
+    expect(p.usesDepth).toBe(true);
+    expect(p.skyColor).toEqual([0.6, 0.75, 0.9]);
+    expect(p.density).toBe(0.02);
+    expect(p.desaturation).toBe(0.5);
+    expect(p.near).toBe(5);
+    expect(p.far).toBe(100);
+  });
+
+  it('自定义参数', () => {
+    const p = new AtmosphericPerspectivePass({
+      skyColor: [1, 0.5, 0.5],
+      density: 0.1,
+      desaturation: 0.8,
+      near: 10,
+      far: 200,
+    });
+    expect(p.skyColor).toEqual([1, 0.5, 0.5]);
+    expect(p.density).toBe(0.1);
+    expect(p.desaturation).toBe(0.8);
+    expect(p.near).toBe(10);
+    expect(p.far).toBe(200);
+  });
+
+  it('校验 skyColor 必须是 3 元素数组', () => {
+    expect(() => new AtmosphericPerspectivePass({ skyColor: [1, 0] as any })).toThrow(/skyColor/i);
+    expect(() => new AtmosphericPerspectivePass({ skyColor: [1, 0, 0, 0] as any })).toThrow(/skyColor/i);
+  });
+
+  it('校验 density > 0', () => {
+    expect(() => new AtmosphericPerspectivePass({ density: 0 })).toThrow(/density/i);
+    expect(() => new AtmosphericPerspectivePass({ density: -0.01 })).toThrow(/density/i);
+    expect(() => new AtmosphericPerspectivePass({ density: NaN })).toThrow(/density/i);
+  });
+
+  it('校验 desaturation 在 [0, 1]', () => {
+    expect(() => new AtmosphericPerspectivePass({ desaturation: -0.1 })).toThrow(/desaturation/i);
+    expect(() => new AtmosphericPerspectivePass({ desaturation: 1.01 })).toThrow(/desaturation/i);
+    // 边界值合法
+    expect(() => new AtmosphericPerspectivePass({ desaturation: 0 })).not.toThrow();
+    expect(() => new AtmosphericPerspectivePass({ desaturation: 1 })).not.toThrow();
+  });
+
+  it('校验 near >= 0', () => {
+    expect(() => new AtmosphericPerspectivePass({ near: -1 })).toThrow(/near/i);
+    expect(() => new AtmosphericPerspectivePass({ near: 0 })).not.toThrow();
+  });
+
+  it('校验 far > near', () => {
+    expect(() => new AtmosphericPerspectivePass({ near: 50, far: 50 })).toThrow(/far/i);
+    expect(() => new AtmosphericPerspectivePass({ near: 50, far: 30 })).toThrow(/far/i);
+  });
+
+  it('getFragmentShader 包含必要的 uniform', () => {
+    const p = new AtmosphericPerspectivePass();
+    const src = p.getFragmentShader();
+    expect(src).toContain('u_texture');
+    expect(src).toContain('u_depthTexture');
+    expect(src).toContain('u_skyColor');
+    expect(src).toContain('u_density');
+    expect(src).toContain('u_desaturation');
+    expect(src).toContain('u_near');
+    expect(src).toContain('u_far');
+    expect(src).toContain('linearizeDepth');
+  });
+
+  it('shader 包含 luma 饱和度计算', () => {
+    const p = new AtmosphericPerspectivePass();
+    const src = p.getFragmentShader();
+    // Rec. 709 luma 系数 0.299/0.587/0.114
+    expect(src).toMatch(/0\.299/);
+    expect(src).toMatch(/0\.587/);
+    expect(src).toMatch(/0\.114/);
+  });
+
+  it('shader 使用 mix 做颜色混合', () => {
+    const p = new AtmosphericPerspectivePass();
+    const src = p.getFragmentShader();
+    expect(src).toContain('mix(');
+  });
+
+  it('修改运行时参数', () => {
+    const p = new AtmosphericPerspectivePass();
+    p.skyColor = [0.5, 0.5, 0.5];
+    p.density = 0.05;
+    p.desaturation = 0.3;
+    expect(p.skyColor).toEqual([0.5, 0.5, 0.5]);
+    expect(p.density).toBe(0.05);
+    expect(p.desaturation).toBe(0.3);
+  });
+
+  it('enabled 默认 true 可关闭', () => {
+    const p = new AtmosphericPerspectivePass();
+    expect(p.enabled).toBe(true);
+    p.enabled = false;
+    expect(p.enabled).toBe(false);
+  });
+
+  it('alpha 通道在 shader 中保持原值', () => {
+    const p = new AtmosphericPerspectivePass();
+    const src = p.getFragmentShader();
+    // 应有 src.a 或 source alpha 的引用
+    expect(src).toMatch(/\.a/);
+  });
+});


### PR DESCRIPTION
## 概述

实现 `AtmosphericPerspectivePass`（Phase 52 KR3），为后处理管线新增大气透视效果。

## 功能说明

利用 Phase 51 DepthPass 输出的 `u_depthTexture`，按深度将场景颜色向天空色衰减：

1. **饱和度衰减**：先用 Rec. 709 luma 系数对远处物体降低饱和度（远处变灰）
2. **天空色混合**：再将去饱和的颜色混合到天空色（远处变蓝）
3. **指数衰减曲线**：使用 `1 - exp(-density * dist)` 使过渡更自然

相比 `DepthFogPass` 的单一雾色全场混合，AtmosphericPerspectivePass 同时处理饱和度，更接近真实大气散射视觉。

## 验收结果

- ✅ 13 个新测试全绿
- ✅ 全量 2127 个测试零回归（157 个测试文件）
- ✅ `usesDepth = true`，可被 `PostProcessor.addPass()` 正确串联
- ✅ 与 `DepthFogPass`、`SSAOPass`、`DOFPass` 链式兼容

close #380