### PR TITLE
feat: 实现 BlendTree1D 1D 参数线性插值权重混合 (#397)

### DIFF
--- a/src/animation/blend-tree-1d.ts
+++ b/src/animation/blend-tree-1d.ts
@@ -1,13 +1,9 @@
 /**
  * BlendTree1D — 1D 参数驱动的 AnimationAction 权重线性插值混合
  * @see test/unit/animation/blend-tree-1d.test.ts
- *
- * STUB FILE — Phase 55 KR2, 等 Forge 实现。
  */
 
 import type { AnimationAction } from './animation-action';
-
-export const __STUB__ = true;
 
 export interface BlendTree1DEntry {
   threshold: number;
@@ -15,19 +11,66 @@ export interface BlendTree1DEntry {
 }
 
 export class BlendTree1D {
-  constructor(_entries: BlendTree1DEntry[]) {
-    throw new Error('BlendTree1D: stub not implemented (Phase 55 KR2)');
+  private readonly _entries: BlendTree1DEntry[];
+  private _param: number;
+
+  constructor(entries: BlendTree1DEntry[]) {
+    if (entries.length < 2) {
+      throw new Error('BlendTree1D: 至少需要 2 个 entry');
+    }
+    for (let i = 1; i < entries.length; i++) {
+      if (entries[i].threshold <= entries[i - 1].threshold) {
+        throw new Error('BlendTree1D: threshold 必须严格升序');
+      }
+    }
+    this._entries = entries;
+    this._param = entries[0].threshold;
+    for (const entry of entries) {
+      entry.action.play();
+    }
   }
 
-  setParameter(_value: number): this {
-    throw new Error('Not implemented');
+  setParameter(value: number): this {
+    const min = this._entries[0].threshold;
+    const max = this._entries[this._entries.length - 1].threshold;
+    this._param = Math.max(min, Math.min(max, value));
+    return this;
   }
 
   get parameter(): number {
-    throw new Error('Not implemented');
+    return this._param;
   }
 
-  update(_deltaTime: number): void {
-    throw new Error('Not implemented');
+  update(deltaTime: number): void {
+    for (const entry of this._entries) {
+      entry.action._update(deltaTime);
+    }
+
+    const entries = this._entries;
+    const last = entries.length - 1;
+
+    // 找到 _param 所在的区间
+    let segIndex = last - 1;
+    for (let i = 0; i < last; i++) {
+      if (this._param < entries[i + 1].threshold) {
+        segIndex = i;
+        break;
+      }
+    }
+
+    const lo = entries[segIndex];
+    const hi = entries[segIndex + 1];
+    const range = hi.threshold - lo.threshold;
+    const t = range > 0 ? (this._param - lo.threshold) / range : 0;
+
+    for (let i = 0; i < entries.length; i++) {
+      if (i === segIndex) {
+        entries[i].action.weight = 1 - t;
+      } else if (i === segIndex + 1) {
+        entries[i].action.weight = t;
+      } else {
+        entries[i].action.weight = 0;
+      }
+    }
   }
 }


### PR DESCRIPTION
## 概述

实现 `BlendTree1D` — 1D 参数驱动的 `AnimationAction` 权重线性插值混合（idle ↔ walk ↔ run 速度驱动）。

## 变更内容

- `src/animation/blend-tree-1d.ts`: 完整实现，删除 `__STUB__` 标记
- `src/animation/animation-clip.ts`: 扩展构造函数，支持三参数形式 `(name, duration, tracks)`，向后兼容

## 验收结果

- ✅ 11/11 BlendTree1D 测试通过
- ✅ 全量单元测试零回归（2239 通过，24 跳过）
- ✅ `__STUB__` 行已删除

close #397