### PR TITLE
feat: 实现 CascadeSplitter — PSSM Frustum 划分纯函数 (#384)

### DIFF
--- a/src/renderer/cascade-splitter.ts
+++ b/src/renderer/cascade-splitter.ts
@@ -28,8 +28,27 @@ export interface CascadeSplit {
   far: number;
 }
 
-export function splitFrustum(_opts: CascadeSplitOptions): CascadeSplit[] {
-  throw new Error('CascadeSplitter: Not implemented (stub)');
-}
+export function splitFrustum(opts: CascadeSplitOptions): CascadeSplit[] {
+  const { near, far, numCascades } = opts;
+  const lambda = opts.lambda ?? 0.5;
 
-export const __STUB__ = true;
+  if (numCascades < 1) throw new Error('CascadeSplitter: numCascades 必须 >= 1');
+  if (near >= far) throw new Error('CascadeSplitter: near 必须小于 far');
+
+  const splits: CascadeSplit[] = [];
+  let prevBound = near;
+
+  for (let i = 1; i <= numCascades; i++) {
+    const t = i / numCascades;
+    const uniformSplit = near + (far - near) * t;
+    // near=0 时对数项无意义，退化为 uniform
+    const logSplit = near > 0 ? near * Math.pow(far / near, t) : uniformSplit;
+    const bound = i < numCascades
+      ? lambda * logSplit + (1 - lambda) * uniformSplit
+      : far; // 最后一级精确等于 far，消除浮点误差
+    splits.push({ near: prevBound, far: bound });
+    prevBound = bound;
+  }
+
+  return splits;
+}


### PR DESCRIPTION
## 概述

实现 `src/renderer/cascade-splitter.ts` 的 `splitFrustum()` 函数，完成 Phase 53 KR1。

## 核心算法

PSSM (Practical Split Scheme by Wolfgang Engel)：
- `uniform_split = near + (far - near) * t`
- `log_split = near * (far/near)^t`
- `split = lambda * log_split + (1 - lambda) * uniform_split`

当 `near = 0` 时对数项退化为 uniform，避免除零。最后一级 `far` 精确等于输入值，消除浮点误差。

## 测试

- 目标测试：11/11 通过
- 全量测试：2163 passed，0 failed

close #384