### PR TITLE
feat: Phase 57 KR2 — State Sync 客户端-权威服务器 + tick rate + interpolation/extrapolation

### DIFF
--- a/src/net/client-state-sync.ts
+++ b/src/net/client-state-sync.ts
@@ -1,0 +1,33 @@
+import type { NetworkClient } from './network-client';
+
+export interface ClientStateSyncOptions<TInput, TState> {
+  client: NetworkClient;
+  inputMessage?: string;
+  stateMessage?: string;
+  tickRate?: number;
+}
+
+export class ClientStateSync<TInput = unknown, TState = unknown> {
+  private readonly _client: NetworkClient;
+  private readonly _inputMessage: string;
+  private readonly _stateHandlers: Array<(id: string, tick: number, state: TState) => void> = [];
+
+  constructor(options: ClientStateSyncOptions<TInput, TState>) {
+    this._client = options.client;
+    this._inputMessage = options.inputMessage ?? 'player.input';
+    const stateMessage = options.stateMessage ?? 'player.state';
+
+    this._client.on(stateMessage, (data) => {
+      const msg = data as { id: string; tick: number; state: TState };
+      for (const h of this._stateHandlers) h(msg.id, msg.tick, msg.state);
+    });
+  }
+
+  sendInput(input: TInput): void {
+    this._client.send(this._inputMessage, input);
+  }
+
+  onState(handler: (id: string, tick: number, state: TState) => void): void {
+    this._stateHandlers.push(handler);
+  }
+}

--- a/src/net/interpolator.ts
+++ b/src/net/interpolator.ts
@@ -4,17 +4,50 @@ export interface Vec3Like {
   z: number;
 }
 
