### PR TITLE
feat: 实现 PhongMaterial CSM 集成 — Shader 选择级联 + Renderer 自动绑定 (#386)

### DIFF
--- a/src/core/scene.ts
+++ b/src/core/scene.ts
@@ -9,6 +9,7 @@ import { AmbientLight, DirectionalLight } from './light';
 import { PointLight } from './point-light';
 import { SpotLight } from './spot-light';
 import { CubeTexture } from '../renderer/cube-texture';
+import type { CascadedShadowMap } from '../renderer/cascaded-shadow-map';
 
 export interface FogOptions {
   color: Vec3;
@@ -31,6 +32,7 @@ export interface CollectedLights {
 export class Scene extends Node3D {
   background: Vec3 | CubeTexture;
   fog: FogOptions | null;
+  cascadedShadowMap: CascadedShadowMap | null = null;
 
   constructor(opts?: SceneOptions) {
     super('scene');

--- a/src/renderer/phong-material.ts
+++ b/src/renderer/phong-material.ts
@@ -47,6 +47,7 @@ function buildFragmentShader(hasEnvMap: boolean): string {
     finalColor = mix(finalColor, envColor, u_reflectivity);` : '';
 
   return `
+  #define NUM_CASCADES 4
   precision mediump float;
   // 向后兼容（单光源，保留声明供旧测试检查）
   uniform vec3 u_lightDir;
@@ -89,12 +90,51 @@ function buildFragmentShader(hasEnvMap: boolean): string {
   // 高光贴图
   uniform sampler2D u_specularMap;
   uniform float u_hasSpecularMap;
+  // CSM 级联阴影贴图
+  uniform sampler2D u_csmShadowMap[NUM_CASCADES];
+  uniform mat4 u_csmLightSpaceMatrix[NUM_CASCADES];
+  uniform float u_csmSplits[NUM_CASCADES];
+  uniform bool u_csmEnabled;
   ${envUniforms}
   varying vec3 v_normal;
   varying vec3 v_worldPos;
   varying vec2 v_uv;
   varying vec3 v_tangent;
   varying vec3 v_bitangent;
+
+  // 根据 viewDepth 选择级联并计算阴影因子（1.0=无阴影，0.0=全阴影）
+  // WebGL 1.0 不支持动态数组索引，使用展开式 if-else
+  float computeCSMShadow(vec3 worldPos, float viewDepth) {
+    if (!u_csmEnabled) return 1.0;
+    int cascadeIdx = 3;
+    if (viewDepth <= u_csmSplits[0]) cascadeIdx = 0;
+    else if (viewDepth <= u_csmSplits[1]) cascadeIdx = 1;
+    else if (viewDepth <= u_csmSplits[2]) cascadeIdx = 2;
+    vec4 lsPos;
+    vec3 proj;
+    float depth;
+    if (cascadeIdx == 0) {
+      lsPos = u_csmLightSpaceMatrix[0] * vec4(worldPos, 1.0);
+      proj = lsPos.xyz / lsPos.w * 0.5 + 0.5;
+      depth = texture2D(u_csmShadowMap[0], proj.xy).r;
+      return proj.z - 0.005 > depth ? 0.0 : 1.0;
+    } else if (cascadeIdx == 1) {
+      lsPos = u_csmLightSpaceMatrix[1] * vec4(worldPos, 1.0);
+      proj = lsPos.xyz / lsPos.w * 0.5 + 0.5;
+      depth = texture2D(u_csmShadowMap[1], proj.xy).r;
+      return proj.z - 0.005 > depth ? 0.0 : 1.0;
+    } else if (cascadeIdx == 2) {
+      lsPos = u_csmLightSpaceMatrix[2] * vec4(worldPos, 1.0);
+      proj = lsPos.xyz / lsPos.w * 0.5 + 0.5;
+      depth = texture2D(u_csmShadowMap[2], proj.xy).r;
+      return proj.z - 0.005 > depth ? 0.0 : 1.0;
+    } else {
+      lsPos = u_csmLightSpaceMatrix[3] * vec4(worldPos, 1.0);
+      proj = lsPos.xyz / lsPos.w * 0.5 + 0.5;
+      depth = texture2D(u_csmShadowMap[3], proj.xy).r;
+      return proj.z - 0.005 > depth ? 0.0 : 1.0;
+    }
+  }
 
   void main() {
     vec3 N = normalize(v_normal);
@@ -115,7 +155,8 @@ function buildFragmentShader(hasEnvMap: boolean): string {
       ? texture2D(u_specularMap, v_uv).rgb * u_specular
       : u_specular;
 
-    vec3 color = u_ambientColor * baseDiffuse;
+    vec3 ambientColor = u_ambientColor * baseDiffuse;
+    vec3 directColor = vec3(0.0);
 
     // 方向光循环
     for (int i = 0; i < 4; i++) {
@@ -124,8 +165,8 @@ function buildFragmentShader(hasEnvMap: boolean): string {
       vec3 H = normalize(L + V);
       float diff = max(dot(N, L), 0.0);
       float spec = pow(max(dot(N, H), 0.0), u_shininess);
-      color += u_dirLightColors[i] * baseDiffuse * diff;
-      color += u_dirLightColors[i] * baseSpecular * spec;
+      directColor += u_dirLightColors[i] * baseDiffuse * diff;
+      directColor += u_dirLightColors[i] * baseSpecular * spec;
     }
 
     // 点光源循环
@@ -145,8 +186,8 @@ function buildFragmentShader(hasEnvMap: boolean): string {
       } else {
         attenuation = pow(max(1.0 - d / dist, 0.0), decay);
       }
-      color += u_pointLightColors[i] * baseDiffuse * diff * attenuation;
-      color += u_pointLightColors[i] * baseSpecular * spec * attenuation;
+      directColor += u_pointLightColors[i] * baseDiffuse * diff * attenuation;
+      directColor += u_pointLightColors[i] * baseSpecular * spec * attenuation;
     }
 
     // 聚光灯循环
@@ -173,9 +214,13 @@ function buildFragmentShader(hasEnvMap: boolean): string {
       float spotEffect = dot(normalize(v_worldPos - u_spotLightPositions[i]), u_spotLightDirs[i]);
       float spotAttenuation = smoothstep(cosOuter, cosInner, spotEffect);
       float attenuation = distAttenuation * spotAttenuation;
-      color += u_spotLightColors[i] * baseDiffuse  * diff * attenuation;
-      color += u_spotLightColors[i] * baseSpecular * spec * attenuation;
+      directColor += u_spotLightColors[i] * baseDiffuse  * diff * attenuation;
+      directColor += u_spotLightColors[i] * baseSpecular * spec * attenuation;
     }
+
+    float viewDepth = length(v_worldPos - u_cameraPos);
+    float shadowFactor = computeCSMShadow(v_worldPos, viewDepth);
+    vec3 color = ambientColor + directColor * shadowFactor;
 
     vec3 emissiveColor = u_hasEmissiveMap > 0.5
       ? u_emissive * texture2D(u_emissiveMap, v_uv).rgb
@@ -237,6 +282,11 @@ export class PhongMaterial extends Material {
     this.envMap           = opts.envMap           ?? null;
     this.envMapIntensity  = opts.envMapIntensity  ?? 1.0;
     this.reflectivity     = opts.reflectivity     ?? 0;
+  }
+
+  /** 返回 fragment shader 源码（供测试和调试使用） */
+  getFragmentShader(): string {
+    return this.fragmentShader;
   }
 
   /** 克隆 Phong 材质（Vec3 属性深拷贝，Texture/CubeTexture 引用共享） */

--- a/src/renderer/webgl-renderer.ts
+++ b/src/renderer/webgl-renderer.ts
@@ -9,7 +9,8 @@ import { Frustum } from '../math/frustum';
 import { buildRenderQueue, type QueueItem } from './render-queue';
 import { Node3D } from '../core/node3d';
 import { Scene } from '../core/scene';
-import { Camera } from '../core/camera';
+import { Camera, PerspectiveCamera } from '../core/camera';
+import { CascadedShadowMap } from './cascaded-shadow-map';
 import { AmbientLight, DirectionalLight } from '../core/light';
 import { PointLight } from '../core/point-light';
 import { SpotLight } from '../core/spot-light';
@@ -98,6 +99,11 @@ interface PhongLocations {
   uSpotLightDecays: Array<WebGLUniformLocation | null>;
   uSpotLightCosAngles: Array<WebGLUniformLocation | null>;
   uSpotLightPenumbras: Array<WebGLUniformLocation | null>;
+  // CSM 级联阴影
+  uCsmEnabled: WebGLUniformLocation | null;
+  uCsmShadowMaps: Array<WebGLUniformLocation | null>;
+  uCsmLightSpaceMatrices: Array<WebGLUniformLocation | null>;
+  uCsmSplits: WebGLUniformLocation | null;
 }
 
 interface FogLocations {
@@ -354,6 +360,11 @@ export class WebGLRenderer {
   private spriteQuad: SpriteQuad | null = null;
   private skyboxRenderer: SkyboxRenderer | null = null;
   private particleCache: WeakMap<ParticleEmitter, ParticleRenderer> = new WeakMap();
+  private depthProgram: {
+    program: WebGLProgram;
+    aPosition: number;
+    uLightMVP: WebGLUniformLocation | null;
+  } | null = null;
 
   constructor(canvas: HTMLCanvasElement) {
     const gl = canvas.getContext('webgl', {
@@ -460,6 +471,19 @@ export class WebGLRenderer {
       spotLights,
     };
 
+    // CSM 处理：shadow pass + 主 pass 绑定
+    const csm = scene.cascadedShadowMap;
+    if (csm !== null) {
+      if (csm.numCascades !== 4) {
+        throw new Error(`WebGLRenderer: CSM numCascades 必须为 4，收到 ${csm.numCascades}`);
+      }
+      const lightDir = dirLights.length > 0 ? dirLights[0].dir : vec3(0, -1, 0);
+      csm.update(camera as PerspectiveCamera, lightDir);
+      this._renderCascadeShadowPass(scene, csm);
+      // 恢复主视口和 framebuffer
+      gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
+    }
+
     const viewProj = camera.viewProjectionMatrix;
 
     // 建立视锥体用于剔除
@@ -502,11 +526,11 @@ export class WebGLRenderer {
 
     // 先绘制不透明网格
     for (const item of queue.opaque) {
-      this._drawMesh(item.mesh, viewProj, lightCtx, scene.fog);
+      this._drawMesh(item.mesh, viewProj, lightCtx, scene.fog, csm);
     }
     // 再绘制透明网格
     for (const item of queue.transparent) {
-      this._drawMesh(item.mesh, viewProj, lightCtx, scene.fog);
+      this._drawMesh(item.mesh, viewProj, lightCtx, scene.fog, csm);
     }
 
     // Line 和 Sprite 在所有 Mesh 之后渲染（叠加行为）
@@ -536,6 +560,71 @@ export class WebGLRenderer {
   dispose(): void {
     // WeakMaps will be GC'd along with the Geometry/Material objects.
     // Nothing else to clean up explicitly without iterating all cached entries.
+  }
+
+  private _getDepthProgram(): { program: WebGLProgram; aPosition: number; uLightMVP: WebGLUniformLocation | null } {
+    if (this.depthProgram) return this.depthProgram;
+    const gl = this.gl;
+    const vs = compileShader(gl, gl.VERTEX_SHADER, `
+      attribute vec3 a_position;
+      uniform mat4 u_lightMVP;
+      void main() {
+        gl_Position = u_lightMVP * vec4(a_position, 1.0);
+      }
+    `);
+    const fs = compileShader(gl, gl.FRAGMENT_SHADER, `
+      precision mediump float;
+      void main() {
+        gl_FragColor = vec4(gl_FragCoord.z, gl_FragCoord.z, gl_FragCoord.z, 1.0);
+      }
+    `);
+    const program = createProgram(gl, vs, fs);
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+    this.depthProgram = {
+      program,
+      aPosition: gl.getAttribLocation(program, 'a_position'),
+      uLightMVP:  gl.getUniformLocation(program, 'u_lightMVP'),
+    };
+    return this.depthProgram;
+  }
+
+  /** 为每个 cascade 渲染深度 pass */
+  private _renderCascadeShadowPass(scene: Scene, csm: CascadedShadowMap): void {
+    const gl = this.gl;
+    const prog = this._getDepthProgram();
+    gl.useProgram(prog.program);
+
+    for (let i = 0; i < csm.numCascades; i++) {
+      const rt = csm.cascades[i].renderTarget;
+      if (!rt.framebuffer) rt.initialize(gl);
+
+      gl.bindFramebuffer(gl.FRAMEBUFFER, rt.framebuffer);
+      gl.viewport(0, 0, rt.width, rt.height);
+      gl.clear(gl.DEPTH_BUFFER_BIT | gl.COLOR_BUFFER_BIT);
+
+      const lightMatrix = csm.lightSpaceMatrices[i];
+
+      scene.traverse((node) => {
+        if (!(node instanceof Mesh) || node instanceof SkinnedMesh) return;
+        const uploaded = this._getGeometry(node.geometry);
+        const lightMVP = multiply(lightMatrix, node.worldMatrix);
+        if (prog.uLightMVP) gl.uniformMatrix4fv(prog.uLightMVP, false, lightMVP);
+        if (prog.aPosition >= 0) {
+          gl.bindBuffer(gl.ARRAY_BUFFER, uploaded.positionBuffer);
+          gl.enableVertexAttribArray(prog.aPosition);
+          gl.vertexAttribPointer(prog.aPosition, 3, gl.FLOAT, false, 0, 0);
+        }
+        if (uploaded.indexBuffer) {
+          gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, uploaded.indexBuffer);
+          gl.drawElements(gl.TRIANGLES, uploaded.indexCount, gl.UNSIGNED_SHORT, 0);
+        } else {
+          gl.drawArrays(gl.TRIANGLES, 0, uploaded.vertexCount);
+        }
+      });
+    }
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
   }
 
   private _applyTextureSamplingParams(texture: Texture): void {
@@ -709,6 +798,12 @@ export class WebGLRenderer {
         spCosAngles.push(gl.getUniformLocation(program, `u_spotLightCosAngles[${i}]`));
         spPenumbras.push(gl.getUniformLocation(program, `u_spotLightPenumbras[${i}]`));
       }
+      const csmShadowMaps: Array<WebGLUniformLocation | null> = [];
+      const csmMatrices: Array<WebGLUniformLocation | null> = [];
+      for (let i = 0; i < 4; i++) {
+        csmShadowMaps.push(gl.getUniformLocation(program, `u_csmShadowMap[${i}]`));
+        csmMatrices.push(gl.getUniformLocation(program, `u_csmLightSpaceMatrix[${i}]`));
+      }
       compiled.phong = {
         aNormal:            gl.getAttribLocation(program, 'a_normal'),
         uModelMatrix:       gl.getUniformLocation(program, 'u_modelMatrix'),
@@ -748,6 +843,10 @@ export class WebGLRenderer {
         uSpotLightDecays:   spDecays,
         uSpotLightCosAngles: spCosAngles,
         uSpotLightPenumbras: spPenumbras,
+        uCsmEnabled:           gl.getUniformLocation(program, 'u_csmEnabled'),
+        uCsmShadowMaps:        csmShadowMaps,
+        uCsmLightSpaceMatrices: csmMatrices,
+        uCsmSplits:            gl.getUniformLocation(program, 'u_csmSplits[0]'),
       };
     }
 
@@ -881,7 +980,13 @@ export class WebGLRenderer {
     return this.skinningProgram;
   }
 
-  private _drawMesh(mesh: Mesh, viewProj: Mat4, lightCtx: LightContext, fog: FogOptions | null = null): void {
+  private _drawMesh(
+    mesh: Mesh,
+    viewProj: Mat4,
+    lightCtx: LightContext,
+    fog: FogOptions | null = null,
+    csm: CascadedShadowMap | null = null,
+  ): void {
     // SkinnedMesh 走专用蒙皮路径
     if (mesh instanceof SkinnedMesh) {
       this._drawSkinnedMesh(mesh, viewProj);
@@ -1155,6 +1260,30 @@ export class WebGLRenderer {
         if (phong.uEnvMap)          gl.uniform1i(phong.uEnvMap, 4);
         if (phong.uEnvMapIntensity) gl.uniform1f(phong.uEnvMapIntensity, mat.envMapIntensity);
         if (phong.uReflectivity)    gl.uniform1f(phong.uReflectivity, mat.reflectivity);
+      }
+
+      // CSM 绑定（纹理单元 5–8）
+      if (csm !== null) {
+        for (let i = 0; i < 4; i++) {
+          const rt = csm.cascades[i].renderTarget;
+          if (rt.colorTexture) {
+            gl.activeTexture(gl.TEXTURE0 + 5 + i);
+            gl.bindTexture(gl.TEXTURE_2D, rt.colorTexture);
+            const samplerLoc = phong.uCsmShadowMaps[i];
+            if (samplerLoc) gl.uniform1i(samplerLoc, 5 + i);
+          }
+          const matrixLoc = phong.uCsmLightSpaceMatrices[i];
+          if (matrixLoc) gl.uniformMatrix4fv(matrixLoc, false, csm.lightSpaceMatrices[i]);
+        }
+        if (phong.uCsmSplits && csm.splits.length >= 4) {
+          gl.uniform1fv(phong.uCsmSplits, new Float32Array([
+            csm.splits[0].far, csm.splits[1].far,
+            csm.splits[2].far, csm.splits[3].far,
+          ]));
+        }
+        if (phong.uCsmEnabled) gl.uniform1i(phong.uCsmEnabled, 1);
+      } else {
+        if (phong.uCsmEnabled) gl.uniform1i(phong.uCsmEnabled, 0);
       }
     }
 

--- a/test/unit/renderer/csm-integration.test.ts
+++ b/test/unit/renderer/csm-integration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * CSM PhongMaterial 集成测试
+ * 验证 Scene.cascadedShadowMap、PhongMaterial CSM shader、WebGLRenderer CSM 渲染路径。
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { CascadedShadowMap } from '../../../src/renderer/cascaded-shadow-map';
+import { Scene } from '../../../src/core/scene';
+import { PerspectiveCamera } from '../../../src/core/camera';
+import { PhongMaterial } from '../../../src/renderer/phong-material';
+import { Mesh } from '../../../src/renderer/mesh';
+import { Geometry } from '../../../src/renderer/geometry';
+import { WebGLRenderer } from '../../../src/renderer/webgl-renderer';
+import * as mockGlMod from '../../helpers/mock-gl';
+
+function makeCamera(): PerspectiveCamera {
+  return new PerspectiveCamera({ fov: Math.PI / 4, aspect: 1, near: 0.1, far: 100 });
+}
+
+function makeTriGeo(): Geometry {
+  const geo = new Geometry({ positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]) });
+  geo.normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+  return geo;
+}
+
+// ── Scene.cascadedShadowMap ────────────────────────────────────────
+
+describe('Scene.cascadedShadowMap', () => {
+  it('defaults to null', () => {
+    const scene = new Scene();
+    expect(scene.cascadedShadowMap).toBeNull();
+  });
+
+  it('accepts CascadedShadowMap assignment', () => {
+    const scene = new Scene();
+    const csm = new CascadedShadowMap({ numCascades: 4 });
+    scene.cascadedShadowMap = csm;
+    expect(scene.cascadedShadowMap).toBe(csm);
+  });
+});
+
+// ── PhongMaterial CSM Shader ──────────────────────────────────────
+
+describe('PhongMaterial CSM Shader', () => {
+  it('fragment shader contains #define NUM_CASCADES 4', () => {
+    const mat = new PhongMaterial();
+    const fragSrc = mat.getFragmentShader();
+    expect(fragSrc).toMatch(/#define\s+NUM_CASCADES\s+4/);
+  });
+
+  it('fragment shader contains CSM uniform declarations', () => {
+    const mat = new PhongMaterial();
+    const fragSrc = mat.getFragmentShader();
+    expect(fragSrc).toContain('u_csmShadowMap');
+    expect(fragSrc).toContain('u_csmLightSpaceMatrix');
+    expect(fragSrc).toContain('u_csmSplits');
+    expect(fragSrc).toContain('u_csmEnabled');
+  });
+
+  it('fragment shader uses unrolled if-else for cascade selection (WebGL 1.0 要求)', () => {
+    const mat = new PhongMaterial();
+    const fragSrc = mat.getFragmentShader();
+    expect(fragSrc).toMatch(/if\s*\(\s*viewDepth\s*<=\s*u_csmSplits\[0\]/);
+    expect(fragSrc).toContain('u_csmSplits[1]');
+    expect(fragSrc).toContain('u_csmSplits[2]');
+  });
+
+  it('fragment shader calls computeCSMShadow in main()', () => {
+    const mat = new PhongMaterial();
+    const fragSrc = mat.getFragmentShader();
+    expect(fragSrc).toContain('computeCSMShadow(');
+    expect(fragSrc).toContain('shadowFactor');
+  });
+
+  it('fragment shader uses constant indices for sampler array access (WebGL 1.0 限制)', () => {
+    const mat = new PhongMaterial();
+    const fragSrc = mat.getFragmentShader();
+    // 展开式 if-else 中使用常量索引 0-3
+    expect(fragSrc).toContain('u_csmShadowMap[0]');
+    expect(fragSrc).toContain('u_csmShadowMap[1]');
+    expect(fragSrc).toContain('u_csmShadowMap[2]');
+    expect(fragSrc).toContain('u_csmShadowMap[3]');
+  });
+});
+
+// ── WebGLRenderer CSM Integration ─────────────────────────────────
+
+describe('WebGLRenderer CSM Integration', () => {
+  it('渲染时 scene.cascadedShadowMap=null 不绑定额外 FBO（向后兼容）', () => {
+    const { canvas, gl } = mockGlMod.createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeTriGeo(), new PhongMaterial()));
+    const bindFboBefore = gl._calls['bindFramebuffer'] ?? 0;
+    renderer.render(scene, makeCamera());
+    // 无 CSM 时不应有额外的 FBO 绑定（shadow pass）
+    const bindFboAfter = gl._calls['bindFramebuffer'] ?? 0;
+    expect(bindFboAfter).toBe(bindFboBefore);
+  });
+
+  it('scene.cascadedShadowMap 非 null 时调用 csm.update(camera, lightDir)', () => {
+    const { canvas } = mockGlMod.createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeTriGeo(), new PhongMaterial()));
+
+    const csm = new CascadedShadowMap({ numCascades: 4 });
+    const updateSpy = vi.spyOn(csm, 'update');
+    scene.cascadedShadowMap = csm;
+
+    renderer.render(scene, makeCamera());
+    expect(updateSpy).toHaveBeenCalledOnce();
+  });
+
+  it('shadow pass 遍历所有 cascade，每个 cascade 绑定一次 FBO', () => {
+    const { canvas, gl } = mockGlMod.createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeTriGeo(), new PhongMaterial()));
+
+    const csm = new CascadedShadowMap({ numCascades: 4 });
+    scene.cascadedShadowMap = csm;
+
+    renderer.render(scene, makeCamera());
+    // shadow pass: 每个 cascade bind + 最后恢复 null = 5 次 bindFramebuffer (4 + 1)
+    expect(gl._calls['bindFramebuffer']).toBeGreaterThanOrEqual(4);
+  });
+
+  it('CSM splits 数组传给 uniform (uniform1fv 被调用)', () => {
+    const { canvas, gl } = mockGlMod.createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeTriGeo(), new PhongMaterial()));
+
+    const csm = new CascadedShadowMap({ numCascades: 4 });
+    scene.cascadedShadowMap = csm;
+
+    renderer.render(scene, makeCamera());
+    // uniform1fv 用于传 csm splits
+    expect(gl._calls['uniform1fv']).toBeGreaterThan(0);
+  });
+
+  it('u_csmEnabled 在无 CSM 时设为 false (uniform1i 被调用传 0)', () => {
+    const { canvas, gl } = mockGlMod.createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeTriGeo(), new PhongMaterial()));
+
+    renderer.render(scene, makeCamera());
+    // 无 CSM 时设 u_csmEnabled=0
+    expect(gl._calls['uniform1i']).toBeGreaterThan(0);
+  });
+
+  it('numCascades != 4 时抛错', () => {
+    const { canvas } = mockGlMod.createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeTriGeo(), new PhongMaterial()));
+
+    const csm = new CascadedShadowMap({ numCascades: 2 });
+    scene.cascadedShadowMap = csm;
+
+    expect(() => renderer.render(scene, makeCamera())).toThrow(/numCascades 必须为 4/);
+  });
+
+  it('全 renderer 测试零回归：无 CSM 场景基本渲染正常', () => {
+    const { canvas, gl } = mockGlMod.createMockCanvas();
+    const renderer = new WebGLRenderer(canvas);
+    const scene = new Scene();
+    scene.addChild(new Mesh(makeTriGeo(), new PhongMaterial()));
+    expect(() => renderer.render(scene, makeCamera())).not.toThrow();
+    expect(gl._drawCalls.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- `Scene` 添加 `cascadedShadowMap: CascadedShadowMap | null` 字段（默认 `null`）
- `PhongMaterial` fragment shader 增加 CSM 路径：`#define NUM_CASCADES 4`、CSM uniforms、`computeCSMShadow()` 展开式 if-else（WebGL 1.0 约束）
- `WebGLRenderer` 自动检测并渲染 N 级 shadow pass，主 pass 自动绑定 cascade 纹理 + matrices + splits
- 向后兼容：`scene.cascadedShadowMap=null` 时不影响原有 ShadowMap 路径

## Test plan

- [x] `test/unit/renderer/csm-integration.test.ts` 14 tests 全绿
- [x] 全量单元测试 2146 tests 零回归（159 test files）

close #386