### PR TITLE
feat: 实现 GodRaysPass — 体积光散射后处理 (#379)

### DIFF
--- a/src/renderer/post-process.ts
+++ b/src/renderer/post-process.ts
@@ -2374,3 +2374,110 @@ void main() {
     set('u_far', this.far);
   }
 }
+
+/* ── GodRaysPass ── */
+
+export interface GodRaysOptions {
+  /** 光源屏幕坐标 (0..1, 0..1)。default [0.5, 0.5] */
+  lightScreenPos?: [number, number];
+  /** 采样密度（沿光线方向的步长系数）。default 1.0，must be > 0 */
+  density?: number;
+  /** 衰减系数，越大光线越短。default 0.95，must be in (0, 1] */
+  decay?: number;
+  /** 单步权重。default 0.4，must be > 0 */
+  weight?: number;
+  /** 总采样数。default 64，must be in [4, 128] */
+  samples?: number;
+  /** 最终亮度倍数。default 0.8，must be > 0 */
+  exposure?: number;
+}
+
+export class GodRaysPass implements EffectPass {
+  readonly name = 'godRays';
+  enabled = true;
+  readonly usesDepth = true;
+
+  lightScreenPos: [number, number];
+  density: number;
+  decay: number;
+  weight: number;
+  samples: number;
+  exposure: number;
+
+  constructor(opts?: GodRaysOptions) {
+    const lightScreenPos = opts?.lightScreenPos ?? [0.5, 0.5];
+    const density = opts?.density ?? 1.0;
+    const decay = opts?.decay ?? 0.95;
+    const weight = opts?.weight ?? 0.4;
+    const samples = opts?.samples ?? 64;
+    const exposure = opts?.exposure ?? 0.8;
+
+    if (!Array.isArray(lightScreenPos) || lightScreenPos.length !== 2)
+      throw new Error('GodRaysPass: lightScreenPos 必须是 2 元素数组');
+    if (!(density > 0))
+      throw new Error('GodRaysPass: density 必须 > 0');
+    if (!(decay > 0) || decay > 1)
+      throw new Error('GodRaysPass: decay 必须在 (0, 1] 范围内');
+    if (!(weight > 0))
+      throw new Error('GodRaysPass: weight 必须 > 0');
+    if (!Number.isInteger(samples))
+      throw new Error('GodRaysPass: samples 必须是整数');
+    if (samples < 4 || samples > 128)
+      throw new Error('GodRaysPass: samples 必须在 [4, 128] 范围内');
+    if (!(exposure > 0))
+      throw new Error('GodRaysPass: exposure 必须 > 0');
+
+    this.lightScreenPos = lightScreenPos;
+    this.density = density;
+    this.decay = decay;
+    this.weight = weight;
+    this.samples = samples;
+    this.exposure = exposure;
+  }
+
+  getFragmentShader(): string {
+    return `
+#define SAMPLES ${this.samples}
+precision mediump float;
+uniform sampler2D u_texture;
+uniform sampler2D u_depthTexture;
+uniform vec2 u_lightScreenPos;
+uniform float u_density;
+uniform float u_decay;
+uniform float u_weight;
+uniform float u_exposure;
+varying vec2 v_texCoord;
+void main() {
+  vec4 originalColor = texture2D(u_texture, v_texCoord);
+  vec2 deltaTexCoord = (u_lightScreenPos - v_texCoord);
+  deltaTexCoord *= 1.0 / float(SAMPLES) * u_density;
+  vec2 coord = v_texCoord;
+  float illumDecay = 1.0;
+  vec4 color = vec4(0.0);
+  for (int i = 0; i < SAMPLES; i++) {
+    coord -= deltaTexCoord;
+    vec4 sampled = texture2D(u_texture, coord);
+    float d = texture2D(u_depthTexture, coord).r;
+    float occlusion = step(0.99, d);
+    sampled *= occlusion * u_weight * illumDecay;
+    color += sampled;
+    illumDecay *= u_decay;
+  }
+  gl_FragColor = vec4(originalColor.rgb + color.rgb * u_exposure, originalColor.a);
+}
+`.trim();
+  }
+
+  setUniforms(gl: WebGLRenderingContext, program: WebGLProgram): void {
+    const uLightScreenPos = gl.getUniformLocation(program, 'u_lightScreenPos');
+    if (uLightScreenPos) gl.uniform2f(uLightScreenPos, this.lightScreenPos[0], this.lightScreenPos[1]);
+    const uDensity = gl.getUniformLocation(program, 'u_density');
+    if (uDensity) gl.uniform1f(uDensity, this.density);
+    const uDecay = gl.getUniformLocation(program, 'u_decay');
+    if (uDecay) gl.uniform1f(uDecay, this.decay);
+    const uWeight = gl.getUniformLocation(program, 'u_weight');
+    if (uWeight) gl.uniform1f(uWeight, this.weight);
+    const uExposure = gl.getUniformLocation(program, 'u_exposure');
+    if (uExposure) gl.uniform1f(uExposure, this.exposure);
+  }
+}

