### PR TITLE
feat: Phase 57 KR3 — Lockstep 帧同步

### DIFF
--- a/src/net/lockstep.ts
+++ b/src/net/lockstep.ts
@@ -3,11 +3,7 @@
  *
  * 确定性帧同步客户端 — 每 tick 广播本地 input，收齐所有 peer 的同 tick input 后推进 simulation。
  * 适合 RTS / 格斗 / 棋牌（peer-to-peer 无需服务器权威）。
- *
- * STUB — 本文件为 Architect 预写占位，等 Forge 实现。
  */
-
-export const __STUB__ = true;
 
 import type { NetworkClient } from './network-client';
 
@@ -24,33 +20,75 @@ export interface LockstepStepResult<TInput> {
   inputs: ReadonlyMap<string, TInput>;
 }
 
+interface InputMsg<TInput> {
+  tick: number;
+  playerId: string;
+  input: TInput;
+}
+
 export class LockstepClient<TInput = unknown> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  constructor(_options: LockstepClientOptions<TInput>) {
-    throw new Error('LockstepClient not implemented (stub)');
+  private _client: NetworkClient;
+  private _localPlayerId: string;
+  private _expectedPeerCount: number;
+  private _inputMessage: string;
+  private _currentTick = 0;
+  private _submitTick = 1;
+  private _stalled = false;
+  private _pendingInputs = new Map<number, Map<string, TInput>>();
+  private _stepHandlers: Array<(tick: number, inputs: ReadonlyMap<string, TInput>) => void> = [];
+
+  constructor(options: LockstepClientOptions<TInput>) {
+    this._client = options.client;
+    this._localPlayerId = options.localPlayerId;
+    this._expectedPeerCount = options.expectedPeerCount;
+    this._inputMessage = options.inputMessage ?? 'lockstep.input';
+
+    this._client.on(this._inputMessage, (data) => {
+      const msg = data as InputMsg<TInput>;
+      if (!this._pendingInputs.has(msg.tick)) {
+        this._pendingInputs.set(msg.tick, new Map());
+      }
+      this._pendingInputs.get(msg.tick)!.set(msg.playerId, msg.input);
+    });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  submitInput(_input: TInput): void {
-    throw new Error('Not implemented (stub)');
+  submitInput(input: TInput): void {
+    const tick = this._submitTick++;
+    if (!this._pendingInputs.has(tick)) {
+      this._pendingInputs.set(tick, new Map());
+    }
+    this._pendingInputs.get(tick)!.set(this._localPlayerId, input);
+    this._client.send(this._inputMessage, {
+      tick,
+      playerId: this._localPlayerId,
+      input,
+    });
   }
 
   tryStep(): LockstepStepResult<TInput> | null {
-    throw new Error('Not implemented (stub)');
+    const nextTick = this._currentTick + 1;
+    const inputs = this._pendingInputs.get(nextTick);
+    if (!inputs || inputs.size < this._expectedPeerCount) {
+      this._stalled = true;
+      return null;
+    }
+    this._stalled = false;
+    this._currentTick = nextTick;
+    const result: LockstepStepResult<TInput> = {
+      tick: nextTick,
+      inputs: new Map(inputs) as ReadonlyMap<string, TInput>,
+    };
+    this._pendingInputs.delete(nextTick);
+    for (const h of this._stepHandlers) h(result.tick, result.inputs);
+    return result;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  onStep(_handler: (tick: number, inputs: ReadonlyMap<string, TInput>) => void): void {
-    throw new Error('Not implemented (stub)');
+  onStep(handler: (tick: number, inputs: ReadonlyMap<string, TInput>) => void): void {
+    this._stepHandlers.push(handler);
   }
 
-  get currentTick(): number {
-    throw new Error('Not implemented (stub)');
-  }
-
-  get stalled(): boolean {
-    throw new Error('Not implemented (stub)');
-  }
+  get currentTick(): number { return this._currentTick; }
+  get stalled(): boolean { return this._stalled; }
 }
 
 export function createLockstepClient<TInput>(

--- a/src/net/mock-network.ts
+++ b/src/net/mock-network.ts
@@ -44,6 +44,10 @@ export class MockNetwork implements INetworkTransport {
     this._listeners.get(type)?.delete(handler);
   }
 
+  createTransport(_playerId: string): INetworkTransport {
+    return new MockNetwork();
+  }
+
   _deliver(type: string, data: unknown): void {
     const handlers = this._listeners.get(type);
     if (!handlers) return;

--- a/test/integration/net/lockstep-roundtrip.test.ts
+++ b/test/integration/net/lockstep-roundtrip.test.ts
@@ -10,7 +10,7 @@ import { WebSocketTransport } from '../../../src/net/websocket-transport';
 import { NetworkClient } from '../../../src/net/network-client';
 import { createLockstepClient } from '../../../src/net/lockstep';
 
-const PORT = 18975;
+const PORT = 18976;
 const BASE_URL = `ws://localhost:${PORT}`;
 
 function waitForConnected(transport: WebSocketTransport, timeout = 5000): Promise<void> {

--- a/test/integration/net/lockstep-roundtrip.test.ts
+++ b/test/integration/net/lockstep-roundtrip.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Phase 57 KR3 — Lockstep 集成测试
+ *
+ * 起 GameServer 做 input relay，验证多客户端锁步同步行为。
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { GameServer } from '../../../src/net/server';
+import { WebSocketTransport } from '../../../src/net/websocket-transport';
+import { NetworkClient } from '../../../src/net/network-client';
+import { createLockstepClient } from '../../../src/net/lockstep';
+
+const PORT = 18975;
+const BASE_URL = `ws://localhost:${PORT}`;
+
+function waitForConnected(transport: WebSocketTransport, timeout = 5000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      if (transport.connected) { resolve(); return; }
+      if (Date.now() - start > timeout) { reject(new Error('连接超时')); return; }
+      setTimeout(check, 10);
+    };
+    check();
+  });
+}
+
+function pollUntil(condition: () => boolean, timeout = 5000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      if (condition()) { resolve(); return; }
+      if (Date.now() - start > timeout) { reject(new Error('轮询超时')); return; }
+      setTimeout(check, 20);
+    };
+    check();
+  });
+}
+
+describe('LockstepClient 集成测试 — GameServer input relay', { timeout: 15000 }, () => {
+  let server: GameServer;
+
+  beforeAll(async () => {
+    server = new GameServer({ port: PORT });
+    await server.start();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  it('三客户端同时 submitInput → 三方都收到 step 触发', async () => {
+    const tA = new WebSocketTransport({ url: BASE_URL, reconnect: false });
+    const tB = new WebSocketTransport({ url: BASE_URL, reconnect: false });
+    const tC = new WebSocketTransport({ url: BASE_URL, reconnect: false });
+
+    const cA = new NetworkClient(tA);
+    const cB = new NetworkClient(tB);
+    const cC = new NetworkClient(tC);
+
+    cA.connect('room-all-three');
+    cB.connect('room-all-three');
+    cC.connect('room-all-three');
+
+    await Promise.all([waitForConnected(tA), waitForConnected(tB), waitForConnected(tC)]);
+
+    const lsA = createLockstepClient<{ n: number }>({
+      client: cA, localPlayerId: 'pA', expectedPeerCount: 3,
+    });
+    const lsB = createLockstepClient<{ n: number }>({
+      client: cB, localPlayerId: 'pB', expectedPeerCount: 3,
+    });
+    const lsC = createLockstepClient<{ n: number }>({
+      client: cC, localPlayerId: 'pC', expectedPeerCount: 3,
+    });
+
+    let aOk = false, bOk = false, cOk = false;
+    lsA.onStep(() => { aOk = true; });
+    lsB.onStep(() => { bOk = true; });
+    lsC.onStep(() => { cOk = true; });
+
+    lsA.submitInput({ n: 1 });
+    lsB.submitInput({ n: 2 });
+    lsC.submitInput({ n: 3 });
+
+    await pollUntil(() => {
+      if (!aOk) lsA.tryStep();
+      if (!bOk) lsB.tryStep();
+      if (!cOk) lsC.tryStep();
+      return aOk && bOk && cOk;
+    });
+
+    expect(lsA.currentTick).toBe(1);
+    expect(lsB.currentTick).toBe(1);
+    expect(lsC.currentTick).toBe(1);
+
+    tA.disconnect();
+    tB.disconnect();
+    tC.disconnect();
+  });
+
+  it('客户端 A 延迟 200ms submitInput → 其他客户端 stall → 收到后恢复', async () => {
+    const tA = new WebSocketTransport({ url: BASE_URL, reconnect: false });
+    const tB = new WebSocketTransport({ url: BASE_URL, reconnect: false });
+    const tC = new WebSocketTransport({ url: BASE_URL, reconnect: false });
+
+    const cA = new NetworkClient(tA);
+    const cB = new NetworkClient(tB);
+    const cC = new NetworkClient(tC);
+
+    cA.connect('room-stall-test');
+    cB.connect('room-stall-test');
+    cC.connect('room-stall-test');
+
+    await Promise.all([waitForConnected(tA), waitForConnected(tB), waitForConnected(tC)]);
+
+    const lsA = createLockstepClient<{ x: number }>({
+      client: cA, localPlayerId: 'pA', expectedPeerCount: 3,
+    });
+    const lsB = createLockstepClient<{ x: number }>({
+      client: cB, localPlayerId: 'pB', expectedPeerCount: 3,
+    });
+    const lsC = createLockstepClient<{ x: number }>({
+      client: cC, localPlayerId: 'pC', expectedPeerCount: 3,
+    });
+
+    // B 和 C 提交，A 故意延迟
+    lsB.submitInput({ x: 2 });
+    lsC.submitInput({ x: 3 });
+
+    // 等待 B 和 C 彼此收到对方的 input（网络传递）
+    await new Promise((r) => setTimeout(r, 200));
+
+    // B 和 C 应该 stall（等待 A）
+    expect(lsB.tryStep()).toBeNull();
+    expect(lsB.stalled).toBe(true);
+    expect(lsC.tryStep()).toBeNull();
+    expect(lsC.stalled).toBe(true);
+
+    // A 延迟后提交
+    lsA.submitInput({ x: 1 });
+
+    // 等待 B 和 C 收到 A 的 input 并恢复
+    let bOk = false, cOk = false;
+    lsB.onStep(() => { bOk = true; });
+    lsC.onStep(() => { cOk = true; });
+
+    await pollUntil(() => {
+      if (!bOk) lsB.tryStep();
+      if (!cOk) lsC.tryStep();
+      return bOk && cOk;
+    });
+
+    expect(lsB.stalled).toBe(false);
+    expect(lsC.stalled).toBe(false);
+
+    tA.disconnect();
+    tB.disconnect();
+    tC.disconnect();
+  });
+});


### PR DESCRIPTION
## 概述

实现 `src/net/lockstep.ts` 确定性帧同步模块（Phase 57 KR3）。

## 变更内容

### `src/net/lockstep.ts`（stub → 完整实现）
- `LockstepClient<TInput>` — 收齐所有 peer 的同 tick 输入后推进 simulation
- `submitInput(input)` — 使用独立 `_submitTick` 计数器，每次调用提交下一个 tick，不依赖 `currentTick`（支持多方不同步 tryStep 的场景）
- `tryStep()` — 检查 nextTick 是否已收齐所有 peer 输入；成功则推进 currentTick、触发 onStep 回调；缺输入则 stalled=true 返回 null
- `onStep(handler)` — 注册 tick 推进回调
- `createLockstepClient(options)` — 工厂函数

### `src/net/mock-network.ts`
- 新增 `createTransport(playerId): INetworkTransport` 工厂方法，返回新的 MockNetwork 实例（单元测试需要）

### `test/integration/net/lockstep-roundtrip.test.ts`（新文件）
- 起 GameServer 做 input relay + 3 WebSocket 客户端
- 测试三方同时 submitInput → 三方都能 step
- 测试客户端 A 延迟 200ms → 其他客户端 stall → A 提交后恢复

## 测试结果

- `test/unit/net/lockstep.test.ts` — 11/11 ✅
- `test/integration/net/lockstep-roundtrip.test.ts` — 2/2 ✅
- 全量 `vitest run` — 2311/2311 ✅

Closes #414