+interface Snapshot {
+  tick: number;
+  x: number;
+  y: number;
+  z: number;
+}
+
+const MAX_SNAPSHOTS = 16;
+
 export class RemoteEntityInterpolator {
-  private _lerpSpeed: number;
+  private readonly _lerpSpeed: number;
+  private readonly _tickRate: number;
   private _targetX = 0;
   private _targetY = 0;
   private _targetZ = 0;
+  private _snapshots: Snapshot[] = [];
+  private _velX = 0;
+  private _velY = 0;
+  private _velZ = 0;
 
-  constructor(lerpSpeed = 10) {
+  constructor(lerpSpeed = 10, tickRate = 30) {
     this._lerpSpeed = lerpSpeed;
+    this._tickRate = tickRate;
   }
 
   setTarget(x: number, y: number, z: number): void {
+    this._targetX = x;
+    this._targetY = y;
+    this._targetZ = z;
+  }
+
+  setSnapshot(tick: number, x: number, y: number, z: number): void {
+    const last = this._snapshots.length > 0 ? this._snapshots[this._snapshots.length - 1] : null;
+    if (last) {
+      const dTick = tick - last.tick;
+      if (dTick > 0) {
+        const dTime = dTick / this._tickRate;
+        this._velX = (x - last.x) / dTime;
+        this._velY = (y - last.y) / dTime;
+        this._velZ = (z - last.z) / dTime;
+      }
+    }
+    this._snapshots.push({ tick, x, y, z });
+    if (this._snapshots.length > MAX_SNAPSHOTS) this._snapshots.shift();
     this._targetX = x;
     this._targetY = y;
     this._targetZ = z;
@@ -27,7 +60,14 @@ export class RemoteEntityInterpolator {
     current.z += (this._targetZ - current.z) * t;
   }
 
+  extrapolate(dt: number, current: Vec3Like): void {
+    current.x += this._velX * dt;
+    current.y += this._velY * dt;
+    current.z += this._velZ * dt;
+  }
+
   get targetX(): number { return this._targetX; }
   get targetY(): number { return this._targetY; }
   get targetZ(): number { return this._targetZ; }
+  get snapshotCount(): number { return this._snapshots.length; }
 }

--- a/src/net/server-state-sync.ts
+++ b/src/net/server-state-sync.ts
@@ -1,0 +1,65 @@
+import type { GameServer } from './server';
+
+export interface ServerStateSyncOptions<TState> {
+  server: GameServer;
+  tickRate?: number;
+  stateMessage?: string;
+  computeDelta?: (prev: TState, next: TState) => Partial<TState>;
+}
+
+export class ServerStateSync<TState = unknown> {
+  private readonly _server: GameServer;
+  private readonly _tickRate: number;
+  private readonly _stateMessage: string;
+  private readonly _computeDelta: (prev: TState, next: TState) => Partial<TState>;
+  private readonly _entityStates = new Map<string, TState>();
+  private readonly _prevEntityStates = new Map<string, TState>();
+  private _currentTick = 0;
+  private _timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(options: ServerStateSyncOptions<TState>) {
+    this._server = options.server;
+    this._tickRate = options.tickRate ?? 30;
+    this._stateMessage = options.stateMessage ?? 'player.state';
+    this._computeDelta = options.computeDelta ?? ((prev, next) => {
+      const p = prev as Record<string, unknown>;
+      const n = next as Record<string, unknown>;
+      const delta: Record<string, unknown> = {};
+      for (const key of Object.keys(n)) {
+        if (n[key] !== p[key]) delta[key] = n[key];
+      }
+      return delta as Partial<TState>;
+    });
+  }
+
+  setEntityState(id: string, state: TState): void {
+    this._entityStates.set(id, state);
+  }
+
+  start(): void {
+    if (this._timer !== null) return;
+    const intervalMs = Math.round(1000 / this._tickRate);
+    this._timer = setInterval(() => this._tick(), intervalMs);
+  }
+
+  stop(): void {
+    if (this._timer !== null) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  get currentTick(): number { return this._currentTick; }
+
+  private _tick(): void {
+    this._currentTick++;
+    for (const [id, state] of this._entityStates) {
+      const prev = this._prevEntityStates.get(id);
+      const payload: unknown = prev ? this._computeDelta(prev, state) : state;
+      for (const roomId of this._server.rooms.keys()) {
+        this._server.broadcast(roomId, this._stateMessage, { id, tick: this._currentTick, state: payload });
+      }
+      this._prevEntityStates.set(id, JSON.parse(JSON.stringify(state)) as TState);
+    }
+  }
+}

--- a/test/integration/net/state-sync-roundtrip.test.ts
+++ b/test/integration/net/state-sync-roundtrip.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { GameServer } from '../../../src/net/server';
+import { WebSocketTransport } from '../../../src/net/websocket-transport';
+import { NetworkClient } from '../../../src/net/network-client';
+import { ClientStateSync } from '../../../src/net/client-state-sync';
+import { ServerStateSync } from '../../../src/net/server-state-sync';
+
+const PORT = 18975;
+
+function waitForCondition(check: () => boolean, timeout = 4000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const poll = () => {
+      if (check()) { resolve(); return; }
+      if (Date.now() - start > timeout) { reject(new Error('等待超时')); return; }
+      setTimeout(poll, 20);
+    };
+    poll();
+  });
+}
+
+function waitForConnected(transport: WebSocketTransport): Promise<void> {
+  return waitForCondition(() => transport.connected);
+}
+
+describe('State Sync 全链路', { timeout: 20000 }, () => {
+  let server: GameServer;
+  let serverSync: ServerStateSync<{ x: number; y: number; z: number }>;
+
+  beforeAll(async () => {
+    server = new GameServer({ port: PORT });
+    await server.start();
+
+    serverSync = new ServerStateSync({ server, tickRate: 30 });
+
+    // 将客户端 input 映射为服务器权威 entity state
+    server.onMessage((clientId, type, data) => {
+      if (type === 'player.input') {
+        const input = data as { x: number; y: number; z: number };
+        serverSync.setEntityState(clientId, input);
+      }
+    });
+
+    serverSync.start();
+  });
+
+  afterAll(async () => {
+    serverSync.stop();
+    await server.stop();
+  });
+
+  it('客户端 A 发 input，服务器更新，客户端 B 收到 state delta', async () => {
+    const transportA = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+    const transportB = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+
+    const clientA = new NetworkClient(transportA);
+    const clientB = new NetworkClient(transportB);
+
+    transportA.connect('game-room');
+    transportB.connect('game-room');
+    await Promise.all([waitForConnected(transportA), waitForConnected(transportB)]);
+
+    const syncA = new ClientStateSync<{ x: number; y: number; z: number }, unknown>({ client: clientA });
+    const syncB = new ClientStateSync<unknown, { x: number; y: number; z: number }>({ client: clientB });
+
+    const bReceived: Array<{ id: string; tick: number; state: unknown }> = [];
+    syncB.onState((id, tick, state) => bReceived.push({ id, tick, state }));
+
+    // 等连接稳定后发送 input
+    await new Promise(r => setTimeout(r, 100));
+    syncA.sendInput({ x: 10, y: 0, z: 0 });
+
+    // 等服务器处理 input 并广播 tick
+    await waitForCondition(() => bReceived.length > 0, 4000);
+
+    expect(bReceived.length).toBeGreaterThan(0);
+
+    // 找到包含 x=10 的状态消息
+    const match = bReceived.find(r => (r.state as { x?: number }).x === 10);
+    expect(match).toBeDefined();
+    expect(match!.tick).toBeGreaterThan(0);
+
+    transportA.disconnect();
+    transportB.disconnect();
+  });
+
+  it('tick 字段对同一 entity 单调递增', async () => {
+    const transport = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+    const client = new NetworkClient(transport);
+    transport.connect('tick-room');
+    await waitForConnected(transport);
+
+    const sync = new ClientStateSync({ client });
+
+    // 设置一个持续广播的 entity
+    serverSync.setEntityState('monotonic-entity', { x: 0, y: 0, z: 0 });
+
+    const ticksForEntity: number[] = [];
+    sync.onState((id, tick) => {
+      if (id === 'monotonic-entity') ticksForEntity.push(tick);
+    });
+
+    await waitForCondition(() => ticksForEntity.length >= 3, 4000);
+
+    for (let i = 1; i < ticksForEntity.length; i++) {
+      expect(ticksForEntity[i]).toBeGreaterThan(ticksForEntity[i - 1]);
+    }
+
+    transport.disconnect();
+  });
+
+  it('2 个客户端同时接收同一 entity 的广播', async () => {
+    const tA = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+    const tB = new WebSocketTransport({ url: `ws://localhost:${PORT}`, reconnect: false });
+    const cA = new NetworkClient(tA);
+    const cB = new NetworkClient(tB);
+
+    tA.connect('shared-room');
+    tB.connect('shared-room');
+    await Promise.all([waitForConnected(tA), waitForConnected(tB)]);
+
+    const syncA2 = new ClientStateSync({ client: cA });
+    const syncB2 = new ClientStateSync({ client: cB });
+
+    const receivedA: unknown[] = [];
+    const receivedB: unknown[] = [];
+    syncA2.onState((id) => { if (id === 'shared-entity') receivedA.push(id); });
+    syncB2.onState((id) => { if (id === 'shared-entity') receivedB.push(id); });
+
+    serverSync.setEntityState('shared-entity', { x: 5, y: 5, z: 5 });
+
+    await waitForCondition(() => receivedA.length > 0 && receivedB.length > 0, 4000);
+
+    expect(receivedA.length).toBeGreaterThan(0);
+    expect(receivedB.length).toBeGreaterThan(0);
+
+    tA.disconnect();
+    tB.disconnect();
+  });
+});

--- a/test/unit/net/client-state-sync.test.ts
+++ b/test/unit/net/client-state-sync.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ClientStateSync } from '../../../src/net/client-state-sync';
+import { MockNetwork, resetMockNetwork } from '../../../src/net/mock-network';
+import { NetworkClient } from '../../../src/net/network-client';
+
+beforeEach(() => {
+  resetMockNetwork();
+});
+
+describe('ClientStateSync', () => {
+  it('sendInput 向房间内其他节点发送 player.input', () => {
+    const netClient = new MockNetwork();
+    const netServer = new MockNetwork();
+    netClient.connect('room');
+    netServer.connect('room');
+
+    const client = new NetworkClient(netClient);
+    const sync = new ClientStateSync({ client });
+
+    const received: unknown[] = [];
+    netServer.on('player.input', (d) => received.push(d));
+
+    sync.sendInput({ x: 1, y: 0 });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({ x: 1, y: 0 });
+  });
+
+  it('onState 在收到 player.state 时触发回调', () => {
+    const netClient = new MockNetwork();
+    const netServer = new MockNetwork();
+    netClient.connect('room');
+    netServer.connect('room');
+
+    const client = new NetworkClient(netClient);
+    const sync = new ClientStateSync({ client });
+
+    const received: Array<{ id: string; tick: number; state: unknown }> = [];
+    sync.onState((id, tick, state) => received.push({ id, tick, state }));
+
+    netServer.send('player.state', { id: 'e1', tick: 5, state: { x: 3, y: 0, z: 0 } });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].id).toBe('e1');
+    expect(received[0].tick).toBe(5);
+    expect(received[0].state).toEqual({ x: 3, y: 0, z: 0 });
+  });
+
+  it('使用自定义 inputMessage 发送 input', () => {
+    const netClient = new MockNetwork();
+    const netServer = new MockNetwork();
+    netClient.connect('room');
+    netServer.connect('room');
+
+    const client = new NetworkClient(netClient);
+    const sync = new ClientStateSync({ client, inputMessage: 'custom.input' });
+
+    const defaultReceived: unknown[] = [];
+    const customReceived: unknown[] = [];
+    netServer.on('player.input', (d) => defaultReceived.push(d));
+    netServer.on('custom.input', (d) => customReceived.push(d));
+
+    sync.sendInput({ action: 'jump' });
+
+    expect(defaultReceived).toHaveLength(0);
+    expect(customReceived).toHaveLength(1);
+  });
+
+  it('使用自定义 stateMessage 接收 state', () => {
+    const netClient = new MockNetwork();
+    const netServer = new MockNetwork();
+    netClient.connect('room');
+    netServer.connect('room');
+
+    const client = new NetworkClient(netClient);
+    const sync = new ClientStateSync({ client, stateMessage: 'custom.state' });
+
+    const received: Array<{ tick: number }> = [];
+    sync.onState((_, tick) => received.push({ tick }));
+
+    // 默认 player.state 不应触发
+    netServer.send('player.state', { id: 'e1', tick: 1, state: {} });
+    // 自定义 custom.state 才触发
+    netServer.send('custom.state', { id: 'e1', tick: 2, state: { x: 1 } });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].tick).toBe(2);
+  });
+
+  it('多个 onState 回调都触发', () => {
+    const netClient = new MockNetwork();
+    const netServer = new MockNetwork();
+    netClient.connect('room');
+    netServer.connect('room');
+
+    const client = new NetworkClient(netClient);
+    const sync = new ClientStateSync({ client });
+
+    const calls1: string[] = [];
+    const calls2: string[] = [];
+    sync.onState((id) => calls1.push(id));
+    sync.onState((id) => calls2.push(id));
+
+    netServer.send('player.state', { id: 'e1', tick: 1, state: {} });
+
+    expect(calls1).toHaveLength(1);
+    expect(calls2).toHaveLength(1);
+  });
+
+  it('多次 sendInput 每次都发送', () => {
+    const netClient = new MockNetwork();
+    const netServer = new MockNetwork();
+    netClient.connect('room');
+    netServer.connect('room');
+
+    const client = new NetworkClient(netClient);
+    const sync = new ClientStateSync({ client });
+
+    const received: unknown[] = [];
+    netServer.on('player.input', (d) => received.push(d));
+
+    sync.sendInput({ x: 1 });
+    sync.sendInput({ x: 2 });
+    sync.sendInput({ x: 3 });
+
+    expect(received).toHaveLength(3);
+  });
+});

