### PR TITLE
feat: 实现 AnimationStateMachine — 状态机驱动动画切换 (#396)

### DIFF
--- a/src/animation/animation-clip.ts
+++ b/src/animation/animation-clip.ts
@@ -10,9 +10,16 @@ export class AnimationClip {
   readonly duration: number;
   readonly tracks: ReadonlyArray<KeyframeTrack>;
 
-  constructor(name: string, tracks: KeyframeTrack[]) {
+  constructor(name: string, tracks: KeyframeTrack[]);
+  constructor(name: string, duration: number, tracks: KeyframeTrack[]);
+  constructor(name: string, tracksOrDuration: KeyframeTrack[] | number, tracks?: KeyframeTrack[]) {
     this.name = name;
-    this.tracks = tracks;
-    this.duration = tracks.reduce((max, t) => Math.max(max, t.duration), 0);
+    if (typeof tracksOrDuration === 'number') {
+      this.tracks = tracks ?? [];
+      this.duration = tracksOrDuration > 0 ? tracksOrDuration : this.tracks.reduce((max, t) => Math.max(max, t.duration), 0);
+    } else {
+      this.tracks = tracksOrDuration;
+      this.duration = this.tracks.reduce((max, t) => Math.max(max, t.duration), 0);
+    }
   }
 }

--- a/src/animation/animation-state-machine.ts
+++ b/src/animation/animation-state-machine.ts
@@ -1,13 +1,9 @@
 /**
  * AnimationStateMachine — 状态机驱动 AnimationAction 切换
  * @see test/unit/animation/animation-state-machine.test.ts
- *
- * STUB FILE — Phase 55 KR1, 等 Forge 实现。
  */
 
 import type { AnimationAction } from './animation-action';
-
-export const __STUB__ = true;
 
 export interface StateTransition {
   from: string;
@@ -17,27 +13,76 @@ export interface StateTransition {
 }
 
 export class AnimationStateMachine {
-  constructor() {
-    throw new Error('AnimationStateMachine: stub not implemented (Phase 55 KR1)');
+  private _states: Map<string, AnimationAction> = new Map();
+  private _transitions: StateTransition[] = [];
+  private _currentState: string | null = null;
+
+  constructor() {}
+
+  addState(name: string, action: AnimationAction): this {
+    if (this._states.has(name)) {
+      throw new Error(`AnimationStateMachine: 状态 "${name}" 已存在`);
+    }
+    this._states.set(name, action);
+    if (this._currentState === null) {
+      this._currentState = name;
+      action.play();
+    }
+    return this;
   }
 
-  addState(_name: string, _action: AnimationAction): this {
-    throw new Error('Not implemented');
+  addTransition(from: string, to: string, condition: () => boolean, duration: number): this {
+    if (!this._states.has(from)) {
+      throw new Error(`AnimationStateMachine: 未知状态 "${from}"`);
+    }
+    if (!this._states.has(to)) {
+      throw new Error(`AnimationStateMachine: 未知状态 "${to}"`);
+    }
+    if (this._transitions.some(t => t.from === from && t.to === to)) {
+      throw new Error(`AnimationStateMachine: 转换 "${from}→${to}" 已存在`);
+    }
+    this._transitions.push({ from, to, condition, duration });
+    return this;
   }
 
-  addTransition(_from: string, _to: string, _condition: () => boolean, _duration: number): this {
-    throw new Error('Not implemented');
-  }
+  setState(name: string): this {
+    if (!this._states.has(name)) {
+      throw new Error(`AnimationStateMachine: 未知状态 "${name}"`);
+    }
+    if (this._currentState === name) return this;
 
-  setState(_name: string): this {
-    throw new Error('Not implemented');
+    if (this._currentState !== null) {
+      const currentAction = this._states.get(this._currentState)!;
+      const targetAction = this._states.get(name)!;
+      const transition = this._transitions.find(t => t.from === this._currentState && t.to === name);
+      const duration = transition ? transition.duration : 0.3;
+      currentAction.crossFadeTo(targetAction, duration);
+    } else {
+      this._states.get(name)!.play();
+    }
+
+    this._currentState = name;
+    return this;
   }
 
   get currentState(): string | null {
-    throw new Error('Not implemented');
+    return this._currentState;
   }
 
-  update(_deltaTime: number): void {
-    throw new Error('Not implemented');
+  update(deltaTime: number): void {
+    for (const action of this._states.values()) {
+      if (action.isRunning) {
+        action._update(deltaTime);
+      }
+    }
+
+    if (this._currentState === null) return;
+
+    for (const transition of this._transitions) {
+      if (transition.from === this._currentState && transition.condition()) {
+        this.setState(transition.to);
+        break;
+      }
+    }
   }
 }


### PR DESCRIPTION
## 概述

实现 `AnimationStateMachine`，状态机驱动 `AnimationAction` 自动 crossFade 切换。

## 改动

- `src/animation/animation-state-machine.ts` — 删除 STUB，实现完整状态机逻辑
- `src/animation/animation-clip.ts` — 扩展构造函数，支持 `(name, duration, tracks)` 3 参数形式（向后兼容原有 2 参数形式）

## 验收结果

- ✅ 12/12 AnimationStateMachine 测试全部通过
- ✅ 全 animation 测试零回归
- ✅ 删除了 `export const __STUB__ = true;`

close #396