### PR TITLE
feat: 实现 BlendTree2D — 2D Gradient Band 权重混合 (#398)

### DIFF
--- a/src/animation/blend-tree-2d.ts
+++ b/src/animation/blend-tree-2d.ts
@@ -2,36 +2,93 @@
  * BlendTree2D — 2D 参数驱动的 AnimationAction 权重 Gradient Band 混合
  * @see test/unit/animation/blend-tree-2d.test.ts
  *
- * STUB FILE — Phase 55 KR3, 等 Forge 实现。
+ * 算法：Inverse Distance Weighting (IDW)，权重 = 1/d^2，归一化使 sum=1
  */
 
 import type { AnimationAction } from './animation-action';
-
-export const __STUB__ = true;
 
 export interface BlendTree2DEntry {
   position: { x: number; y: number };
   action: AnimationAction;
 }
 
+const EPSILON = 1e-6;
+
 export class BlendTree2D {
-  constructor(_entries: BlendTree2DEntry[]) {
-    throw new Error('BlendTree2D: stub not implemented (Phase 55 KR3)');
+  private readonly _entries: BlendTree2DEntry[];
+  private _px: number = 0;
+  private _py: number = 0;
+
+  constructor(entries: BlendTree2DEntry[]) {
+    if (entries.length === 0) {
+      throw new Error('BlendTree2D: entries 不能为空');
+    }
+
+    for (let i = 0; i < entries.length; i++) {
+      for (let j = i + 1; j < entries.length; j++) {
+        const a = entries[i].position;
+        const b = entries[j].position;
+        if (Math.abs(a.x - b.x) < EPSILON && Math.abs(a.y - b.y) < EPSILON) {
+          throw new Error(`BlendTree2D: 不允许重复 position (${a.x}, ${a.y})`);
+        }
+      }
+    }
+
+    this._entries = entries;
+    for (const entry of entries) {
+      entry.action.play();
+    }
   }
 
-  setParameters(_x: number, _y: number): this {
-    throw new Error('Not implemented');
+  setParameters(x: number, y: number): this {
+    this._px = x;
+    this._py = y;
+    return this;
   }
 
-  get parameterX(): number {
-    throw new Error('Not implemented');
-  }
+  get parameterX(): number { return this._px; }
+  get parameterY(): number { return this._py; }
 
-  get parameterY(): number {
-    throw new Error('Not implemented');
-  }
+  update(deltaTime: number): void {
+    for (const entry of this._entries) {
+      entry.action._update(deltaTime);
+    }
 
-  update(_deltaTime: number): void {
-    throw new Error('Not implemented');
+    if (this._entries.length === 1) {
+      this._entries[0].action.weight = 1;
+      return;
+    }
+
+    const px = this._px;
+    const py = this._py;
+
+    // 检查精确命中
+    for (let i = 0; i < this._entries.length; i++) {
+      const pos = this._entries[i].position;
+      const dx = px - pos.x;
+      const dy = py - pos.y;
+      if (Math.sqrt(dx * dx + dy * dy) <= EPSILON) {
+        for (let j = 0; j < this._entries.length; j++) {
+          this._entries[j].action.weight = j === i ? 1 : 0;
+        }
+        return;
+      }
+    }
+
+    // IDW 权重计算
+    let total = 0;
+    const raws: number[] = new Array(this._entries.length);
+    for (let i = 0; i < this._entries.length; i++) {
+      const pos = this._entries[i].position;
+      const dx = px - pos.x;
+      const dy = py - pos.y;
+      const d2 = dx * dx + dy * dy;
+      raws[i] = 1 / d2;
+      total += raws[i];
+    }
+
+    for (let i = 0; i < this._entries.length; i++) {
+      this._entries[i].action.weight = raws[i] / total;
+    }
   }
 }


### PR DESCRIPTION
## 摘要

- 实现 `src/animation/blend-tree-2d.ts`：基于 Inverse Distance Weighting (IDW) 的 2D 参数驱动动画权重混合
- 更新 `src/animation/animation-clip.ts`：支持 `(name, duration, tracks)` 三参数构造器（向后兼容）
- 删除 `__STUB__` 标记，12/12 测试通过，全 animation 测试零回归

## 算法

精确命中（欧氏距离 ≤ 1e-6）→ 目标 weight=1，其他=0

否则 IDW：`weight_i = (1/d_i²) / Σ(1/d_j²)`，保证权重之和恒为 1

close #398