--- a/test/unit/net/interpolator.test.ts
+++ b/test/unit/net/interpolator.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { RemoteEntityInterpolator } from '../../../src/net/interpolator';
+
+describe('RemoteEntityInterpolator — setSnapshot + extrapolate', () => {
+  it('setSnapshot 更新目标位置', () => {
+    const interp = new RemoteEntityInterpolator();
+    interp.setSnapshot(1, 5, 10, 15);
+    expect(interp.targetX).toBe(5);
+    expect(interp.targetY).toBe(10);
+    expect(interp.targetZ).toBe(15);
+  });
+
+  it('setSnapshot 缓冲多个 snapshot', () => {
+    const interp = new RemoteEntityInterpolator();
+    interp.setSnapshot(1, 0, 0, 0);
+    interp.setSnapshot(2, 1, 0, 0);
+    interp.setSnapshot(3, 2, 0, 0);
+    expect(interp.snapshotCount).toBe(3);
+  });
+
+  it('超过最大缓冲数时旧 snapshot 被丢弃，数量不超过 16', () => {
+    const interp = new RemoteEntityInterpolator();
+    for (let i = 0; i < 20; i++) {
+      interp.setSnapshot(i, i, 0, 0);
+    }
+    expect(interp.snapshotCount).toBeLessThanOrEqual(16);
+  });
+
+  it('extrapolate 在两个 snapshot 后沿速度方向外推', () => {
+    // tickRate=30，tick 0→1 表示 1/30 秒内移动 1 单位，速度 = 30 units/s
+    const interp = new RemoteEntityInterpolator(10, 30);
+    interp.setSnapshot(0, 0, 0, 0);
+    interp.setSnapshot(1, 1, 0, 0);
+    const pos = { x: 1, y: 0, z: 0 };
+    interp.extrapolate(0.1, pos); // 30 units/s * 0.1s = 3 units
+    expect(pos.x).toBeCloseTo(4, 1);
+    expect(pos.y).toBe(0);
+    expect(pos.z).toBe(0);
+  });
+
+  it('extrapolate 处理多轴速度', () => {
+    const interp = new RemoteEntityInterpolator(10, 10);
+    interp.setSnapshot(0, 0, 0, 0);
+    interp.setSnapshot(1, 1, 2, 3); // 速度: x=10, y=20, z=30 units/s
+    const pos = { x: 0, y: 0, z: 0 };
+    interp.extrapolate(0.1, pos);
+    expect(pos.x).toBeCloseTo(1, 5);
+    expect(pos.y).toBeCloseTo(2, 5);
+    expect(pos.z).toBeCloseTo(3, 5);
+  });
+
+  it('只有一个 snapshot 时 extrapolate 不移动（无速度）', () => {
+    const interp = new RemoteEntityInterpolator();
+    interp.setSnapshot(1, 5, 5, 5);
+    const pos = { x: 5, y: 5, z: 5 };
+    interp.extrapolate(1.0, pos);
+    expect(pos.x).toBe(5);
+    expect(pos.y).toBe(5);
+    expect(pos.z).toBe(5);
+  });
+
+  it('setSnapshot 后 update 仍然有效（lerp 到目标）', () => {
+    const interp = new RemoteEntityInterpolator(10);
+    interp.setSnapshot(1, 10, 0, 0);
+    const pos = { x: 0, y: 0, z: 0 };
+    interp.update(0.1, pos);
+    expect(pos.x).toBeGreaterThan(0);
+    expect(pos.x).toBeLessThan(10);
+  });
+
+  it('setSnapshot 与 setTarget 均更新 targetX/Y/Z', () => {
+    const interp = new RemoteEntityInterpolator();
+    interp.setTarget(1, 2, 3);
+    expect(interp.targetX).toBe(1);
+    interp.setSnapshot(5, 7, 8, 9);
+    expect(interp.targetX).toBe(7);
+    expect(interp.targetY).toBe(8);
+    expect(interp.targetZ).toBe(9);
+  });
+});

