### PR TITLE
feat: Phase 57 KR4 — br-12p 真 WebSocket 12 客户端 30s 压测

### DIFF
--- a/examples/br-12p/package.json
+++ b/examples/br-12p/package.json
@@ -7,12 +7,14 @@
     "build": "vite build",
     "test": "vitest run",
     "test:visual": "playwright test --config playwright.config.ts",
-    "test:visual:update": "playwright test --config playwright.config.ts --update-snapshots"
+    "test:visual:update": "playwright test --config playwright.config.ts --update-snapshots",
+    "server:start": "BR_PORT=8080 npx vite-node server/index.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",
     "typescript": "^5.8.0",
     "vite": "^6.3.0",
-    "vitest": "^3.1.0"
+    "vitest": "^3.1.0",
+    "ws": "^8.20.0"
   }
 }

--- a/examples/br-12p/playwright.config.ts
+++ b/examples/br-12p/playwright.config.ts
@@ -14,6 +14,10 @@ const systemChromium = resolve(
 );
 const executablePath = existsSync(systemChromium) ? systemChromium : undefined;
 
+// 视觉测试用服务端口（独立于生产 8080，避免冲突）
+const SERVER_PORT = 18080;
+const VITE_PORT = 5174;
+
 export default defineConfig({
   testDir: './test/visual',
   timeout: 60_000,
@@ -24,7 +28,7 @@ export default defineConfig({
     },
   },
   use: {
-    baseURL: 'http://localhost:5174',
+    baseURL: `http://localhost:${VITE_PORT}`,
     browserName: 'chromium',
     headless: true,
     launchOptions: {
@@ -39,11 +43,21 @@ export default defineConfig({
     },
     viewport: { width: 800, height: 600 },
   },
-  webServer: {
-    command: 'npx vite --port 5174',
-    url: 'http://localhost:5174',
-    reuseExistingServer: true,
-    timeout: 30_000,
-  },
+  webServer: [
+    {
+      // 游戏服务器（消息中继）
+      command: `BR_PORT=${SERVER_PORT} npx vite-node server/index.ts`,
+      port: SERVER_PORT,
+      reuseExistingServer: true,
+      timeout: 15_000,
+    },
+    {
+      // Vite 前端开发服务器
+      command: `npx vite --port ${VITE_PORT}`,
+      url: `http://localhost:${VITE_PORT}`,
+      reuseExistingServer: true,
+      timeout: 30_000,
+    },
+  ],
   snapshotPathTemplate: '{testDir}/baselines/{testName}{ext}',
 });

--- a/examples/br-12p/server/index.ts
+++ b/examples/br-12p/server/index.ts
@@ -1,0 +1,74 @@
+/**
+ * server/index.ts — BR-12P 游戏服务器。
+ * 使用引擎 GameServer 实现 12 人房间消息中继。
+ * 启动：npx vite-node server/index.ts 或 pnpm --filter br-12p server:start
+ */
+
+import { GameServer } from '../../../src/net/server';
+import { ServerStateSync } from '../../../src/net/server-state-sync';
+
+const PORT = Number(process.env.BR_PORT ?? 8080);
+const ROOM = 'br-12p';
+const MAX_CLIENTS = 12;
+
+interface PlayerState {
+  id: string;
+  position: { x: number; y: number; z: number };
+  rotation: number;
+  health: number;
+}
+
+async function main(): Promise<void> {
+  const server = new GameServer({ port: PORT, maxClientsPerRoom: MAX_CLIENTS });
+
+  // 服务端权威状态追踪（delta 广播）
+  const stateSync = new ServerStateSync<PlayerState>({
+    server,
+    tickRate: 20,
+    stateMessage: 'server.state',
+  });
+
+  server.onClientJoin((clientId, roomId) => {
+    if (roomId === ROOM) {
+      console.log(`[br-12p] 玩家连入 ${clientId} (房间: ${roomId}，当前: ${server.clientCount})`);
+    }
+  });
+
+  server.onClientLeave((clientId, roomId) => {
+    if (roomId === ROOM) {
+      console.log(`[br-12p] 玩家离开 ${clientId} (剩余: ${server.clientCount})`);
+    }
+  });
+
+  // 监听客户端上报的玩家状态，更新服务端权威副本
+  server.onMessage((clientId, type, data) => {
+    if (type === 'player.state') {
+      const msg = data as { id: string; position: { x: number; y: number; z: number }; rotation: number; health: number };
+      if (msg?.id) {
+        stateSync.setEntityState(msg.id, {
+          id: msg.id,
+          position: msg.position,
+          rotation: msg.rotation,
+          health: msg.health,
+        });
+      }
+    }
+  });
+
+  await server.start();
+  stateSync.start();
+
+  console.log(`[br-12p] 服务器已启动 → ws://localhost:${PORT}  (room=${ROOM}，最多${MAX_CLIENTS}人)`);
+
+  process.on('SIGINT', async () => {
+    stateSync.stop();
+    await server.stop();
+    console.log('[br-12p] 服务器已关闭');
+    process.exit(0);
+  });
+}
+
+main().catch((err) => {
+  console.error('[br-12p] 服务器启动失败:', err);
+  process.exit(1);
+});

--- a/examples/br-12p/src/game.ts
+++ b/examples/br-12p/src/game.ts
@@ -66,6 +66,9 @@ export class Game {
   /** 已运行帧数（供测试读取） */
   frameCount = 0;
 
+  /** 外部每帧回调（供网络层注册） */
+  private _externalUpdateCbs: Array<(dt: number) => void> = [];
+
   /** 场景中可渲染节点数量的估算（headless 代理 drawCalls） */
   private _drawCallCount = 0;
 
@@ -198,7 +201,13 @@ export class Game {
       this._input.update();  // 清除 keysPressed
     }
 
+    for (const cb of this._externalUpdateCbs) cb(dt);
     this.frameCount++;
+  }
+
+  /** 注册每帧回调（供网络层注册，不影响 headless 测试） */
+  addUpdateCallback(cb: (dt: number) => void): void {
+    this._externalUpdateCbs.push(cb);
   }
 
   private _render(): void {

--- a/examples/br-12p/src/main.ts
+++ b/examples/br-12p/src/main.ts
@@ -1,10 +1,13 @@
 /**
  * main.ts — BR-12P 游戏入口。
- * 初始化 Canvas，创建 Game 并启动循环。
+ * 初始化 Canvas，创建 Game，连接 WebSocket 服务器，启动循环。
  */
 
 import { Game } from './game';
 import { vec3 } from '../../../src/math/vec3';
+import { WsGameNetwork } from './net/ws-game-network';
+import { StateSync } from './net/state-sync';
+import { NetworkClient } from './net/network-client';
 
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 canvas.width = window.innerWidth;
@@ -16,10 +19,35 @@ window.addEventListener('resize', () => {
 });
 
 const game = new Game(canvas);
-(window as any).__game = game;  // 调试用
+(window as any).__game = game;
 
-// 生成 11 个 AI 敌人
+// 生成 11 个 AI 敌人（供视觉回归测试用）
 game.spawnEnemies(11);
+
+// 网络层：连接服务器（连接失败时静默降级，游戏仍可单机运行）
+const localId = 'player-' + Math.random().toString(36).slice(2, 8);
+const net = new WsGameNetwork('ws://localhost:8080');
+const sync = new StateSync(net, localId);
+const client = new NetworkClient(net, sync, localId, '本地玩家');
+
+client.bindLocalState(
+  () => { const p = game.player.position; return { x: p[0], y: p[1], z: p[2] }; },
+  () => game.fpsCamera.yaw,
+  () => game.playerHealth.current,
+);
+
+net.connect();
+
+// 连接成功后发送 join 消息
+const checkConnected = setInterval(() => {
+  if (net.isConnected) {
+    clearInterval(checkConnected);
+    client.join();
+  }
+}, 100);
+
+// 每帧更新网络
+game.addUpdateCallback((dt) => client.update(dt));
 
 // 鼠标左键射击
 canvas.addEventListener('click', () => {
@@ -27,6 +55,14 @@ canvas.addEventListener('click', () => {
   const origin = vec3(cam.position[0], cam.position[1], cam.position[2]);
   const dir = game.fpsCamera.getViewDirection();
   game.weapon.fire(origin, dir);
+
+  // 广播射击事件
+  if (net.isConnected) {
+    client.fire(
+      { x: origin[0], y: origin[1], z: origin[2] },
+      { x: dir[0], y: dir[1], z: dir[2] },
+    );
+  }
 });
 
 game.start();

--- a/examples/br-12p/src/net/game-network.ts
+++ b/examples/br-12p/src/net/game-network.ts
@@ -1,0 +1,11 @@
+import type { NetworkMessage, MessageType } from './message-protocol';
+
+/** br-12p 游戏网络层接口 — MockNetwork 和 WsGameNetwork 均实现此接口 */
+export interface IGameNetwork {
+  readonly isConnected: boolean;
+  connect(): void;
+  disconnect(): void;
+  send(msg: NetworkMessage): void;
+  on<K extends MessageType>(type: K, handler: (msg: NetworkMessage & { type: K }) => void): void;
+  off<K extends MessageType>(type: K, handler: (msg: NetworkMessage & { type: K }) => void): void;
+}

--- a/examples/br-12p/src/net/mock-network.ts
+++ b/examples/br-12p/src/net/mock-network.ts
@@ -8,6 +8,7 @@ import {
   createMockNetwork as _create,
   resetMockNetwork as _reset,
 } from '../../../../src/net/mock-network';
+import type { IGameNetwork } from './game-network';
 import type { NetworkMessage, MessageType } from './message-protocol';
 
 const GAME_ROOM = 'br-12p';
@@ -21,7 +22,7 @@ export function resetMockNetwork(): void {
  * MockNetwork — 游戏专用网络封装。
  * 将引擎的 INetworkTransport 适配为游戏消息协议 API。
  */
-export class MockNetwork {
+export class MockNetwork implements IGameNetwork {
   private readonly _net: _EngineMockNetwork;
   private _connected = false;
 

--- a/examples/br-12p/src/net/network-client.ts
+++ b/examples/br-12p/src/net/network-client.ts
@@ -3,7 +3,7 @@
  * 负责将本地玩家状态广播出去，以及处理玩家自身受到的网络命中事件。
  */
 
-import type { MockNetwork } from './mock-network';
+import type { IGameNetwork } from './game-network';
 import type { StateSync } from './state-sync';
 import type { PlayerHitMsg } from './message-protocol';
 
@@ -12,7 +12,7 @@ const STATE_SEND_HZ = 10;
 const STATE_SEND_INTERVAL = 1 / STATE_SEND_HZ;
 
 export class NetworkClient {
-  private readonly _net: MockNetwork;
+  private readonly _net: IGameNetwork;
   private readonly _sync: StateSync;
   readonly localId: string;
   readonly localName: string;
@@ -27,7 +27,7 @@ export class NetworkClient {
   /** 本地受到命中的回调（供 Game 注册） */
   private _onLocalHit?: (attackerId: string, damage: number) => void;
 
-  constructor(net: MockNetwork, sync: StateSync, id: string, name: string) {
+  constructor(net: IGameNetwork, sync: StateSync, id: string, name: string) {
     this._net = net;
     this._sync = sync;
     this.localId = id;

--- a/examples/br-12p/src/net/state-sync.ts
+++ b/examples/br-12p/src/net/state-sync.ts
@@ -4,7 +4,7 @@
  */
 
 import { RemotePlayer } from './remote-player';
-import type { MockNetwork } from './mock-network';
+import type { IGameNetwork } from './game-network';
 import type {
   PlayerJoinMsg,
   PlayerLeaveMsg,
@@ -26,7 +26,7 @@ export type StateSyncEvents = {
  */
 export class StateSync {
   private readonly _players = new Map<string, RemotePlayer>();
-  private readonly _net: MockNetwork;
+  private readonly _net: IGameNetwork;
   /** 本地玩家 ID，收到自己的消息时忽略 */
   private readonly _localId: string;
 
@@ -34,7 +34,7 @@ export class StateSync {
   private _onLeft?: (id: string) => void;
   private _onFired?: (id: string, origin: { x: number; y: number; z: number }, direction: { x: number; y: number; z: number }, weaponId: string) => void;
 
-  constructor(net: MockNetwork, localId = '') {
+  constructor(net: IGameNetwork, localId = '') {
     this._net = net;
     this._localId = localId;
     this._registerHandlers();

--- a/examples/br-12p/src/net/ws-game-network.ts
+++ b/examples/br-12p/src/net/ws-game-network.ts
@@ -1,0 +1,51 @@
+/**
+ * ws-game-network.ts — 真 WebSocket 游戏网络适配器。
+ * 使用引擎 WebSocketTransport，将 br-12p 消息协议适配到 IGameNetwork 接口。
+ * 浏览器和 Node.js 24+ 均可用。
+ */
+
+import { WebSocketTransport } from '../../../../src/net/websocket-transport';
+import type { IGameNetwork } from './game-network';
+import type { NetworkMessage, MessageType } from './message-protocol';
+
+const ROOM_ID = 'br-12p';
+
+export class WsGameNetwork implements IGameNetwork {
+  private readonly _transport: WebSocketTransport;
+  private readonly _handlerMap = new Map<Function, (data: unknown) => void>();
+
+  constructor(url: string) {
+    this._transport = new WebSocketTransport({ url, reconnect: false });
+  }
+
+  get isConnected(): boolean {
+    return this._transport.connected;
+  }
+
+  connect(): void {
+    this._transport.connect(ROOM_ID);
+  }
+
+  disconnect(): void {
+    this._transport.disconnect();
+  }
+
+  /** 发送游戏消息：以 msg.type 为消息类型，msg 整体为 data */
+  send(msg: NetworkMessage): void {
+    this._transport.send(msg.type, msg);
+  }
+
+  on<K extends MessageType>(type: K, handler: (msg: NetworkMessage & { type: K }) => void): void {
+    const wrapped = (data: unknown) => handler(data as NetworkMessage & { type: K });
+    this._handlerMap.set(handler, wrapped);
+    this._transport.on(type, wrapped);
+  }
+
+  off<K extends MessageType>(type: K, handler: (msg: NetworkMessage & { type: K }) => void): void {
+    const wrapped = this._handlerMap.get(handler);
+    if (wrapped) {
+      this._transport.off(type, wrapped);
+      this._handlerMap.delete(handler);
+    }
+  }
+}

--- a/examples/br-12p/test/integration/full-game-network.test.ts
+++ b/examples/br-12p/test/integration/full-game-network.test.ts
@@ -1,0 +1,532 @@
+/**
+ * full-game-network.test.ts — M7 KR4 真 WebSocket 12 客户端 30s 压测。
+ *
+ * 验收目标：
+ * - 12 客户端（1 本地 Game + 11 原始 WS）连接同一 Room
+ * - 1800 帧（30s @ 60fps）无崩溃无异常
+ * - drawCalls ≤ 60（vs M4.6 基线不退化）
+ * - 至少 1 远程玩家死亡消息经服务器广播验证
+ * - 11 个 RemotePlayer mixer.time ≈ 30s
+ * - 断开后 server.clientCount === 0（无连接泄漏）
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { GameServer } from '../../../../src/net/server';
+import { WsGameNetwork } from '../../src/net/ws-game-network';
+import { StateSync } from '../../src/net/state-sync';
+import { NetworkClient } from '../../src/net/network-client';
+import { Game } from '../../src/game';
+import { HUDManager } from '../../src/ui/hud-manager';
+import type { NetworkMessage } from '../../src/net/message-protocol';
+
+// ── 常量 ─────────────────────────────────────────────────────────────────
+
+const PORT = 19080;
+const ROOM = 'br-12p';
+const WS_URL = `ws://localhost:${PORT}`;
+const DT = 1 / 60;
+const TOTAL_FRAMES = 1800; // 30s @ 60fps
+
+// ── 工具函数 ──────────────────────────────────────────────────────────────
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+function waitConnected(net: WsGameNetwork, timeoutMs = 5000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const t0 = Date.now();
+    const check = () => {
+      if (net.isConnected) { resolve(); return; }
+      if (Date.now() - t0 > timeoutMs) { reject(new Error(`WsGameNetwork 连接超时 ${timeoutMs}ms`)); return; }
+      setTimeout(check, 10);
+    };
+    check();
+  });
+}
+
+function waitWsOpen(ws: WebSocket, timeoutMs = 5000): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const tid = setTimeout(() => reject(new Error('WebSocket 连接超时')), timeoutMs);
+    ws.onopen = () => { clearTimeout(tid); resolve(); };
+    ws.onerror = () => { clearTimeout(tid); reject(new Error('WebSocket 连接错误')); };
+  });
+}
+
+/** 以 { type, data } 格式发送游戏消息 */
+function sendMsg(ws: WebSocket, msg: NetworkMessage): void {
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ type: msg.type, data: msg }));
+  }
+}
+
+/** 创建并连接 N 个远程 WebSocket 客户端 */
+async function connectRemoteClients(count: number): Promise<WebSocket[]> {
+  const clients = Array.from({ length: count }, () =>
+    new WebSocket(`${WS_URL}?room=${ROOM}`),
+  );
+  await Promise.all(clients.map(ws => waitWsOpen(ws)));
+  return clients;
+}
+
+function closeAll(net: WsGameNetwork, remotes: WebSocket[]): void {
+  net.disconnect();
+  for (const ws of remotes) {
+    if (ws.readyState !== WebSocket.CLOSED) ws.close();
+  }
+}
+
+// ── 测试夹具 ─────────────────────────────────────────────────────────────
+
+let server: GameServer;
+
+beforeAll(async () => {
+  server = new GameServer({ port: PORT });
+  await server.start();
+}, 10_000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+// ── 1. 服务器 + 12 客户端连接 ─────────────────────────────────────────────
+
+describe('M7 KR4 — 服务器启动与 12 客户端连接', { timeout: 15_000 }, () => {
+  it('GameServer 成功启动并接受连接', async () => {
+    const ws = new WebSocket(`${WS_URL}?room=ping`);
+    await waitWsOpen(ws);
+    expect(server.clientCount).toBeGreaterThanOrEqual(1);
+    ws.close();
+    await sleep(50);
+  });
+
+  it('12 客户端（1 WsGameNetwork + 11 原始 WS）全部连接', async () => {
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    const remotes = await connectRemoteClients(11);
+    await waitConnected(net);
+
+    expect(net.isConnected).toBe(true);
+    expect(server.clientCount).toBeGreaterThanOrEqual(12);
+
+    closeAll(net, remotes);
+    await sleep(100);
+  });
+});
+
+// ── 2. 11 远程玩家 join → StateSync 创建 RemotePlayer ────────────────────
+
+describe('M7 KR4 — 远程玩家 Join 广播', { timeout: 15_000 }, () => {
+  it('11 个 player.join 消息经服务器广播后 sync.playerCount === 11', async () => {
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    await waitConnected(net);
+
+    const sync = new StateSync(net, 'local-join-test');
+    const remotes = await connectRemoteClients(11);
+    await sleep(50);
+
+    for (let i = 0; i < 11; i++) {
+      sendMsg(remotes[i], {
+        type: 'player.join',
+        id: `remote-j${i}`,
+        name: `玩家${i}`,
+        position: { x: i * 3, y: 0, z: i * 3 },
+      });
+    }
+
+    await sleep(300);
+
+    expect(sync.playerCount).toBe(11);
+    for (const player of sync.players.values()) {
+      expect(player.node).toBeDefined();
+      expect(player.mixer).toBeDefined();
+    }
+
+    closeAll(net, remotes);
+    await sleep(50);
+  });
+
+  it('11 个远程玩家各自 id 唯一', async () => {
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    await waitConnected(net);
+
+    const sync = new StateSync(net, 'local-unique');
+    const remotes = await connectRemoteClients(11);
+    await sleep(100);
+
+    for (let i = 0; i < 11; i++) {
+      sendMsg(remotes[i], {
+        type: 'player.join',
+        id: `remote-u${i}`,
+        name: `玩家${i}`,
+        position: { x: 0, y: 0, z: 0 },
+      });
+    }
+    await sleep(500); // 11 条消息并发传播需要更多时间
+
+    const ids = [...sync.players.keys()];
+    expect(new Set(ids).size).toBe(11);
+
+    closeAll(net, remotes);
+    await sleep(50);
+  });
+});
+
+// ── 3. 远程玩家 die 消息经服务器广播验证 ─────────────────────────────────
+
+describe('M7 KR4 — 死亡消息广播', { timeout: 15_000 }, () => {
+  it('remote-0 发送 player.die → 本地 StateSync 标记死亡', async () => {
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    await waitConnected(net);
+
+    const sync = new StateSync(net, 'local-die-test');
+    const remotes = await connectRemoteClients(1);
+    await sleep(50);
+
+    sendMsg(remotes[0], {
+      type: 'player.join',
+      id: 'remote-die-p',
+      name: '死亡测试',
+      position: { x: 0, y: 0, z: 0 },
+    });
+    await sleep(150);
+
+    expect(sync.players.has('remote-die-p')).toBe(true);
+    expect(sync.players.get('remote-die-p')!.isDead).toBe(false);
+
+    sendMsg(remotes[0], { type: 'player.die', id: 'remote-die-p' });
+    await sleep(200);
+
+    expect(sync.players.get('remote-die-p')!.isDead).toBe(true);
+
+    closeAll(net, remotes);
+    await sleep(50);
+  });
+
+  it('player.hit → 目标血量降低', async () => {
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    await waitConnected(net);
+
+    const sync = new StateSync(net, 'local-hit-test');
+    const remotes = await connectRemoteClients(2);
+    await sleep(50);
+
+    for (let i = 0; i < 2; i++) {
+      sendMsg(remotes[i], {
+        type: 'player.join',
+        id: `remote-hit-${i}`,
+        name: `命中玩家${i}`,
+        position: { x: 0, y: 0, z: 0 },
+      });
+    }
+    await sleep(150);
+
+    const hp0 = sync.players.get('remote-hit-1')!.health.current;
+
+    sendMsg(remotes[0], {
+      type: 'player.hit',
+      attackerId: 'remote-hit-0',
+      targetId: 'remote-hit-1',
+      damage: 30,
+    });
+    await sleep(150);
+
+    expect(sync.players.get('remote-hit-1')!.health.current).toBe(hp0 - 30);
+
+    closeAll(net, remotes);
+    await sleep(50);
+  });
+});
+
+// ── 4. 1800 帧全量压测 ────────────────────────────────────────────────────
+
+describe('M7 KR4 — 1800 帧全量压测', { timeout: 60_000 }, () => {
+  it('1800 帧无崩溃 + drawCalls ≤ 60', async () => {
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    await waitConnected(net);
+
+    const game = new Game({ headless: true });
+    const hud = new HUDManager(game, 800, 600);
+    const sync = new StateSync(net, 'local-perf');
+    const client = new NetworkClient(net, sync, 'local-perf', '本地玩家');
+    client.bindLocalState(
+      () => { const p = game.player.position; return { x: p[0], y: p[1], z: p[2] }; },
+      () => game.fpsCamera.yaw,
+      () => game.playerHealth.current,
+    );
+
+    const remotes = await connectRemoteClients(11);
+    await sleep(50);
+
+    for (let i = 0; i < 11; i++) {
+      sendMsg(remotes[i], {
+        type: 'player.join',
+        id: `remote-perf-${i}`,
+        name: `玩家${i}`,
+        position: { x: (i - 5) * 5, y: 0, z: (i - 5) * 5 },
+      });
+    }
+    await sleep(200);
+
+    expect(sync.playerCount).toBe(11);
+
+    const initialDrawCalls = game.drawCallCount;
+
+    expect(() => {
+      for (let f = 0; f < TOTAL_FRAMES; f++) {
+        game.update(DT);
+        client.update(DT);
+        hud.update(DT);
+      }
+    }).not.toThrow();
+
+    expect(game.frameCount).toBe(TOTAL_FRAMES);
+    expect(game.drawCallCount).toBeLessThanOrEqual(60);
+    // drawCalls 不单调递增（±5 允许波动）
+    expect(game.drawCallCount).toBeLessThanOrEqual(initialDrawCalls + 5);
+
+    closeAll(net, remotes);
+    await sleep(50);
+  });
+
+  it('1800 帧无 console.error 输出', async () => {
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    await waitConnected(net);
+
+    const game = new Game({ headless: true });
+    const hud = new HUDManager(game, 800, 600);
+    const sync = new StateSync(net, 'local-noerr');
+    const client = new NetworkClient(net, sync, 'local-noerr', '本地');
+    client.bindLocalState(
+      () => { const p = game.player.position; return { x: p[0], y: p[1], z: p[2] }; },
+      () => 0,
+      () => 100,
+    );
+
+    const errors: string[] = [];
+    const orig = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(' '));
+
+    try {
+      for (let f = 0; f < TOTAL_FRAMES; f++) {
+        game.update(DT);
+        client.update(DT);
+        hud.update(DT);
+      }
+    } finally {
+      console.error = orig;
+    }
+
+    expect(errors).toEqual([]);
+    net.disconnect();
+    await sleep(50);
+  });
+
+  it('1800 帧 headless 执行时间 < 15 秒', async () => {
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    await waitConnected(net);
+
+    const game = new Game({ headless: true });
+    const hud = new HUDManager(game, 800, 600);
+    const sync = new StateSync(net, 'local-timing');
+    const client = new NetworkClient(net, sync, 'local-timing', '计时');
+    client.bindLocalState(
+      () => { const p = game.player.position; return { x: p[0], y: p[1], z: p[2] }; },
+      () => 0,
+      () => 100,
+    );
+
+    const t0 = Date.now();
+    for (let f = 0; f < TOTAL_FRAMES; f++) {
+      game.update(DT);
+      client.update(DT);
+      hud.update(DT);
+    }
+    expect(Date.now() - t0).toBeLessThan(15_000);
+
+    net.disconnect();
+    await sleep(50);
+  });
+});
+
+// ── 5. mixer.time ≈ 30s 验证 ─────────────────────────────────────────────
+
+describe('M7 KR4 — AnimationMixer 时间累积', { timeout: 30_000 }, () => {
+  it('11 个 RemotePlayer 经 1800 帧后 mixer.time ≈ 30s', async () => {
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    await waitConnected(net);
+
+    const sync = new StateSync(net, 'local-mixer');
+    const client = new NetworkClient(net, sync, 'local-mixer', '计时测试');
+    client.bindLocalState(() => ({ x: 0, y: 0, z: 0 }), () => 0, () => 100);
+
+    const remotes = await connectRemoteClients(11);
+    await sleep(50);
+
+    for (let i = 0; i < 11; i++) {
+      sendMsg(remotes[i], {
+        type: 'player.join',
+        id: `p-mixer-${i}`,
+        name: `MixerPlayer${i}`,
+        position: { x: i * 2, y: 0, z: 0 },
+      });
+    }
+    await sleep(200);
+
+    expect(sync.playerCount).toBe(11);
+
+    for (let f = 0; f < TOTAL_FRAMES; f++) {
+      client.update(DT);
+    }
+
+    for (const player of sync.players.values()) {
+      // idle 动画 duration=0，时间线性累积至 ~30s
+      expect(player.mixer.time).toBeCloseTo(30, 0);
+    }
+
+    closeAll(net, remotes);
+    await sleep(50);
+  });
+});
+
+// ── 6. 状态广播 + 位置插值验证 ────────────────────────────────────────────
+
+describe('M7 KR4 — 状态广播与位置插值', { timeout: 30_000 }, () => {
+  it('远程玩家发送 player.state → 本地 RemotePlayer 位置趋近目标', async () => {
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    await waitConnected(net);
+
+    const sync = new StateSync(net, 'local-interp');
+    const client = new NetworkClient(net, sync, 'local-interp', '插值测试');
+    client.bindLocalState(() => ({ x: 0, y: 0, z: 0 }), () => 0, () => 100);
+
+    const remotes = await connectRemoteClients(1);
+    await sleep(50);
+
+    sendMsg(remotes[0], {
+      type: 'player.join',
+      id: 'remote-interp',
+      name: '插值玩家',
+      position: { x: 0, y: 0, z: 0 },
+    });
+    await sleep(100);
+
+    sendMsg(remotes[0], {
+      type: 'player.state',
+      id: 'remote-interp',
+      position: { x: 50, y: 0, z: 50 },
+      rotation: 0,
+      health: 100,
+    });
+    await sleep(100);
+
+    for (let f = 0; f < 120; f++) {
+      client.update(DT);
+    }
+
+    const player = sync.players.get('remote-interp')!;
+    expect(player.node.position[0]).toBeGreaterThan(40);
+    expect(player.node.position[2]).toBeGreaterThan(40);
+
+    closeAll(net, remotes);
+    await sleep(50);
+  });
+
+  it('player.respawn 消息使死亡玩家复活', async () => {
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    await waitConnected(net);
+
+    const sync = new StateSync(net, 'local-respawn');
+    const client = new NetworkClient(net, sync, 'local-respawn', '复活测试');
+    client.bindLocalState(() => ({ x: 0, y: 0, z: 0 }), () => 0, () => 100);
+
+    const remotes = await connectRemoteClients(1);
+    await sleep(50);
+
+    sendMsg(remotes[0], {
+      type: 'player.join',
+      id: 'remote-resp',
+      name: '复活玩家',
+      position: { x: 0, y: 0, z: 0 },
+    });
+    await sleep(100);
+
+    sendMsg(remotes[0], { type: 'player.die', id: 'remote-resp' });
+    await sleep(150);
+    expect(sync.players.get('remote-resp')!.isDead).toBe(true);
+
+    sendMsg(remotes[0], {
+      type: 'player.respawn',
+      id: 'remote-resp',
+      position: { x: 10, y: 0, z: 10 },
+    });
+    await sleep(150);
+    expect(sync.players.get('remote-resp')!.isDead).toBe(false);
+
+    closeAll(net, remotes);
+    await sleep(50);
+  });
+});
+
+// ── 7. 无连接泄漏 ─────────────────────────────────────────────────────────
+
+describe('M7 KR4 — 连接清理（无泄漏）', { timeout: 15_000 }, () => {
+  it('客户端断开后 server.clientCount 归零', async () => {
+    await sleep(300); // 等上一组测试的连接全部关闭
+
+    const countBefore = server.clientCount;
+
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    const remotes = await connectRemoteClients(11);
+    await waitConnected(net);
+    await sleep(50);
+
+    expect(server.clientCount).toBeGreaterThanOrEqual(countBefore + 12);
+
+    closeAll(net, remotes);
+    await sleep(300);
+
+    expect(server.clientCount).toBe(countBefore);
+  });
+
+  it('玩家位置 1800 帧后无 NaN', async () => {
+    const net = new WsGameNetwork(WS_URL);
+    net.connect();
+    await waitConnected(net);
+
+    const game = new Game({ headless: true });
+    const sync = new StateSync(net, 'local-nan');
+    const client = new NetworkClient(net, sync, 'local-nan', 'NaN测试');
+    client.bindLocalState(
+      () => { const p = game.player.position; return { x: p[0], y: p[1], z: p[2] }; },
+      () => game.fpsCamera.yaw,
+      () => game.playerHealth.current,
+    );
+
+    game.simulateKey('w');
+    game.simulateKey('a');
+
+    for (let f = 0; f < TOTAL_FRAMES; f++) {
+      game.update(DT);
+      client.update(DT);
+    }
+
+    const pos = game.player.position;
+    expect(isNaN(pos[0])).toBe(false);
+    expect(isNaN(pos[1])).toBe(false);
+    expect(isNaN(pos[2])).toBe(false);
+
+    net.disconnect();
+    await sleep(50);
+  });
+});

--- a/examples/br-12p/test/integration/full-game-network.test.ts
+++ b/examples/br-12p/test/integration/full-game-network.test.ts
@@ -378,7 +378,7 @@ describe('M7 KR4 — AnimationMixer 时间累积', { timeout: 30_000 }, () => {
         position: { x: i * 2, y: 0, z: 0 },
       });
     }
-    await sleep(200);
+    await sleep(500);
 
     expect(sync.playerCount).toBe(11);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       vitest:
         specifier: ^3.1.0
         version: 3.2.4(@types/node@25.6.2)
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
 
   examples/runner-3d:
     devDependencies:


### PR DESCRIPTION
## 摘要

- 将 `examples/br-12p` 网络层从 `MockNetwork`（P2P EventEmitter）升级到真 WebSocket + Node.js 服务器
- 新增 14 个真 WebSocket 集成测试，全部通过
- 根项目 2339 个测试零回归

## 变更清单

### 新增文件
- `examples/br-12p/src/net/game-network.ts` — `IGameNetwork` 接口（MockNetwork/WsGameNetwork 共同实现）
- `examples/br-12p/src/net/ws-game-network.ts` — 基于引擎 `WebSocketTransport` 的适配器
- `examples/br-12p/server/index.ts` — `GameServer` + `ServerStateSync` 12人房间中继服务器
- `examples/br-12p/test/integration/full-game-network.test.ts` — 14 个真 WS 集成测试

### 修改文件
- `src/net/mock-network.ts` (br-12p) — 添加 `implements IGameNetwork`
- `src/net/state-sync.ts` (br-12p) — MockNetwork → IGameNetwork
- `src/net/network-client.ts` (br-12p) — MockNetwork → IGameNetwork
- `src/game.ts` — 新增 `addUpdateCallback` 供网络层注册每帧回调
- `src/main.ts` — 接入 WsGameNetwork，自动连 `ws://localhost:8080`
- `playwright.config.ts` — 双 webServer（GameServer + Vite）
- `package.json` — 新增 `server:start` 脚本

## 验收标准

- [x] 服务器启动：`pnpm --filter br-12p server:start` 起 server (port 8080)
- [x] 客户端连接：浏览器打开 br-12p index.html → 自动连 ws://localhost:8080
- [x] 30s 压测：`full-game-network.test.ts` 14 个测试全部通过
- [x] 不退化：drawCalls ≤ 60（测试验证）
- [x] 测试全绿：br-12p 155 通过 + 根项目 2339 通过

## 测试覆盖

| 测试组 | 内容 |
|--------|------|
| 服务器连接 | GameServer 启动 + 12 客户端连接 |
| Join 广播 | 11 player.join 消息经服务器中继到本地 StateSync |
| 死亡广播 | player.die / player.hit / player.respawn 消息验证 |
| 1800 帧压测 | 无崩溃 / 无 console.error / drawCalls ≤ 60 / 执行时间 < 15s |
| mixer 时间 | 11 RemotePlayer 动画 mixer.time ≈ 30s |
| 位置插值 | player.state 广播后位置趋近目标 |
| 清理验证 | 断开后 server.clientCount 归零，玩家位置无 NaN |

close #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)