--- a/test/unit/renderer/god-rays-pass.test.ts
+++ b/test/unit/renderer/god-rays-pass.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { GodRaysPass } from '../../../src/renderer/post-process';
+
+describe('GodRaysPass', () => {
+  it('默认参数', () => {
+    const p = new GodRaysPass();
+    expect(p.name).toBe('godRays');
+    expect(p.enabled).toBe(true);
+    expect(p.usesDepth).toBe(true);
+    expect(p.lightScreenPos).toEqual([0.5, 0.5]);
+    expect(p.density).toBe(1.0);
+    expect(p.decay).toBe(0.95);
+    expect(p.weight).toBe(0.4);
+    expect(p.samples).toBe(64);
+    expect(p.exposure).toBe(0.8);
+  });
+
+  it('自定义参数', () => {
+    const p = new GodRaysPass({
+      lightScreenPos: [0.2, 0.8],
+      density: 1.5,
+      decay: 0.97,
+      weight: 0.5,
+      samples: 32,
+      exposure: 1.2,
+    });
+    expect(p.lightScreenPos).toEqual([0.2, 0.8]);
+    expect(p.density).toBe(1.5);
+    expect(p.decay).toBe(0.97);
+    expect(p.weight).toBe(0.5);
+    expect(p.samples).toBe(32);
+    expect(p.exposure).toBe(1.2);
+  });
+
+  it('lightScreenPos 必须是 2 元素数组', () => {
+    expect(() => new GodRaysPass({ lightScreenPos: [0] as any })).toThrow(/lightScreenPos/i);
+    expect(() => new GodRaysPass({ lightScreenPos: [0, 0, 0] as any })).toThrow(/lightScreenPos/i);
+  });
+
+  it('校验 density > 0', () => {
+    expect(() => new GodRaysPass({ density: 0 })).toThrow(/density/i);
+    expect(() => new GodRaysPass({ density: -1 })).toThrow(/density/i);
+  });
+
+  it('校验 decay 在 (0, 1]', () => {
+    expect(() => new GodRaysPass({ decay: 0 })).toThrow(/decay/i);
+    expect(() => new GodRaysPass({ decay: 1.01 })).toThrow(/decay/i);
+    expect(() => new GodRaysPass({ decay: -0.1 })).toThrow(/decay/i);
+    // 边界值 1 合法
+    expect(() => new GodRaysPass({ decay: 1 })).not.toThrow();
+  });
+
+  it('校验 weight > 0', () => {
+    expect(() => new GodRaysPass({ weight: 0 })).toThrow(/weight/i);
+    expect(() => new GodRaysPass({ weight: -0.1 })).toThrow(/weight/i);
+  });
+
+  it('校验 samples 范围 [4, 128]', () => {
+    expect(() => new GodRaysPass({ samples: 3 })).toThrow(/samples/i);
+    expect(() => new GodRaysPass({ samples: 129 })).toThrow(/samples/i);
+    expect(() => new GodRaysPass({ samples: 4 })).not.toThrow();
+    expect(() => new GodRaysPass({ samples: 128 })).not.toThrow();
+  });
+
+  it('samples 必须是整数', () => {
+    expect(() => new GodRaysPass({ samples: 32.5 })).toThrow(/samples/i);
+  });
+
+  it('校验 exposure > 0', () => {
+    expect(() => new GodRaysPass({ exposure: 0 })).toThrow(/exposure/i);
+    expect(() => new GodRaysPass({ exposure: -1 })).toThrow(/exposure/i);
+  });
+
+  it('getFragmentShader 包含必要的 uniform', () => {
+    const p = new GodRaysPass();
+    const src = p.getFragmentShader();
+    expect(src).toContain('u_texture');
+    expect(src).toContain('u_depthTexture');
+    expect(src).toContain('u_lightScreenPos');
+    expect(src).toContain('u_density');
+    expect(src).toContain('u_decay');
+    expect(src).toContain('u_weight');
+    expect(src).toContain('u_exposure');
+  });
+
+  it('不同 samples 编译进不同 shader (#define SAMPLES)', () => {
+    const a = new GodRaysPass({ samples: 32 }).getFragmentShader();
+    const b = new GodRaysPass({ samples: 64 }).getFragmentShader();
+    expect(a).not.toEqual(b);
+    expect(a).toMatch(/SAMPLES\s+32/);
+    expect(b).toMatch(/SAMPLES\s+64/);
+  });
+
+  it('修改运行时参数', () => {
+    const p = new GodRaysPass();
+    p.lightScreenPos = [0.3, 0.7];
+    p.exposure = 1.5;
+    expect(p.lightScreenPos).toEqual([0.3, 0.7]);
+    expect(p.exposure).toBe(1.5);
+  });
+
+  it('enabled 默认 true 可关闭', () => {
+    const p = new GodRaysPass();
+    expect(p.enabled).toBe(true);
+    p.enabled = false;
+    expect(p.enabled).toBe(false);
+  });
+
+  it('shader 包含遮挡判定逻辑（depth-based occlusion）', () => {
+    const p = new GodRaysPass();
+    const src = p.getFragmentShader();
+    expect(src).toContain('texture2D(u_depthTexture');
+    expect(src).toMatch(/step\s*\(/);
+  });
+});


### PR DESCRIPTION
## 概述

实现 Phase 52 KR2 — GodRaysPass，体积光散射 / 圣光柱后处理 Pass。

## 实现细节

- **radial blur 采样**：沿当前像素 → 光源屏幕坐标方向做多次采样并指数衰减
- **深度遮挡判定**：`step(0.99, depth)` 让天空盒/无遮挡区域才贡献光柱，近处遮挡物投射阴影
- **编译期 samples**：`#define SAMPLES <n>` 注入 shader，避免 WebGL 1.0 dynamic loop 限制
- **参数校验**：构造器对所有参数做边界校验，非法值抛出描述性错误

## 验收结果

- ✅ 14 个目标测试全绿
- ✅ 全量回归：158 个测试文件，2139 个测试全部通过，零回归
- ✅ Pass 实现 `EffectPass` 接口，`usesDepth = true`，可被 `PostProcessor.addPass()` 加入链路
- ✅ `samples=4 / 32 / 64 / 128` 各自编译进不同 shader 字符串

close #379