--- a/test/unit/net/server-state-sync.test.ts
+++ b/test/unit/net/server-state-sync.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ServerStateSync } from '../../../src/net/server-state-sync';
+import type { GameServer } from '../../../src/net/server';
+
+function createMockServer(initialRooms: Record<string, string[]> = {}) {
+  const rooms = new Map<string, Set<string>>(
+    Object.entries(initialRooms).map(([k, v]) => [k, new Set(v)])
+  );
+  return {
+    broadcast: vi.fn(),
+    rooms,
+    addRoom(roomId: string, clients: string[] = []) {
+      rooms.set(roomId, new Set(clients));
+    },
+  } as unknown as GameServer & { broadcast: ReturnType<typeof vi.fn>; addRoom: (r: string, c?: string[]) => void };
+}
+
+describe('ServerStateSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('初始 currentTick 为 0', () => {
+    const server = createMockServer();
+    const sync = new ServerStateSync({ server });
+    expect(sync.currentTick).toBe(0);
+  });
+
+  it('start 后每个 tick 周期递增 currentTick', () => {
+    const server = createMockServer();
+    const sync = new ServerStateSync({ server, tickRate: 30 });
+    sync.start();
+    vi.advanceTimersByTime(Math.ceil(1000 / 30));
+    expect(sync.currentTick).toBe(1);
+    vi.advanceTimersByTime(Math.ceil(1000 / 30));
+    expect(sync.currentTick).toBe(2);
+    sync.stop();
+  });
+
+  it('stop 后不再递增 tick', () => {
+    const server = createMockServer();
+    const sync = new ServerStateSync({ server, tickRate: 30 });
+    sync.start();
+    vi.advanceTimersByTime(Math.ceil(1000 / 30));
+    expect(sync.currentTick).toBe(1);
+    sync.stop();
+    vi.advanceTimersByTime(1000);
+    expect(sync.currentTick).toBe(1);
+  });
+
+  it('重复调用 start 不会启动多个 timer', () => {
+    const server = createMockServer();
+    const sync = new ServerStateSync({ server, tickRate: 30 });
+    sync.start();
+    sync.start(); // 重复调用
+    vi.advanceTimersByTime(Math.ceil(1000 / 30));
+    expect(sync.currentTick).toBe(1); // 只递增一次
+    sync.stop();
+  });
+
+  it('setEntityState 后 tick 时广播到所有房间', () => {
+    const server = createMockServer();
+    server.addRoom('room1', ['c1']);
+    server.addRoom('room2', ['c2']);
+    const sync = new ServerStateSync({ server, tickRate: 30 });
+    sync.setEntityState('e1', { x: 1, y: 2, z: 3 });
+    sync.start();
+    vi.advanceTimersByTime(Math.ceil(1000 / 30));
+    expect(server.broadcast).toHaveBeenCalledWith(
+      'room1', 'player.state', expect.objectContaining({ id: 'e1', tick: 1 })
+    );
+    expect(server.broadcast).toHaveBeenCalledWith(
+      'room2', 'player.state', expect.objectContaining({ id: 'e1', tick: 1 })
+    );
+    sync.stop();
+  });
+
+  it('第一次 tick 广播完整 state（无 prev）', () => {
+    const server = createMockServer({ room1: ['c1'] });
+    const sync = new ServerStateSync({ server, tickRate: 30 });
+    sync.setEntityState('e1', { x: 5, y: 3, z: 0 });
+    sync.start();
+    vi.advanceTimersByTime(Math.ceil(1000 / 30));
+    const arg = (server.broadcast as ReturnType<typeof vi.fn>).mock.calls[0][2] as { state: unknown };
+    expect(arg.state).toEqual({ x: 5, y: 3, z: 0 });
+    sync.stop();
+  });
+
+  it('第二次 tick 广播 delta（只有变化字段）', () => {
+    const server = createMockServer({ room1: ['c1'] });
+    const sync = new ServerStateSync<{ x: number; y: number; z: number }>({ server, tickRate: 30 });
+    sync.setEntityState('e1', { x: 0, y: 0, z: 0 });
+    sync.start();
+    vi.advanceTimersByTime(Math.ceil(1000 / 30)); // tick 1: 完整 state
+    sync.setEntityState('e1', { x: 5, y: 0, z: 0 }); // 仅 x 变化
+    vi.advanceTimersByTime(Math.ceil(1000 / 30)); // tick 2: delta
+    const calls = (server.broadcast as ReturnType<typeof vi.fn>).mock.calls;
+    const tick2Arg = calls[calls.length - 1][2] as { state: Partial<{ x: number; y: number; z: number }> };
+    expect(tick2Arg.state).toEqual({ x: 5 });
+    sync.stop();
+  });
+
+  it('state 无变化时广播空 delta', () => {
+    const server = createMockServer({ r: ['c1'] });
+    const sync = new ServerStateSync<{ x: number }>({ server, tickRate: 30 });
+    sync.setEntityState('e1', { x: 1 });
+    sync.start();
+    vi.advanceTimersByTime(Math.ceil(1000 / 30)); // tick 1
+    vi.advanceTimersByTime(Math.ceil(1000 / 30)); // tick 2: 无变化
+    const calls = (server.broadcast as ReturnType<typeof vi.fn>).mock.calls;
+    const tick2Arg = calls[calls.length - 1][2] as { state: unknown };
+    expect(tick2Arg.state).toEqual({});
+    sync.stop();
+  });
+
+  it('广播消息包含 tick 字段单调递增', () => {
+    const server = createMockServer({ r: ['c1'] });
+    const sync = new ServerStateSync({ server, tickRate: 30 });
+    sync.setEntityState('e1', { v: 1 });
+    sync.start();
+    for (let i = 0; i < 3; i++) {
+      vi.advanceTimersByTime(Math.ceil(1000 / 30));
+    }
+    const calls = (server.broadcast as ReturnType<typeof vi.fn>).mock.calls;
+    const ticks = calls.map(c => (c[2] as { tick: number }).tick);
+    for (let i = 1; i < ticks.length; i++) {
+      expect(ticks[i]).toBeGreaterThan(ticks[i - 1]);
+    }
+    sync.stop();
+  });
+
+  it('支持自定义 computeDelta', () => {
+    const server = createMockServer({ r: ['c1'] });
+    const customDelta = vi.fn((_prev: { x: number }, next: { x: number }) => ({ x: next.x * 2 }));
+    const sync = new ServerStateSync<{ x: number }>({ server, tickRate: 30, computeDelta: customDelta });
+    sync.setEntityState('e1', { x: 1 });
+    sync.start();
+    vi.advanceTimersByTime(Math.ceil(1000 / 30)); // tick 1: 无 prev，不调用 computeDelta
+    sync.setEntityState('e1', { x: 2 });
+    vi.advanceTimersByTime(Math.ceil(1000 / 30)); // tick 2: 调用 computeDelta
+    expect(customDelta).toHaveBeenCalled();
+    const calls = (server.broadcast as ReturnType<typeof vi.fn>).mock.calls;
+    const lastArg = calls[calls.length - 1][2] as { state: { x: number } };
+    expect(lastArg.state.x).toBe(4); // 自定义 delta: x * 2
+    sync.stop();
+  });
+
+  it('无 entity 时不广播', () => {
+    const server = createMockServer({ r: ['c1'] });
+    const sync = new ServerStateSync({ server, tickRate: 30 });
+    sync.start();
+    vi.advanceTimersByTime(Math.ceil(1000 / 30));
+    expect(server.broadcast).not.toHaveBeenCalled();
+    sync.stop();
+  });
+});


