### PR TITLE
feat: Phase 57 KR1 — WebSocket Transport + Node.js Server + 二进制序列化

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   },
   "devDependencies": {
     "@playwright/test": "1.52.0",
+    "@types/ws": "^8.18.1",
     "pixel-buffer-diff": "^1.1.0",
     "pngjs": "^7.0.0",
     "typescript": "^5.8.0",
     "vite": "^6.3.0",
-    "vitest": "^3.1.0"
+    "vitest": "^3.1.0",
+    "ws": "^8.20.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@playwright/test':
         specifier: 1.52.0
         version: 1.52.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       pixel-buffer-diff:
         specifier: ^1.1.0
         version: 1.4.0
@@ -22,10 +25,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.0
-        version: 6.4.1
+        version: 6.4.1(@types/node@25.6.2)
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4
+        version: 3.2.4(@types/node@25.6.2)
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
 
   examples/action-rpg:
     devDependencies:
@@ -37,10 +43,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.0
-        version: 6.4.1
+        version: 6.4.1(@types/node@25.6.2)
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4
+        version: 3.2.4(@types/node@25.6.2)
 
   examples/action-rpg-v2:
     devDependencies:
@@ -52,10 +58,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.0
-        version: 6.4.1
+        version: 6.4.1(@types/node@25.6.2)
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4
+        version: 3.2.4(@types/node@25.6.2)
 
   examples/br-12p:
     devDependencies:
@@ -67,10 +73,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.0
-        version: 6.4.1
+        version: 6.4.1(@types/node@25.6.2)
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4
+        version: 3.2.4(@types/node@25.6.2)
 
   examples/runner-3d:
     devDependencies:
@@ -82,10 +88,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.0
-        version: 6.4.1
+        version: 6.4.1(@types/node@25.6.2)
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4
+        version: 3.2.4(@types/node@25.6.2)
 
   examples/slg-3d:
     devDependencies:
@@ -97,10 +103,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.0
-        version: 6.4.1
+        version: 6.4.1(@types/node@25.6.2)
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4
+        version: 3.2.4(@types/node@25.6.2)
 
   examples/tower-defense-3d:
     devDependencies:
@@ -112,10 +118,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.0
-        version: 6.4.1
+        version: 6.4.1(@types/node@25.6.2)
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4
+        version: 3.2.4(@types/node@25.6.2)
 
 packages:
 
@@ -417,6 +423,12 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node@25.6.2':
+    resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -609,6 +621,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -686,6 +701,18 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
 snapshots:
 
@@ -857,6 +884,14 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@25.6.2':
+    dependencies:
+      undici-types: 7.19.2
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.6.2
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -865,13 +900,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.1)':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@25.6.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1
+      vite: 6.4.1(@types/node@25.6.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1064,13 +1099,15 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  vite-node@3.2.4:
+  undici-types@7.19.2: {}
+
+  vite-node@3.2.4(@types/node@25.6.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1
+      vite: 6.4.1(@types/node@25.6.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -1085,7 +1122,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.1:
+  vite@6.4.1(@types/node@25.6.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1094,13 +1131,14 @@ snapshots:
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 25.6.2
       fsevents: 2.3.3
 
-  vitest@3.2.4:
+  vitest@3.2.4(@types/node@25.6.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1)
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@25.6.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1118,9 +1156,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1
-      vite-node: 3.2.4
+      vite: 6.4.1(@types/node@25.6.2)
+      vite-node: 3.2.4(@types/node@25.6.2)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.2
     transitivePeerDependencies:
       - jiti
       - less
@@ -1139,3 +1179,5 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.20.0: {}

--- a/src/net/serialization.ts
+++ b/src/net/serialization.ts
@@ -1,0 +1,119 @@
+const TAG_NULL = 0x00;
+const TAG_FALSE = 0x01;
+const TAG_TRUE = 0x02;
+const TAG_NUMBER = 0x03;
+const TAG_STRING = 0x04;
+const TAG_ARRAY = 0x05;
+const TAG_OBJECT = 0x06;
+
+function encodeValue(value: unknown, parts: Uint8Array[]): void {
+  if (value === null || value === undefined) {
+    parts.push(new Uint8Array([TAG_NULL]));
+    return;
+  }
+  if (typeof value === 'boolean') {
+    parts.push(new Uint8Array([value ? TAG_TRUE : TAG_FALSE]));
+    return;
+  }
+  if (typeof value === 'number') {
+    const buf = new Uint8Array(9);
+    buf[0] = TAG_NUMBER;
+    new DataView(buf.buffer).setFloat64(1, value, false);
+    parts.push(buf);
+    return;
+  }
+  if (typeof value === 'string') {
+    const encoded = new TextEncoder().encode(value);
+    const header = new Uint8Array(5);
+    header[0] = TAG_STRING;
+    new DataView(header.buffer).setUint32(1, encoded.length, false);
+    parts.push(header, encoded);
+    return;
+  }
+  if (Array.isArray(value)) {
+    const header = new Uint8Array(5);
+    header[0] = TAG_ARRAY;
+    new DataView(header.buffer).setUint32(1, value.length, false);
+    parts.push(header);
+    for (const item of value) encodeValue(item, parts);
+    return;
+  }
+  if (typeof value === 'object') {
+    const keys = Object.keys(value as Record<string, unknown>);
+    const header = new Uint8Array(5);
+    header[0] = TAG_OBJECT;
+    new DataView(header.buffer).setUint32(1, keys.length, false);
+    parts.push(header);
+    for (const key of keys) {
+      encodeValue(key, parts);
+      encodeValue((value as Record<string, unknown>)[key], parts);
+    }
+    return;
+  }
+  parts.push(new Uint8Array([TAG_NULL]));
+}
+
+export function encode(value: unknown): Uint8Array {
+  const parts: Uint8Array[] = [];
+  encodeValue(value, parts);
+  const totalLength = parts.reduce((acc, p) => acc + p.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
+}
+
+function decodeValue(buffer: Uint8Array, offset: number): [unknown, number] {
+  const tag = buffer[offset++];
+  switch (tag) {
+    case TAG_NULL:
+      return [null, offset];
+    case TAG_FALSE:
+      return [false, offset];
+    case TAG_TRUE:
+      return [true, offset];
+    case TAG_NUMBER: {
+      const v = new DataView(buffer.buffer, buffer.byteOffset + offset).getFloat64(0, false);
+      return [v, offset + 8];
+    }
+    case TAG_STRING: {
+      const len = new DataView(buffer.buffer, buffer.byteOffset + offset).getUint32(0, false);
+      offset += 4;
+      const str = new TextDecoder().decode(buffer.subarray(offset, offset + len));
+      return [str, offset + len];
+    }
+    case TAG_ARRAY: {
+      const count = new DataView(buffer.buffer, buffer.byteOffset + offset).getUint32(0, false);
+      offset += 4;
+      const arr: unknown[] = [];
+      for (let i = 0; i < count; i++) {
+        const [val, next] = decodeValue(buffer, offset);
+        arr.push(val);
+        offset = next;
+      }
+      return [arr, offset];
+    }
+    case TAG_OBJECT: {
+      const count = new DataView(buffer.buffer, buffer.byteOffset + offset).getUint32(0, false);
+      offset += 4;
+      const obj: Record<string, unknown> = {};
+      for (let i = 0; i < count; i++) {
+        const [key, afterKey] = decodeValue(buffer, offset);
+        const [val, afterVal] = decodeValue(buffer, afterKey);
+        obj[key as string] = val;
+        offset = afterVal;
+      }
+      return [obj, offset];
+    }
+    default:
+      throw new Error(`未知 tag: 0x${tag.toString(16)}`);
+  }
+}
+
+export function decode(buffer: Uint8Array): unknown {
+  const [value] = decodeValue(buffer, 0);
+  return value;
+}

--- a/src/net/server.ts
+++ b/src/net/server.ts
@@ -1,0 +1,111 @@
+import { WebSocketServer, WebSocket } from 'ws';
+import type { IncomingMessage } from 'http';
+
+export interface GameServerOptions {
+  port: number;
+  tickRate?: number;
+  maxClientsPerRoom?: number;
+}
+
+export class GameServer {
+  private _wss: WebSocketServer | null = null;
+  private _clients = new Map<string, WebSocket>();
+  private _clientRooms = new Map<string, string>();
+  private _rooms = new Map<string, Set<string>>();
+
+  private _joinHandlers: Array<(clientId: string, roomId: string) => void> = [];
+  private _leaveHandlers: Array<(clientId: string, roomId: string) => void> = [];
+  private _msgHandlers: Array<(clientId: string, type: string, data: unknown) => void> = [];
+
+  constructor(private readonly options: GameServerOptions) {}
+
+  start(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this._wss = new WebSocketServer({ port: this.options.port });
+      this._wss.once('listening', () => resolve());
+      this._wss.once('error', reject);
+      this._wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
+        this._handleConnection(ws, req);
+      });
+    });
+  }
+
+  stop(): Promise<void> {
+    return new Promise((resolve) => {
+      for (const ws of this._clients.values()) ws.terminate();
+      this._clients.clear();
+      this._rooms.clear();
+      this._clientRooms.clear();
+      if (!this._wss) { resolve(); return; }
+      this._wss.close(() => resolve());
+      this._wss = null;
+    });
+  }
+
+  broadcast(roomId: string, type: string, data: unknown): void {
+    const room = this._rooms.get(roomId);
+    if (!room) return;
+    const msg = JSON.stringify({ type, data });
+    for (const clientId of room) {
+      const ws = this._clients.get(clientId);
+      if (ws?.readyState === WebSocket.OPEN) ws.send(msg);
+    }
+  }
+
+  onClientJoin(handler: (clientId: string, roomId: string) => void): void {
+    this._joinHandlers.push(handler);
+  }
+
+  onClientLeave(handler: (clientId: string, roomId: string) => void): void {
+    this._leaveHandlers.push(handler);
+  }
+
+  onMessage(handler: (clientId: string, type: string, data: unknown) => void): void {
+    this._msgHandlers.push(handler);
+  }
+
+  get clientCount(): number {
+    return this._clients.size;
+  }
+
+  get rooms(): ReadonlyMap<string, ReadonlySet<string>> {
+    return this._rooms;
+  }
+
+  private _handleConnection(ws: WebSocket, req: IncomingMessage): void {
+    const url = new URL(req.url ?? '/', `ws://localhost:${this.options.port}`);
+    const roomId = url.searchParams.get('room') ?? 'default';
+    const clientId = Math.random().toString(36).slice(2) + Date.now().toString(36);
+
+    this._clients.set(clientId, ws);
+    this._clientRooms.set(clientId, roomId);
+    if (!this._rooms.has(roomId)) this._rooms.set(roomId, new Set());
+    this._rooms.get(roomId)!.add(clientId);
+
+    for (const h of this._joinHandlers) h(clientId, roomId);
+
+    ws.on('message', (rawData: Buffer) => {
+      try {
+        const { type, data } = JSON.parse(rawData.toString()) as { type: string; data: unknown };
+        for (const h of this._msgHandlers) h(clientId, type, data);
+        const room = this._rooms.get(roomId);
+        if (!room) return;
+        const msg = JSON.stringify({ type, data });
+        for (const peerId of room) {
+          if (peerId === clientId) continue;
+          const peer = this._clients.get(peerId);
+          if (peer?.readyState === WebSocket.OPEN) peer.send(msg);
+        }
+      } catch {
+        // 忽略格式错误的消息
+      }
+    });
+
+    ws.on('close', () => {
+      this._clients.delete(clientId);
+      this._clientRooms.delete(clientId);
+      this._rooms.get(roomId)?.delete(clientId);
+      for (const h of this._leaveHandlers) h(clientId, roomId);
+    });
+  }
+}

--- a/src/net/websocket-transport.ts
+++ b/src/net/websocket-transport.ts
@@ -1,0 +1,93 @@
+import type { INetworkTransport } from './transport';
+
+export interface WebSocketTransportOptions {
+  url: string;
+  reconnect?: boolean;
+  reconnectDelay?: number;
+}
+
+export class WebSocketTransport implements INetworkTransport {
+  private _ws: WebSocket | null = null;
+  private _connected = false;
+  private _listeners = new Map<string, Set<(data: unknown) => void>>();
+  private _roomId: string | null = null;
+  private _explicitDisconnect = false;
+  private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly options: WebSocketTransportOptions) {}
+
+  get connected(): boolean {
+    return this._connected;
+  }
+
+  connect(roomId: string): void {
+    this._roomId = roomId;
+    this._explicitDisconnect = false;
+    this._openWS();
+  }
+
+  disconnect(): void {
+    this._explicitDisconnect = true;
+    if (this._reconnectTimer !== null) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+    if (this._ws) {
+      this._ws.onclose = null;
+      this._ws.onopen = null;
+      this._ws.onmessage = null;
+      this._ws.close();
+      this._ws = null;
+    }
+    this._connected = false;
+  }
+
+  send(type: string, data: unknown): void {
+    if (this._ws && this._ws.readyState === WebSocket.OPEN) {
+      this._ws.send(JSON.stringify({ type, data }));
+    }
+  }
+
+  on(type: string, handler: (data: unknown) => void): void {
+    if (!this._listeners.has(type)) this._listeners.set(type, new Set());
+    this._listeners.get(type)!.add(handler);
+  }
+
+  off(type: string, handler: (data: unknown) => void): void {
+    this._listeners.get(type)?.delete(handler);
+  }
+
+  private _openWS(): void {
+    const url = this._roomId
+      ? `${this.options.url}?room=${encodeURIComponent(this._roomId)}`
+      : this.options.url;
+    const ws = new WebSocket(url);
+    this._ws = ws;
+
+    ws.onopen = () => {
+      this._connected = true;
+    };
+
+    ws.onclose = () => {
+      this._connected = false;
+      if (!this._explicitDisconnect && this.options.reconnect !== false) {
+        this._reconnectTimer = setTimeout(
+          () => this._openWS(),
+          this.options.reconnectDelay ?? 1000
+        );
+      }
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const { type, data } = JSON.parse(event.data as string) as { type: string; data: unknown };
+        const handlers = this._listeners.get(type);
+        if (handlers) {
+          for (const h of handlers) h(data);
+        }
+      } catch {
+        // 忽略格式错误的消息
+      }
+    };
+  }
+}

--- a/test/integration/net/server-roundtrip.test.ts
+++ b/test/integration/net/server-roundtrip.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { GameServer } from '../../../src/net/server';
+import { WebSocketTransport } from '../../../src/net/websocket-transport';
+
+const PORT = 18974;
+
+function waitForConnected(transport: WebSocketTransport, timeout = 5000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      if (transport.connected) { resolve(); return; }
+      if (Date.now() - start > timeout) { reject(new Error('连接超时')); return; }
+      setTimeout(check, 10);
+    };
+    check();
+  });
+}
+
+describe('GameServer 消息回路', { timeout: 10000 }, () => {
+  let server: GameServer;
+
+  beforeAll(async () => {
+    server = new GameServer({ port: PORT });
+    await server.start();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  it('clientA 发消息，clientB 收到', async () => {
+    const clientA = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+    const clientB = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+
+    clientA.connect('test-room');
+    clientB.connect('test-room');
+
+    await Promise.all([waitForConnected(clientA), waitForConnected(clientB)]);
+
+    const received: unknown[] = [];
+    clientB.on('chat', (data) => received.push(data));
+
+    clientA.send('chat', { text: 'hello from A' });
+
+    await new Promise<void>((resolve, reject) => {
+      const deadline = Date.now() + 3000;
+      const poll = () => {
+        if (received.length > 0) { resolve(); return; }
+        if (Date.now() > deadline) { reject(new Error('消息未收到')); return; }
+        setTimeout(poll, 20);
+      };
+      poll();
+    });
+
+    expect(received).toEqual([{ text: 'hello from A' }]);
+
+    clientA.disconnect();
+    clientB.disconnect();
+  });
+
+  it('clientA 的消息不会反射回自己', async () => {
+    const clientA = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+    const clientB = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+
+    clientA.connect('solo-room');
+    clientB.connect('solo-room');
+
+    await Promise.all([waitForConnected(clientA), waitForConnected(clientB)]);
+
+    const selfReceived: unknown[] = [];
+    clientA.on('ping', (d) => selfReceived.push(d));
+
+    clientA.send('ping', { n: 1 });
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(selfReceived.length).toBe(0);
+
+    clientA.disconnect();
+    clientB.disconnect();
+  });
+
+  it('不同房间消息隔离', async () => {
+    const clientA = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+    const clientC = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+
+    clientA.connect('room-alpha');
+    clientC.connect('room-beta');
+
+    await Promise.all([waitForConnected(clientA), waitForConnected(clientC)]);
+
+    const cReceived: unknown[] = [];
+    clientC.on('msg', (d) => cReceived.push(d));
+
+    clientA.send('msg', { secret: 42 });
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(cReceived.length).toBe(0);
+
+    clientA.disconnect();
+    clientC.disconnect();
+  });
+
+  it('server.clientCount 统计连接数', async () => {
+    await new Promise((r) => setTimeout(r, 200)); // 等前序测试连接关闭
+    const before = server.clientCount;
+    const t = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+    t.connect('count-room');
+    await waitForConnected(t);
+    expect(server.clientCount).toBe(before + 1);
+    t.disconnect();
+    await new Promise((r) => setTimeout(r, 100));
+    expect(server.clientCount).toBe(before);
+  });
+
+  it('onClientJoin / onClientLeave 回调', async () => {
+    const joins: string[] = [];
+    const leaves: string[] = [];
+    server.onClientJoin((id) => joins.push(id));
+    server.onClientLeave((id) => leaves.push(id));
+
+    const t = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+    t.connect('cb-room');
+    await waitForConnected(t);
+    expect(joins.length).toBeGreaterThan(0);
+
+    t.disconnect();
+    await new Promise((r) => setTimeout(r, 100));
+    expect(leaves.length).toBeGreaterThan(0);
+  });
+});

--- a/test/unit/net/serialization.test.ts
+++ b/test/unit/net/serialization.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { encode, decode } from '../../../src/net/serialization';
+
+describe('序列化 round-trip', () => {
+  it('null', () => {
+    expect(decode(encode(null))).toBeNull();
+  });
+
+  it('布尔值 false', () => {
+    expect(decode(encode(false))).toBe(false);
+  });
+
+  it('布尔值 true', () => {
+    expect(decode(encode(true))).toBe(true);
+  });
+
+  it('整数', () => {
+    expect(decode(encode(42))).toBe(42);
+  });
+
+  it('负数', () => {
+    expect(decode(encode(-100))).toBe(-100);
+  });
+
+  it('浮点数', () => {
+    expect(decode(encode(3.14))).toBeCloseTo(3.14, 10);
+  });
+
+  it('零', () => {
+    expect(decode(encode(0))).toBe(0);
+  });
+
+  it('空字符串', () => {
+    expect(decode(encode(''))).toBe('');
+  });
+
+  it('ASCII 字符串', () => {
+    expect(decode(encode('hello world'))).toBe('hello world');
+  });
+
+  it('中文字符串', () => {
+    expect(decode(encode('你好世界'))).toBe('你好世界');
+  });
+
+  it('空数组', () => {
+    expect(decode(encode([]))).toEqual([]);
+  });
+
+  it('数字数组', () => {
+    expect(decode(encode([1, 2, 3]))).toEqual([1, 2, 3]);
+  });
+
+  it('混合数组', () => {
+    expect(decode(encode([1, 'a', true, null]))).toEqual([1, 'a', true, null]);
+  });
+
+  it('空对象', () => {
+    expect(decode(encode({}))).toEqual({});
+  });
+
+  it('简单对象', () => {
+    expect(decode(encode({ x: 1, y: 2 }))).toEqual({ x: 1, y: 2 });
+  });
+
+  it('嵌套对象', () => {
+    const obj = { a: { b: { c: 42 } } };
+    expect(decode(encode(obj))).toEqual(obj);
+  });
+
+  it('对象数组嵌套', () => {
+    const val = { items: [{ id: 1 }, { id: 2 }], count: 2 };
+    expect(decode(encode(val))).toEqual(val);
+  });
+
+  it('Vec3 对象', () => {
+    const vec = { x: 1.5, y: -2.5, z: 0.0 };
+    expect(decode(encode(vec))).toEqual(vec);
+  });
+
+  it('encode 返回 Uint8Array', () => {
+    expect(encode(42)).toBeInstanceOf(Uint8Array);
+  });
+});

--- a/test/unit/net/websocket-transport.test.ts
+++ b/test/unit/net/websocket-transport.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WebSocketTransport } from '../../../src/net/websocket-transport';
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  binaryType = 'blob';
+  url: string;
+
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+
+  sentMessages: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sentMessages.push(data);
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  simulateMessage(data: string): void {
+    this.onmessage?.({ data });
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  vi.stubGlobal('WebSocket', MockWebSocket);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('WebSocketTransport', () => {
+  it('connect 后创建 WebSocket 连接', () => {
+    const t = new WebSocketTransport({ url: 'ws://localhost:8080' });
+    t.connect('room-1');
+    expect(MockWebSocket.instances.length).toBe(1);
+    expect(MockWebSocket.instances[0].url).toContain('room=room-1');
+  });
+
+  it('初始 connected 为 false', () => {
+    const t = new WebSocketTransport({ url: 'ws://localhost:8080' });
+    t.connect('room-1');
+    expect(t.connected).toBe(false);
+  });
+
+  it('WebSocket open 后 connected 为 true', () => {
+    const t = new WebSocketTransport({ url: 'ws://localhost:8080' });
+    t.connect('room-1');
+    MockWebSocket.instances[0].simulateOpen();
+    expect(t.connected).toBe(true);
+  });
+
+  it('disconnect 后 connected 为 false', () => {
+    const t = new WebSocketTransport({ url: 'ws://localhost:8080' });
+    t.connect('room-1');
+    MockWebSocket.instances[0].simulateOpen();
+    t.disconnect();
+    expect(t.connected).toBe(false);
+  });
+
+  it('send 发送 JSON 消息', () => {
+    const t = new WebSocketTransport({ url: 'ws://localhost:8080' });
+    t.connect('room-1');
+    MockWebSocket.instances[0].simulateOpen();
+    t.send('chat', { text: 'hello' });
+    const sent = MockWebSocket.instances[0].sentMessages;
+    expect(sent.length).toBe(1);
+    expect(JSON.parse(sent[0])).toEqual({ type: 'chat', data: { text: 'hello' } });
+  });
+
+  it('send 在未连接时不发送', () => {
+    const t = new WebSocketTransport({ url: 'ws://localhost:8080' });
+    t.connect('room-1');
+    t.send('msg', {});
+    expect(MockWebSocket.instances[0].sentMessages.length).toBe(0);
+  });
+
+  it('on 接收服务器推送的消息', () => {
+    const t = new WebSocketTransport({ url: 'ws://localhost:8080' });
+    t.connect('room-1');
+    MockWebSocket.instances[0].simulateOpen();
+    const handler = vi.fn();
+    t.on('chat', handler);
+    MockWebSocket.instances[0].simulateMessage(JSON.stringify({ type: 'chat', data: { text: 'hi' } }));
+    expect(handler).toHaveBeenCalledWith({ text: 'hi' });
+  });
+
+  it('off 移除监听器', () => {
+    const t = new WebSocketTransport({ url: 'ws://localhost:8080' });
+    t.connect('room-1');
+    MockWebSocket.instances[0].simulateOpen();
+    const handler = vi.fn();
+    t.on('msg', handler);
+    t.off('msg', handler);
+    MockWebSocket.instances[0].simulateMessage(JSON.stringify({ type: 'msg', data: {} }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('disconnect 阻止自动重连', () => {
+    vi.useFakeTimers();
+    const t = new WebSocketTransport({ url: 'ws://localhost:8080', reconnect: true, reconnectDelay: 100 });
+    t.connect('room-1');
+    MockWebSocket.instances[0].simulateOpen();
+    t.disconnect();
+    vi.advanceTimersByTime(500);
+    expect(MockWebSocket.instances.length).toBe(1);
+    vi.useRealTimers();
+  });
+
+  it('reconnect:false 断线不重连', () => {
+    vi.useFakeTimers();
+    const t = new WebSocketTransport({ url: 'ws://localhost:8080', reconnect: false });
+    t.connect('room-1');
+    MockWebSocket.instances[0].simulateOpen();
+    MockWebSocket.instances[0].close();
+    vi.advanceTimersByTime(2000);
+    expect(MockWebSocket.instances.length).toBe(1);
+    vi.useRealTimers();
+  });
+
+  it('reconnect:true 断线后重连', () => {
+    vi.useFakeTimers();
+    const t = new WebSocketTransport({ url: 'ws://localhost:8080', reconnect: true, reconnectDelay: 100 });
+    t.connect('room-1');
+    MockWebSocket.instances[0].simulateOpen();
+    // 模拟意外断线（不调用 disconnect()）
+    const ws = MockWebSocket.instances[0];
+    ws.readyState = MockWebSocket.CLOSED;
+    ws.onclose?.();
+    vi.advanceTimersByTime(200);
+    expect(MockWebSocket.instances.length).toBe(2);
+    t.disconnect();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## 变更概要

- `src/net/websocket-transport.ts` — 实现 `INetworkTransport`，走真实浏览器 `WebSocket`，支持自动重连（`reconnect`/`reconnectDelay` 选项）
- `src/net/server.ts` — Node.js `GameServer`（基于 `ws` 包），Room 管理 + 广播 + 客户端加入/离开回调
- `src/net/serialization.ts` — 自定义 ArrayBuffer 编解码（无外部依赖），支持 null/bool/number/string/array/object 嵌套 round-trip

## 测试

| 文件 | 用例数 | 覆盖点 |
|------|--------|--------|
| `test/unit/net/websocket-transport.test.ts` | 11 | `vi.stubGlobal` mock WebSocket，双向通信、重连逻辑 |
| `test/unit/net/serialization.test.ts` | 19 | 所有基础类型 + 嵌套 + Vec3 round-trip |
| `test/integration/net/server-roundtrip.test.ts` | 5 | 真实 GameServer + 2 客户端，消息路由、房间隔离、clientCount |

全量 `vitest run`: **2298 tests passed**（零回归）

## 依赖变更

- 新增 `ws ^8.20.0` + `@types/ws` 为 devDependencies（仅测试/服务端用）

close #412