### PR DESCRIPTION
## 变更摘要

- **`src/net/client-state-sync.ts`**（新增）：`ClientStateSync` — 客户端发 `sendInput`、注册 `onState` 接收服务器权威 state，tick 字段单调递增
- **`src/net/server-state-sync.ts`**（新增）：`ServerStateSync` — 按 `tickRate` (默认 30 Hz) 驱动 tick loop，广播 entity delta（浅比较，只广播变化字段），支持自定义 `computeDelta`
- **`src/net/interpolator.ts`**（扩展）：`RemoteEntityInterpolator` 新增 `setSnapshot(tick, x, y, z)` 缓冲最多 16 帧快照 + `extrapolate(dt, current)` 基于帧间速度外推

## 测试覆盖

| 文件 | 测试数 | 说明 |
|------|--------|------|
| `test/unit/net/client-state-sync.test.ts` | 6 | sendInput / onState / 自定义消息名 |
| `test/unit/net/server-state-sync.test.ts` | 11 | tick 递增 / delta 广播 / stop / 自定义 computeDelta |
| `test/unit/net/interpolator.test.ts` | 8 | setSnapshot buffer / extrapolate 速度外推 |
| `test/integration/net/state-sync-roundtrip.test.ts` | 3 | 全链路：2 客户端 + 真实 WebSocket 服务器 |

全量回归：175 测试文件，2326 tests 全部通过。

close #413